### PR TITLE
Add admin user management forms

### DIFF
--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -1,0 +1,16 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, SelectField, BooleanField, SubmitField
+from wtforms.validators import DataRequired, Email, Optional
+
+
+class UserForm(FlaskForm):
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    password = PasswordField('Password', validators=[Optional()])
+    role_id = SelectField('Role', coerce=int, validators=[DataRequired()])
+    is_active = BooleanField('Active', default=True)
+    submit = SubmitField('Save')
+
+
+class UserCreateForm(UserForm):
+    password = PasswordField('Password', validators=[DataRequired()])
+

--- a/app/templates/admin/user_form.html
+++ b/app/templates/admin/user_form.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if user else 'Create' }} User</h2>
+<form method="post" class="bp-form bp-card space-y-6">
+  {{ form.hidden_tag() }}
+  <div>
+    {{ form.email.label(class_='block font-semibold') }}
+    {{ form.email(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.password.label(class_='block font-semibold') }}
+    {{ form.password(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.role_id.label(class_='block font-semibold') }}
+    {{ form.role_id(class_='border p-3 rounded w-full') }}
+  </div>
+  <div class="flex items-center space-x-2">
+    {{ form.is_active() }}
+    {{ form.is_active.label(class_='font-semibold') }}
+  </div>
+  <button type="submit" class="bp-btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -286,6 +286,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-14 – Implemented meetings list view with table layout.
 * 2025-06-14 – Enhanced meetings list with htmx search and sort.
 * 2025-06-14 – Added meeting create/edit form with CSRF protection.
+* 2025-06-14 – Implemented admin user create/edit flow with forms and routes.
 ---
 
 ## 14  Glossary

--- a/tests/test_admin_user.py
+++ b/tests/test_admin_user.py
@@ -1,0 +1,32 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+from app.extensions import db
+from app.models import Role, User
+from app.admin.forms import UserCreateForm
+from app.admin.routes import _save_user
+
+
+def test_save_user_creates_record():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        role = Role(name='Admin')
+        db.session.add(role)
+        db.session.commit()
+
+        with app.test_request_context('/'):
+            form = UserCreateForm(meta={'csrf': False})
+            form.email.data = 'new@example.com'
+            form.password.data = 'secret'
+            form.role_id.data = role.id
+            form.is_active.data = True
+
+            user = _save_user(form)
+            assert user.id == 1
+            assert user.email == 'new@example.com'
+            assert user.role_id == role.id
+            assert user.check_password('secret')
+            assert User.query.count() == 1


### PR DESCRIPTION
## Summary
- support adding & editing users in admin panel
- create WTForms for User and UserCreate
- add user creation test
- document user management in PRD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d8c30afc8832ba81f5d7efbfae3c5