### PR TITLE
Add unit tests and testing guide

### DIFF
--- a/docs/unit-test-strategy.md
+++ b/docs/unit-test-strategy.md
@@ -1,0 +1,30 @@
+# Unit Test Strategy
+
+This project uses **pytest** for all automated testing. The tests live in the
+`tests/` directory and can be run with:
+
+```bash
+pytest -q
+```
+
+## Fixtures
+
+* **Application setup** – Where tests require a Flask application or database,
+they should create an app using `app.create_app()` and configure it to use the
+in‑memory SQLite database (`sqlite:///:memory:`). The database can be initialised
+with `db.create_all()` inside the fixture.
+* **Mocking** – External services and the current user should be mocked using
+`unittest.mock.patch`.
+
+## Writing tests
+
+* Focus on individual functions and lightweight route testing.
+* Avoid hitting external systems or the real database; rely on in‑memory SQLite
+and mocks instead.
+* Keep tests fast so they can run on every PR.
+
+## Running in CI
+
+Tests should pass locally and in any CI environment by just installing
+`requirements.txt` and running `pytest`. No Docker services are required for unit
+tests, keeping the feedback loop quick.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,20 @@
+import sys, os; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.models import User, Role, Permission
+
+
+def test_set_password_and_check():
+    user = User()
+    user.set_password('secret')
+    assert user.password_hash != 'secret'
+    assert user.check_password('secret') is True
+    assert user.check_password('wrong') is False
+
+
+def test_has_permission():
+    perm_view = Permission(name='view_dashboard')
+    role = Role(permissions=[perm_view])
+    user = User(role=role)
+
+    assert user.has_permission('view_dashboard') is True
+    assert user.has_permission('manage_users') is False
+

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,39 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from werkzeug.exceptions import Forbidden
+from unittest.mock import patch
+from flask_login import AnonymousUserMixin
+
+from app.permissions import permission_required
+from app.models import User, Role, Permission
+
+
+@permission_required('view_dashboard')
+def _protected():
+    return 'ok'
+
+
+def test_permission_required_allows_when_has_permission():
+    perm = Permission(name='view_dashboard')
+    user = User(role=Role(permissions=[perm]))
+    user.is_active = True
+    with patch('flask_login.utils._get_user', return_value=user):
+        assert _protected() == 'ok'
+
+
+def test_permission_required_forbidden_when_missing():
+    user = User(role=Role(permissions=[]))
+    user.is_active = True
+    with patch('flask_login.utils._get_user', return_value=user):
+        with pytest.raises(Forbidden):
+            _protected()
+
+
+def test_permission_required_forbidden_when_anonymous():
+    anon = AnonymousUserMixin()
+    with patch('flask_login.utils._get_user', return_value=anon):
+        with pytest.raises(Forbidden):
+            _protected()


### PR DESCRIPTION
## Summary
- add unit tests for models and permission decorator
- document a pytest strategy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d755d7944832bbf47f1e3d6811f74