### PR TITLE
Implement meeting permissions

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, render_template, redirect, url_for, request, flash
+from flask_login import login_required
 from ..extensions import db
 from ..models import Meeting, Member, VoteToken
+from ..permissions import permission_required
 from .forms import MeetingForm, MemberImportForm
 import csv
 import io
@@ -9,6 +11,8 @@ from uuid6 import uuid7
 bp = Blueprint('meetings', __name__, url_prefix='/meetings')
 
 @bp.route('/')
+@login_required
+@permission_required('manage_meetings')
 def list_meetings():
     q = request.args.get('q', '').strip()
     sort = request.args.get('sort', 'title')
@@ -58,6 +62,8 @@ def _save_meeting(form: MeetingForm, meeting: Meeting | None = None) -> Meeting:
 
 
 @bp.route('/create', methods=['GET', 'POST'])
+@login_required
+@permission_required('manage_meetings')
 def create_meeting():
     form = MeetingForm()
     if form.validate_on_submit():
@@ -67,6 +73,8 @@ def create_meeting():
 
 
 @bp.route('/<int:meeting_id>/edit', methods=['GET', 'POST'])
+@login_required
+@permission_required('manage_meetings')
 def edit_meeting(meeting_id):
     meeting = Meeting.query.get_or_404(meeting_id)
     form = MeetingForm(obj=meeting)
@@ -77,6 +85,8 @@ def edit_meeting(meeting_id):
 
 
 @bp.route('/<int:meeting_id>/import-members', methods=['GET', 'POST'])
+@login_required
+@permission_required('manage_meetings')
 def import_members(meeting_id):
     """Upload a CSV of members and generate vote tokens."""
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -288,6 +288,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-14 – Added meeting create/edit form with CSRF protection.
 * 2025-06-14 – Added member CSV import with token generation.
 * 2025-06-14 – Implemented admin user create/edit flow with forms and routes.
+* 2025-06-14 – Secured meeting management routes with new 'manage_meetings' permission.
 
 
 

--- a/migrations/versions/ab12cd34ef56_add_manage_meetings_permission.py
+++ b/migrations/versions/ab12cd34ef56_add_manage_meetings_permission.py
@@ -1,0 +1,30 @@
+"""add manage meetings permission
+
+Revision ID: ab12cd34ef56
+Revises: 9769bae50c41
+Create Date: 2025-06-14 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'ab12cd34ef56'
+down_revision = '9769bae50c41'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    permissions = sa.table('permissions', sa.column('id', sa.Integer), sa.column('name', sa.String))
+    role_permissions = sa.table('roles_permissions', sa.column('role_id', sa.Integer), sa.column('permission_id', sa.Integer))
+
+    op.bulk_insert(permissions, [{'id': 3, 'name': 'manage_meetings'}])
+    op.bulk_insert(role_permissions, [
+        {'role_id': 1, 'permission_id': 3},
+        {'role_id': 2, 'permission_id': 3},
+    ])
+
+
+def downgrade():
+    op.execute('DELETE FROM roles_permissions WHERE permission_id=3')
+    op.execute('DELETE FROM permissions WHERE id=3')
+

--- a/tests/test_meetings_routes.py
+++ b/tests/test_meetings_routes.py
@@ -1,0 +1,40 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from unittest.mock import patch
+from werkzeug.exceptions import Forbidden
+
+from app import create_app
+from app.extensions import db
+from app.models import User, Role, Permission
+from app.meetings import routes as meetings
+
+
+def _make_user(has_permission: bool):
+    perm = Permission(name='manage_meetings') if has_permission else None
+    role = Role(permissions=[perm] if perm else [])
+    user = User(role=role)
+    user.is_active = True
+    return user
+
+
+def test_list_meetings_requires_permission():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        with app.test_request_context('/meetings/'):
+            user = _make_user(True)
+            with patch('flask_login.utils._get_user', return_value=user):
+                meetings.list_meetings()
+
+        with app.test_request_context('/meetings/'):
+            user = _make_user(False)
+            with patch('flask_login.utils._get_user', return_value=user):
+                with patch('flask.flash'):
+                    try:
+                        meetings.list_meetings()
+                    except Forbidden:
+                        pass
+                    else:
+                        assert False, 'expected Forbidden'


### PR DESCRIPTION
## Summary
- restrict meeting management endpoints behind `manage_meetings` permission
- seed new permission via Alembic migration
- log change in PRD
- test access control for meetings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d8ee27a0c832b9afec860876da2b5