### PR TITLE
Handle locked voting stages

### DIFF
--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -98,6 +98,17 @@ def ballot_token(token: str):
             400,
         )
 
+    if (vote_token.stage == 1 and meeting.stage1_locked) or (
+        vote_token.stage == 2 and meeting.stage2_locked
+    ):
+        return (
+            render_template(
+                "voting/token_error.html",
+                message="This stage is now locked by the Returning Officer.",
+            ),
+            400,
+        )
+
     if vote_token.used_at and not meeting.revoting_allowed:
         return (
             render_template(

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -309,6 +309,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Addeed motion categories, thresholds and options with new tables
 * 2025-06-15 – Implemented run-off detection and automatic Stage-1 extension.
 * 2025-06-16 – Amendments now record proposer and seconder with a 21‑day deadline and three‑per‑member cap.
+* 2025-06-16 – Stage locking check prevents voting when RO has locked a stage.
 
 
 

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -249,3 +249,70 @@ def test_stage2_token_window_enforcement():
                 resp = voting.ballot_token("tok-stage2")
                 assert resp[1] == 400
                 assert token.used_at is None
+
+
+def test_stage1_locked_rejects_vote():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM", stage1_locked=True)
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(
+            meeting_id=meeting.id,
+            title="M1",
+            text_md="Motion text",
+            category="motion",
+            threshold="normal",
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+        amend = Amendment(
+            meeting_id=meeting.id,
+            motion_id=motion.id,
+            text_md="A1",
+            order=1,
+        )
+        db.session.add(amend)
+        member = Member(meeting_id=meeting.id, name="Bob")
+        db.session.add(member)
+        db.session.commit()
+        token = VoteToken(token="lock1", member_id=member.id, stage=1)
+        db.session.add(token)
+        db.session.commit()
+
+        with app.test_request_context("/vote/lock1"):
+            resp = voting.ballot_token("lock1")
+            assert resp[1] == 400
+            assert token.used_at is None
+
+
+def test_stage2_locked_rejects_vote():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM", stage2_locked=True)
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(
+            meeting_id=meeting.id,
+            title="M1",
+            text_md="Motion text",
+            category="motion",
+            threshold="normal",
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name="Alice")
+        db.session.add(member)
+        db.session.commit()
+        token = VoteToken(token="lock2", member_id=member.id, stage=2)
+        db.session.add(token)
+        db.session.commit()
+
+        with app.test_request_context("/vote/lock2"):
+            resp = voting.ballot_token("lock2")
+            assert resp[1] == 400
+            assert token.used_at is None


### PR DESCRIPTION
## Summary
- prevent ballot access if stage is locked
- test that locked stages reject votes
- document the new check in the PRD

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e5fa16a74832b9afb3ab2792980d0