### PR TITLE
Enable manual merging of amendments for Stage 2

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -75,6 +75,7 @@ class Motion(db.Model):
     meeting_id = db.Column(db.Integer, db.ForeignKey('meetings.id'))
     title = db.Column(db.String(255))
     text_md = db.Column(db.Text)
+    final_text_md = db.Column(db.Text)
     category = db.Column(db.String(20))
     threshold = db.Column(db.String(20))
     ordering = db.Column(db.Integer)

--- a/app/templates/meetings/prepare_stage2.html
+++ b/app/templates/meetings/prepare_stage2.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Finalise Motion Text</h2>
+<form method="post" class="space-y-6">
+  {{ form.hidden_tag() }}
+  {% for motion in motions %}
+  <div class="bp-card grid md:grid-cols-2 gap-4">
+    <div>
+      <h3 class="font-semibold mb-2">{{ motion.title }}</h3>
+      <div class="border p-2 whitespace-pre-wrap">{{ compile_motion_text(motion) }}</div>
+    </div>
+    <div>
+      {{ form['motion_' ~ motion.id].label(class_='block font-semibold') }}
+      {{ form['motion_' ~ motion.id](class_='border p-2 rounded w-full h-40') }}
+    </div>
+  </div>
+  {% endfor %}
+  <button type="submit" class="bp-btn-primary">Save and Send Stage 2 Links</button>
+</form>
+{% endblock %}

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -20,4 +20,7 @@
 </table>
 <a href="{{ url_for('meetings.results_docx', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block">Download DOCX</a>
 <a href="{{ url_for('meetings.results_stage2_docx', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block ml-2">Download Final DOCX</a>
+{% if meeting.status == 'Pending Stage 2' %}
+<a href="{{ url_for('meetings.prepare_stage2', meeting_id=meeting.id) }}" class="bp-btn-primary mt-4 inline-block ml-2">Prepare Stage 2 Motion</a>
+{% endif %}
 {% endblock %}

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -257,7 +257,9 @@ def ballot_token(token: str):
             db.session.commit()
             return render_template("voting/confirmation.html", choice="recorded")
 
-        compiled = [(m, compile_motion_text(m)) for m in motions]
+        compiled = [
+            (m, m.final_text_md or compile_motion_text(m)) for m in motions
+        ]
         return render_template(
             "voting/stage2_ballot.html",
             form=form,

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -318,6 +318,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Implemented public results visibility toggle and results page.
 * 2025-06-15 – Corrected email invite links to use `/vote/<token>`.
 * 2025-06-15 – Stage 2 ballot now shows compiled motion text with carried amendments.
+* 2025-06-17 – Added manual Stage 2 merge screen with final text field.
 
 
 

--- a/migrations/versions/b39d7a4add7_add_final_text_md.py
+++ b/migrations/versions/b39d7a4add7_add_final_text_md.py
@@ -1,0 +1,23 @@
+"""add final text field to motions
+
+Revision ID: b39d7a4add7
+Revises: 84f4e231e1ac
+Create Date: 2025-06-17 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'b39d7a4add7'
+down_revision = '84f4e231e1ac'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('motions', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('final_text_md', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('motions', schema=None) as batch_op:
+        batch_op.drop_column('final_text_md')

--- a/tests/test_meetings_routes.py
+++ b/tests/test_meetings_routes.py
@@ -122,11 +122,12 @@ def test_close_stage1_creates_stage2_tokens_and_emails():
                 with patch('app.meetings.routes.runoff.close_stage1', return_value=[]):
                     with patch('app.meetings.routes.send_stage2_invite') as mock_send:
                         meetings.close_stage1(meeting.id)
-                        mock_send.assert_called_once()
+                        mock_send.assert_not_called()
                         assert (
                             VoteToken.query.filter_by(member_id=member.id, stage=2).count()
-                            == 1
+                            == 0
                         )
+                        assert meeting.status == 'Pending Stage 2'
 
 
 def test_close_stage1_runoff_triggers_emails_and_tokens():

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -384,3 +384,32 @@ def test_stage2_ballot_displays_compiled_text():
         with app.test_request_context("/vote/s2"):
             html = voting.ballot_token("s2")
             assert "Add" in html
+
+
+def test_stage2_ballot_uses_final_text():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM")
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(
+            meeting_id=meeting.id,
+            title="M1",
+            text_md="Base",
+            final_text_md="Merged",
+            category="motion",
+            threshold="normal",
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name="A", email="a@e.co")
+        db.session.add(member)
+        db.session.flush()
+        token = VoteToken(token="s2", member_id=member.id, stage=2)
+        db.session.add(token)
+        db.session.commit()
+        with app.test_request_context("/vote/s2"):
+            html = voting.ballot_token("s2")
+            assert "Merged" in html


### PR DESCRIPTION
## Summary
- add `final_text_md` field on motions
- require admins to manually prepare Stage 2 text
- show button after Stage 1 results to prepare text
- display human-edited text on Stage 2 ballot
- document change in `prd.md`
- update tests for new workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e70244854832b90c8406414d4d516