### PR TITLE
Enable CSRF protection

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 
-from .extensions import db, migrate, login_manager, bcrypt
+from .extensions import db, migrate, login_manager, bcrypt, csrf
 
 
 def create_app(config_object='config.DevelopmentConfig'):
@@ -18,6 +18,7 @@ def register_extensions(app):
     migrate.init_app(app, db)
     login_manager.init_app(app)
     bcrypt.init_app(app)
+    csrf.init_app(app)
     login_manager.login_view = 'auth.login'
 
     from .models import User

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -2,9 +2,11 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_login import LoginManager
 from flask_bcrypt import Bcrypt
+from flask_wtf import CSRFProtect
 
 
 db = SQLAlchemy()
 migrate = Migrate()
 login_manager = LoginManager()
 bcrypt = Bcrypt()
+csrf = CSRFProtect()

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Admin Login</h2>
 <form method="post">
+  {{ csrf_token() }}
   <label>Email
     <input type="email" name="email" required>
   </label>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -272,6 +272,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-13 – Added Docker setup and initial database migrations with `.env.example`.
 * 2025-06-14 – Created Flask blueprint skeleton and config structure.
 * 2025-06-15 – Implemented login and session management with Flask-Login.
+* 2025-06-16 – Added CSRF protection via Flask-WTF.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary==2.9.7
 gunicorn==21.2.0
 Flask-Login==0.6.3
 Flask-Bcrypt==1.0.1
+Flask-WTF==1.2.2


### PR DESCRIPTION
## Summary
- install Flask-WTF
- create `csrf` extension and initialize in the app factory
- include `csrf_token` in login form
- document the change

## Testing
- `python -m pip install Flask-WTF==1.2.2`
- `docker-compose up --build` *(fails: command not found)*
- `flask --app app run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c30a42e00832bb44c79a3aeabeec1