### PR TITLE
Implement staged voting with motion categories

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -29,3 +29,27 @@ class MemberImportForm(FlaskForm):
 
     csv_file = FileField('CSV File', validators=[FileRequired()])
     submit = SubmitField('Upload')
+
+
+class AmendmentForm(FlaskForm):
+    text_md = TextAreaField('Amendment Text', validators=[DataRequired()])
+    submit = SubmitField('Save')
+
+
+class MotionForm(FlaskForm):
+    title = StringField('Title', validators=[DataRequired()])
+    text_md = TextAreaField('Motion Text', validators=[DataRequired()])
+    category = SelectField(
+        'Category',
+        choices=[
+            ('motion', 'Motion'),
+            ('directors_report', "Director's Report"),
+            ('multiple_choice', 'Multiple Choice'),
+        ],
+    )
+    threshold = SelectField(
+        'Voting Threshold',
+        choices=[('normal', 'Normal'), ('special', 'Special')],
+    )
+    options = TextAreaField('Options (one per line)')
+    submit = SubmitField('Save')

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -936,3 +936,8 @@ a:focus-visible {
   padding: 0.75rem 1rem;
   border-radius: 0.25rem;
 }
+
+/* Highlight glow for motion context */
+.bp-glow {
+  box-shadow: 0 0 0 4px rgba(220, 7, 20, 0.4);
+}

