### PR TITLE
Display compiled motion text on Stage 2 ballot

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -49,6 +49,13 @@ def send_runoff_invite(member: Member, token: str, meeting: Meeting) -> None:
     )
     msg.html = render_template(
         'email/runoff_invite.html',
+        member=member,
+        meeting=meeting,
+        link=link,
+        unsubscribe_url='#',
+    )
+    mail.send(msg)
+
 
 def send_stage1_reminder(member: Member, token: str, meeting: Meeting) -> None:
     """Email reminder to cast Stage 1 vote."""

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -8,8 +8,8 @@
 {% endif %}
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}
-  {% for motion in motions %}
-    <div class="bp-card bp-glow mb-4">{{ motion.text_md }}</div>
+  {% for motion, compiled in motions %}
+    <blockquote class="bp-card bp-glow mb-4 whitespace-pre-line">{{ compiled }}</blockquote>
     <div class="space-x-4 mb-4">
       {% for sub in form['motion_' ~ motion.id] %}
         <label class="inline-flex items-center mr-4">{{ sub() }}<span>{{ sub.label.text }}</span></label>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -315,6 +315,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Proxy votes now store an additional record for the represented member and display a proxy banner.
 * 2025-06-15 – Implemented public results visibility toggle and results page.
 * 2025-06-15 – Corrected email invite links to use `/vote/<token>`.
+* 2025-06-15 – Stage 2 ballot now shows compiled motion text with carried amendments.
 
 
 


### PR DESCRIPTION
## Summary
- compose final motion text by merging carried amendments
- show compiled text on Stage 2 ballot in blockquote
- fix email helper syntax
- test motion compilation logic
- document behaviour in PRD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e663c6980832b95737af804c305d6