### PR TITLE
Fix email links to token route

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -7,7 +7,7 @@ from ..models import Member, Meeting
 
 def send_vote_invite(member: Member, token: str, meeting: Meeting) -> None:
     """Send voting link to a member using Flask-Mail."""
-    link = url_for('voting.ballot_home', token=token, _external=True)
+    link = url_for('voting.ballot_token', token=token, _external=True)
     msg = Message(
         subject=f"Your voting link for {meeting.title}",
         recipients=[member.email],
@@ -19,7 +19,7 @@ def send_vote_invite(member: Member, token: str, meeting: Meeting) -> None:
 
 def send_stage2_invite(member: Member, token: str, meeting: Meeting) -> None:
     """Email Stage 2 voting link to a member."""
-    link = url_for('voting.ballot_home', token=token, _external=True)
+    link = url_for('voting.ballot_token', token=token, _external=True)
     msg = Message(
         subject=f"Stage 2 voting open for {meeting.title}",
         recipients=[member.email],

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -309,6 +309,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Addeed motion categories, thresholds and options with new tables
 * 2025-06-15 – Implemented run-off detection and automatic Stage-1 extension.
 * 2025-06-16 – Amendments now record proposer and seconder with a 21‑day deadline and three‑per‑member cap.
+* 2025-06-17 – Corrected email invite links to use `/vote/<token>`.
 
 
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -23,3 +23,5 @@ def test_send_vote_invite_sends_mail():
             with patch.object(mail, 'send') as mock_send:
                 send_vote_invite(member, 'abc123', meeting)
                 mock_send.assert_called_once()
+                sent_msg = mock_send.call_args[0][0]
+                assert '/vote/abc123' in sent_msg.body


### PR DESCRIPTION
## Summary
- use `voting.ballot_token` for invite emails
- test invite link path
- note email correction in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e5e80890c832bbc9472f86dfb356c