### PR TITLE
Implement basic voting flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ MAIL_PORT=587
 MAIL_USERNAME=your_smtp_username
 MAIL_PASSWORD=your_smtp_password
 MAIL_DEFAULT_SENDER="VoteBuddy <noreply@example.com>"
+VOTE_SALT=change-me

--- a/app/templates/voting/ballot.html
+++ b/app/templates/voting/ballot.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">Amendment Vote</h2>
+<div class="bp-card mb-4">
+  {{ amendment.text_md or 'No amendment text.' }}
+</div>
+<form method="post" class="bp-form bp-card space-y-4">
+  {{ form.hidden_tag() }}
+  <div>
+    <span class="font-semibold">Select your choice:</span>
+    <div class="mt-2 space-x-4">
+      {% for sub in form.choice %}
+        <label class="inline-flex items-center space-x-2 mr-4">
+          {{ sub() }}<span>{{ sub.label.text }}</span>
+        </label>
+      {% endfor %}
+    </div>
+  </div>
+  <button type="submit" class="bp-btn-primary">Submit vote</button>
+</form>
+{% endblock %}

--- a/app/templates/voting/confirmation.html
+++ b/app/templates/voting/confirmation.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="bp-alert-success text-center mb-4">
+  Thanks, you voted {{ choice.capitalize() }}.
+</div>
+<a href="{{ url_for('main.index') }}" class="bp-btn-secondary">Return home</a>
+{% endblock %}

--- a/app/templates/voting/token_error.html
+++ b/app/templates/voting/token_error.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="bp-alert-error text-center mb-4">
+  {{ message }}
+</div>
+<a href="{{ url_for('main.index') }}" class="bp-btn-secondary">Return home</a>
+{% endblock %}

--- a/app/voting/forms.py
+++ b/app/voting/forms.py
@@ -1,0 +1,11 @@
+from flask_wtf import FlaskForm
+from wtforms import RadioField, SubmitField
+from wtforms.validators import DataRequired
+
+class VoteForm(FlaskForm):
+    choice = RadioField(
+        'Your vote',
+        choices=[('yes', 'Yes'), ('no', 'No'), ('abstain', 'Abstain')],
+        validators=[DataRequired()],
+    )
+    submit = SubmitField('Submit vote')

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -1,12 +1,53 @@
-from flask import Blueprint, render_template
+from datetime import datetime
+from flask import Blueprint, render_template, abort, request, current_app
+
+from ..extensions import db
+from ..models import VoteToken, Member, Amendment, Meeting, Vote
+from .forms import VoteForm
 
 bp = Blueprint('voting', __name__, url_prefix='/vote')
+
 
 @bp.route('/')
 def ballot_home():
     return render_template('voting/home.html')
 
 
-@bp.route('/<token>')
-def ballot_token(token):
-    return render_template('voting/home.html', token=token)
+@bp.route('/<token>', methods=['GET', 'POST'])
+def ballot_token(token: str):
+    """Verify token, display amendment and record vote."""
+    vote_token = VoteToken.query.filter_by(token=token).first_or_404()
+    member = Member.query.get_or_404(vote_token.member_id)
+    meeting = Meeting.query.get_or_404(member.meeting_id)
+
+    if vote_token.used_at and not meeting.revoting_allowed:
+        return render_template(
+            'voting/token_error.html',
+            message='This voting link has already been used.',
+        ), 400
+
+    amendment = (
+        Amendment.query.filter_by(meeting_id=meeting.id)
+        .order_by(Amendment.order)
+        .first()
+    )
+
+    form = VoteForm()
+    if form.validate_on_submit():
+        Vote.record(
+            member_id=member.id,
+            amendment_id=amendment.id if amendment else None,
+            choice=form.choice.data,
+            salt=current_app.config['VOTE_SALT'],
+            motion=False,
+        )
+        vote_token.used_at = datetime.utcnow()
+        db.session.commit()
+        return render_template('voting/confirmation.html', choice=form.choice.data)
+
+    return render_template(
+        'voting/ballot.html',
+        form=form,
+        amendment=amendment,
+        meeting=meeting,
+    )

--- a/config.py
+++ b/config.py
@@ -13,6 +13,7 @@ class Config:
     MAIL_PASSWORD = os.getenv('MAIL_PASSWORD')
     MAIL_USE_TLS = os.getenv('MAIL_USE_TLS', 'true').lower() in ['1', 'true']
     MAIL_DEFAULT_SENDER = os.getenv('MAIL_DEFAULT_SENDER')
+    VOTE_SALT = os.getenv('VOTE_SALT', 'static-salt')
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -293,6 +293,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-14 – Secured meeting management routes with new 'manage_meetings' permission.
 * 2025-06-15 – Implemented email service sending voting links after member import.
 * 2025-06-14 – Added contributor note about enforcing permissions on all new features.
+* 2025-06-15 – Added basic voting routes with token verification and hashed vote storage.
 
 
 

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -1,0 +1,55 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from datetime import datetime
+import hashlib
+
+import pytest
+from werkzeug.exceptions import NotFound
+
+from app import create_app
+from app.extensions import db
+from app.models import Meeting, Member, VoteToken, Amendment, Vote
+from app.voting import routes as voting
+
+
+def _setup_app():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['VOTE_SALT'] = 'salty'
+    app.config['WTF_CSRF_ENABLED'] = False
+    return app
+
+
+def test_ballot_token_not_found():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        with app.test_request_context('/vote/bad'):
+            with pytest.raises(NotFound):
+                voting.ballot_token('bad')
+
+
+def test_cast_vote_records_hash_and_marks_used():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name='Alice', email='a@example.com')
+        db.session.add(member)
+        amendment = Amendment(meeting_id=meeting.id, text_md='Test', order=1)
+        db.session.add(amendment)
+        db.session.commit()
+        token = VoteToken(token='tok123', member_id=member.id, stage=1)
+        db.session.add(token)
+        db.session.commit()
+
+        with app.test_request_context('/vote/tok123', method='POST', data={'choice': 'yes'}):
+            voting.ballot_token('tok123')
+
+        vote = Vote.query.first()
+        expected = hashlib.sha256(f"{member.id}yessalty".encode()).hexdigest()
+        assert vote.hash == expected
+        assert token.used_at is not None


### PR DESCRIPTION
## Summary
- add VOTE_SALT config and example env
- implement hashed vote storage in model
- create voting forms and templates for ballot, confirmation and error states
- add token verification and voting route
- test voting routes and hashed storage
- document new voting page in PRD changelog

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d94719e2c832baa0062bd026f72cf