### PR TITLE
Apply UI guidance across templates

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -902,3 +902,37 @@ a:focus-visible {
   bottom: 1.5rem;
   right: 1.5rem;
 }
+
+/* Form layout utility */
+.bp-form > div {
+  margin-bottom: 1.5rem; /* 24px */
+}
+
+.bp-form input,
+.bp-form select,
+.bp-form textarea {
+  padding: 0.75rem; /* 12px */
+  border-radius: 0.25rem; /* 4px */
+}
+
+/* Alert banners */
+.bp-alert-success {
+  background-color: #d1fae5;
+  color: #065f46;
+  padding: 0.75rem 1rem;
+  border-radius: 0.25rem;
+}
+
+.bp-alert-warning {
+  background-color: #fff7ed;
+  color: #92400e;
+  padding: 0.75rem 1rem;
+  border-radius: 0.25rem;
+}
+
+.bp-alert-error {
+  background-color: #fee2e2;
+  color: #991b1b;
+  padding: 0.75rem 1rem;
+  border-radius: 0.25rem;
+}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -2,9 +2,9 @@
 {% block content %}
 <h2 class="font-bold text-bp-blue mb-4">User Accounts</h2>
 
-<form class="mb-4 bp-card" hx-get="{{ url_for('admin.list_users') }}" hx-target="#user-table-body" hx-trigger="keyup changed delay:300ms" hx-push-url="true">
+<form class="mb-4 bp-card bp-form" hx-get="{{ url_for('admin.list_users') }}" hx-target="#user-table-body" hx-trigger="keyup changed delay:300ms" hx-push-url="true">
   <label for="q" class="sr-only">Search users</label>
-  <input id="q" type="text" name="q" value="{{ q or '' }}" placeholder="Search users..." class="border rounded p-2 w-full">
+  <input id="q" type="text" name="q" value="{{ q or '' }}" placeholder="Search users..." class="border p-3 rounded w-full">
 </form>
 
 <div class="bp-card">

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -2,17 +2,17 @@
 {% block content %}
 <h2>Admin Login</h2>
 
-<form method="post" class="space-y-4 bp-card">
+<form method="post" class="bp-form bp-card">
   <div>
     {{ csrf_token() }}
     <input type="hidden" name="next" value="{{ next or '' }}">
     <label for="email" class="block font-semibold">Email</label>
-    <input id="email" type="email" name="email" required class="border rounded p-2 w-full">
+  <input id="email" type="email" name="email" required class="border p-3 rounded w-full">
     <p class="bp-error-text"></p>
   </div>
   <div>
     <label for="password" class="block font-semibold">Password</label>
-    <input id="password" type="password" name="password" required class="border rounded p-2 w-full">
+  <input id="password" type="password" name="password" required class="border p-3 rounded w-full">
     <p class="bp-error-text"></p>
   </div>
   <button type="submit" class="bp-btn-primary">Login</button>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,7 +6,7 @@
     <title>VoteBuddy</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
   </head>
-  <body hx-boost="true" class="flex flex-col min-h-screen bg-bp-grey-50">
+  <body hx-boost="true" class="flex flex-col min-h-screen bg-bp-grey-50 font-sans">
     <header>
       <nav class="bg-bp-blue text-white">
         <div class="max-w-[1200px] mx-auto flex items-center justify-between px-4 py-3">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,4 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
-<p>Welcome to VoteBuddy.</p>
+<div class="bp-card text-center space-y-4">
+  <h1 class="text-3xl font-bold text-bp-blue">Welcome to VoteBuddy</h1>
+  <p class="text-bp-grey-700">British Powerlifting's official voting platform.</p>
+  <a href="{{ url_for('auth.login') }}" class="bp-btn-primary">Admin Login</a>
+</div>
 {% endblock %}

--- a/app/templates/meetings/list.html
+++ b/app/templates/meetings/list.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Meetings</h2>
-<p>No meetings created yet.</p>
+<div class="bp-card">
+  <h2 class="font-bold text-bp-blue mb-2">Meetings</h2>
+  <p class="text-bp-grey-700">No meetings created yet.</p>
+</div>
 {% endblock %}

--- a/app/templates/voting/home.html
+++ b/app/templates/voting/home.html
@@ -1,4 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<p>Voting interface placeholder.</p>
+<div class="bp-card text-center">
+  <p class="text-bp-grey-700">Voting interface placeholder.</p>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure base template uses the brand font stack
- add `.bp-form` and alert banner utilities
- follow form and card styling in login and user list pages
- update hero and placeholder pages with VoteBuddy styles

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flask --app app run -p 5050` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d75001d88832b85d6b0cf8164bd27