### PR TITLE
Add meeting create/edit form

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -1,0 +1,16 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, SelectField, DateTimeLocalField, BooleanField, TextAreaField, SubmitField
+from wtforms.validators import DataRequired
+
+class MeetingForm(FlaskForm):
+    title = StringField('Title', validators=[DataRequired()])
+    type = SelectField('Type', choices=[('AGM', 'AGM'), ('EGM', 'EGM')])
+    opens_at_stage1 = DateTimeLocalField('Stage 1 Opens', format='%Y-%m-%dT%H:%M')
+    closes_at_stage1 = DateTimeLocalField('Stage 1 Closes', format='%Y-%m-%dT%H:%M')
+    opens_at_stage2 = DateTimeLocalField('Stage 2 Opens', format='%Y-%m-%dT%H:%M')
+    closes_at_stage2 = DateTimeLocalField('Stage 2 Closes', format='%Y-%m-%dT%H:%M')
+    ballot_mode = SelectField('Ballot Mode', choices=[('two-stage', 'Two-stage'), ('combined', 'Combined'), ('in-person', 'In-person/Hybrid')])
+    revoting_allowed = BooleanField('Revoting Allowed')
+    status = StringField('Status')
+    chair_notes_md = TextAreaField('Chair Notes')
+    submit = SubmitField('Save')

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1,7 +1,40 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, redirect, url_for
+from ..extensions import db
+from ..models import Meeting
+from .forms import MeetingForm
 
 bp = Blueprint('meetings', __name__, url_prefix='/meetings')
 
 @bp.route('/')
 def list_meetings():
     return render_template('meetings/list.html')
+
+
+def _save_meeting(form: MeetingForm, meeting: Meeting | None = None) -> Meeting:
+    """Populate Meeting from form and save."""
+    if meeting is None:
+        meeting = Meeting()
+
+    form.populate_obj(meeting)
+    db.session.add(meeting)
+    db.session.commit()
+    return meeting
+
+
+@bp.route('/create', methods=['GET', 'POST'])
+def create_meeting():
+    form = MeetingForm()
+    if form.validate_on_submit():
+        _save_meeting(form)
+        return redirect(url_for('meetings.list_meetings'))
+    return render_template('meetings/meetings_form.html', form=form)
+
+
+@bp.route('/<int:meeting_id>/edit', methods=['GET', 'POST'])
+def edit_meeting(meeting_id):
+    meeting = Meeting.query.get_or_404(meeting_id)
+    form = MeetingForm(obj=meeting)
+    if form.validate_on_submit():
+        _save_meeting(form, meeting)
+        return redirect(url_for('meetings.list_meetings'))
+    return render_template('meetings/meetings_form.html', form=form, meeting=meeting)

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if meeting else 'Create' }} Meeting</h2>
+<form method="post" class="bp-form bp-card space-y-4">
+  {{ form.hidden_tag() }}
+  <div>
+    {{ form.title.label(class_='block font-semibold') }}
+    {{ form.title(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.type.label(class_='block font-semibold') }}
+    {{ form.type(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.opens_at_stage1.label(class_='block font-semibold') }}
+    {{ form.opens_at_stage1(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.closes_at_stage1.label(class_='block font-semibold') }}
+    {{ form.closes_at_stage1(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.opens_at_stage2.label(class_='block font-semibold') }}
+    {{ form.opens_at_stage2(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.closes_at_stage2.label(class_='block font-semibold') }}
+    {{ form.closes_at_stage2(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.ballot_mode.label(class_='block font-semibold') }}
+    {{ form.ballot_mode(class_='border p-3 rounded w-full') }}
+  </div>
+  <div class="flex items-center space-x-2">
+    {{ form.revoting_allowed() }}
+    {{ form.revoting_allowed.label(class_='font-semibold') }}
+  </div>
+  <div>
+    {{ form.status.label(class_='block font-semibold') }}
+    {{ form.status(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.chair_notes_md.label(class_='block font-semibold') }}
+    {{ form.chair_notes_md(class_='border p-3 rounded w-full') }}
+  </div>
+  <button type="submit" class="bp-btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -283,6 +283,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-14 – Added dotenv loading with SQLite fallback when `DATABASE_URL` is unset.
 * 2025-06-14 – Added focus-visible outlines for buttons and links.
 * 2025-06-14 – Expanded UI/UX design guidance with extended design patterns.
+* 2025-06-14 – Added meeting create/edit form with CSRF protection.
 
 ---
 


### PR DESCRIPTION
## Summary
- create MeetingForm wtforms for meeting data
- support create/edit meeting routes
- add meetings_form.html template following bp-form styles
- document new feature in the changelog

## Testing
- `python -m flask db upgrade`
- `python -m flask run --port 5050` *(terminated manually)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d7d176a8c832ba5377060760ecc47