### PR TITLE
Add focus outline styles

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -15,6 +15,15 @@ body {
   @apply opacity-90;
 }
 
+.bp-btn-primary:focus-visible,
+.bp-btn-secondary:focus-visible,
+.btn-primary:focus-visible,
+.btn-secondary:focus-visible,
+a:focus-visible {
+  outline: 2px solid #FFEB3B; /* bp-yellow-a11y */
+  outline-offset: 2px;
+}
+
 /* Inline error placeholder */
 .bp-error-text {
   @apply min-h-4 text-sm text-bp-red;

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -281,6 +281,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-14 – Added meeting cards on admin dashboard with floating “Create Meeting” button.
 * 2025-06-14 – Added Tailwind build setup for CSS and updated README.
 * 2025-06-14 – Added secondary button, table, badge and card styles.
+* 2025-06-14 – Added focus-visible outlines for buttons and links.
 
 
 ---


### PR DESCRIPTION
## Summary
- show a bp-yellow-a11y outline when buttons and links get focus
- document the focus-visible outlines in the changelog

## Testing
- `docker-compose up --build -d` *(fails: command not found)*
- `python -m flask --app app run --port 5000` *(fails: No module named flask)*
- `python -m flask --app app db upgrade` *(fails: No module named flask)*

------
https://chatgpt.com/codex/tasks/task_b_684d6021a644832b81327c359d2760b6