--- a/app/templates/meetings/amendment_form.html
+++ b/app/templates/meetings/amendment_form.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">Add Amendment</h2>
+<form method="post" class="bp-form bp-card space-y-4">
+  {{ form.hidden_tag() }}
+  <div>
+    {{ form.text_md.label(class_='block font-semibold') }}
+    {{ form.text_md(class_='border p-3 rounded w-full') }}
+  </div>
+  <button type="submit" class="bp-btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/meetings/motion_form.html
+++ b/app/templates/meetings/motion_form.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if motion else 'Create' }} Motion</h2>
+<form method="post" class="bp-form bp-card space-y-4">
+  {{ form.hidden_tag() }}
+  <div>
+    {{ form.title.label(class_='block font-semibold') }}
+    {{ form.title(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.text_md.label(class_='block font-semibold') }}
+    {{ form.text_md(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.category.label(class_='block font-semibold') }}
+    {{ form.category(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.threshold.label(class_='block font-semibold') }}
+    {{ form.threshold(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.options.label(class_='block font-semibold') }}
+    {{ form.options(class_='border p-3 rounded w-full') }}
+  </div>
+  <button type="submit" class="bp-btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Motions</h2>
+<div class="space-y-4">
+  {% for m in motions %}
+    <div class="bp-card">
+      <h3 class="font-semibold mb-1">{{ m.title }}</h3>
+      <p class="mb-2">Category: {{ m.category }}</p>
+      <a href="{{ url_for('meetings.view_motion', motion_id=m.id) }}" class="bp-btn-secondary">View</a>
+    </div>
+  {% else %}
+    <p>No motions yet.</p>
+  {% endfor %}
+</div>
+<a href="{{ url_for('meetings.create_motion', meeting_id=meeting.id) }}" class="bp-btn-primary mt-4 inline-block">Add Motion</a>
+{% endblock %}

--- a/app/templates/meetings/view_motion.html
+++ b/app/templates/meetings/view_motion.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">{{ motion.title }}</h2>
+<div class="bp-card bp-glow mb-4">{{ motion.text_md or 'No motion text.' }}</div>
+<h3 class="font-bold mb-2">Amendments</h3>
+{% for amend in amendments %}
+  <div class="bp-card mb-2">{{ amend.text_md }}</div>
+{% else %}
+  <p>No amendments submitted.</p>
+{% endfor %}
+{% endblock %}

--- a/app/templates/voting/stage1_ballot.html
+++ b/app/templates/voting/stage1_ballot.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">Stage 1 – Amendment Votes</h2>
+<form method="post" class="bp-form bp-card space-y-6">
+  {{ form.hidden_tag() }}
+  {% for motion, ams in motions %}
+    <div class="bp-card bp-glow mb-4">{{ motion.text_md }}</div>
+    {% for amend in ams %}
+      <div class="mb-4">
+        <div class="font-semibold mb-2">{{ amend.text_md }}</div>
+        <div class="space-x-4">
+          {% for sub in form['amend_' ~ amend.id] %}
+            <label class="inline-flex items-center mr-4">{{ sub() }}<span>{{ sub.label.text }}</span></label>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  {% endfor %}
+  <button type="submit" class="bp-btn-primary">Submit votes</button>
+</form>
+{% endblock %}

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">Stage 2 – Vote on Motion</h2>
+<form method="post" class="bp-form bp-card space-y-4">
+  {{ form.hidden_tag() }}
+  {% for motion in motions %}
+    <div class="bp-card bp-glow mb-4">{{ motion.text_md }}</div>
+    <div class="space-x-4 mb-4">
+      {% for sub in form['motion_' ~ motion.id] %}
+        <label class="inline-flex items-center mr-4">{{ sub() }}<span>{{ sub.label.text }}</span></label>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <button type="submit" class="bp-btn-primary">Submit vote</button>
+</form>
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -294,6 +294,8 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Implemented email service sending voting links after member import.
 * 2025-06-14 – Added contributor note about enforcing permissions on all new features.
 * 2025-06-15 – Added basic voting routes with token verification and hashed vote storage.
+* 2025-06-15 – Implemented stage-based voting flow with motion display and amendment handling.
+* 2025-06-15 – Added motion categories, thresholds and options with new tables.
 
 
 

--- a/migrations/versions/ccd9d99d0db0_add_motion_md.py
+++ b/migrations/versions/ccd9d99d0db0_add_motion_md.py
@@ -1,0 +1,23 @@
+"""add motion_md to meetings
+
+Revision ID: ccd9d99d0db0
+Revises: 4b7aeabb87a7
+Create Date: 2025-06-15 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'ccd9d99d0db0'
+down_revision = '4b7aeabb87a7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('meetings', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('motion_md', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('meetings', schema=None) as batch_op:
+        batch_op.drop_column('motion_md')

--- a/migrations/versions/ea3a1b2c3d45_add_motions_table.py
+++ b/migrations/versions/ea3a1b2c3d45_add_motions_table.py
@@ -1,0 +1,53 @@
+"""add motions table and motion options
+
+Revision ID: ea3a1b2c3d45
+Revises: ccd9d99d0db0
+Create Date: 2025-06-15 01:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'ea3a1b2c3d45'
+down_revision = 'ccd9d99d0db0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'motions',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('meeting_id', sa.Integer(), sa.ForeignKey('meetings.id')),
+        sa.Column('title', sa.String(length=255)),
+        sa.Column('text_md', sa.Text()),
+        sa.Column('category', sa.String(length=20)),
+        sa.Column('threshold', sa.String(length=20)),
+        sa.Column('ordering', sa.Integer()),
+    )
+    op.create_table(
+        'motion_options',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('motion_id', sa.Integer(), sa.ForeignKey('motions.id')),
+        sa.Column('text', sa.String(length=255)),
+    )
+    with op.batch_alter_table('meetings', schema=None) as batch_op:
+        batch_op.drop_column('motion_md')
+    with op.batch_alter_table('amendments', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('motion_id', sa.Integer(), sa.ForeignKey('motions.id')))
+    with op.batch_alter_table('votes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('motion_id', sa.Integer(), nullable=True))
+        batch_op.drop_column('motion')
+        batch_op.create_foreign_key('fk_votes_motion_id_motions', 'motions', ['motion_id'], ['id'])
+
+
+def downgrade():
+    with op.batch_alter_table('votes', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_votes_motion_id_motions', type_='foreignkey')
+        batch_op.add_column(sa.Column('motion', sa.Boolean(), nullable=True))
+        batch_op.drop_column('motion_id')
+    with op.batch_alter_table('amendments', schema=None) as batch_op:
+        batch_op.drop_column('motion_id')
+    with op.batch_alter_table('meetings', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('motion_md', sa.Text(), nullable=True))
+    op.drop_table('motion_options')
+    op.drop_table('motions')

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -9,7 +9,15 @@ from werkzeug.exceptions import NotFound
 
 from app import create_app
 from app.extensions import db
-from app.models import Meeting, Member, VoteToken, Amendment, Vote
+from app.models import (
+    Meeting,
+    Member,
+    VoteToken,
+    Amendment,
+    Motion,
+    MotionOption,
+    Vote,
+)
 from app.voting import routes as voting
 
 
@@ -37,19 +45,52 @@ def test_cast_vote_records_hash_and_marks_used():
         meeting = Meeting(title='AGM')
         db.session.add(meeting)
         db.session.flush()
+        motion = Motion(meeting_id=meeting.id, title='M1', text_md='Motion text', category='motion', threshold='normal', ordering=1)
+        db.session.add(motion)
+        db.session.flush()
         member = Member(meeting_id=meeting.id, name='Alice', email='a@example.com')
         db.session.add(member)
-        amendment = Amendment(meeting_id=meeting.id, text_md='Test', order=1)
+        amendment = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='Test', order=1)
         db.session.add(amendment)
         db.session.commit()
         token = VoteToken(token='tok123', member_id=member.id, stage=1)
         db.session.add(token)
         db.session.commit()
+        member_id = member.id
 
-        with app.test_request_context('/vote/tok123', method='POST', data={'choice': 'yes'}):
+        with app.test_request_context('/vote/tok123', method='POST', data={f'amend_{amendment.id}': 'for'}):
             voting.ballot_token('tok123')
 
         vote = Vote.query.first()
-        expected = hashlib.sha256(f"{member.id}yessalty".encode()).hexdigest()
+        token_db = VoteToken.query.filter_by(token='tok123').first()
+        expected = hashlib.sha256(f"{member_id}forsalty".encode()).hexdigest()
+    assert vote.hash == expected
+    assert token_db.used_at is not None
+
+
+def test_stage2_motion_vote():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(meeting_id=meeting.id, title='M1', text_md='Motion text', category='motion', threshold='normal', ordering=1)
+        db.session.add(motion)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name='Alice', email='a@example.com')
+        db.session.add(member)
+        db.session.commit()
+        token = VoteToken(token='tok2', member_id=member.id, stage=2)
+        db.session.add(token)
+        db.session.commit()
+        member_id = member.id
+
+        with app.test_request_context('/vote/tok2', method='POST', data={f'motion_{motion.id}': 'against'}):
+            voting.ballot_token('tok2')
+
+        vote = Vote.query.first()
+        expected = hashlib.sha256(f"{member_id}againstsalty".encode()).hexdigest()
+        assert vote.motion_id == motion.id
         assert vote.hash == expected
         assert token.used_at is not None


### PR DESCRIPTION
## Summary
- add Motion and MotionOption models
- drop meeting `motion_md` and link amendments and votes to motions
- provide motion management forms and list view
- show motion text for each amendment and during motion vote
- support multiple choice ballots
- update tests and migrations

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684dbc8067e8832bbaacde47a6baa2f1