### PR TITLE
Enforce stage lock when voting

### DIFF
--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -118,6 +118,18 @@ def ballot_token(token: str):
             400,
         )
 
+    # reject tokens if the RO has locked this stage
+    if (vote_token.stage == 1 and meeting.stage1_locked) or (
+        vote_token.stage == 2 and meeting.stage2_locked
+    ):
+        return (
+            render_template(
+                "voting/token_error.html",
+                message="Voting for this stage has been locked by the Returning Officer.",
+            ),
+            400,
+        )
+
     if vote_token.used_at and not meeting.revoting_allowed:
         return (
             render_template(

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -319,6 +319,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Corrected email invite links to use `/vote/<token>`.
 * 2025-06-15 – Stage 2 ballot now shows compiled motion text with carried amendments.
 * 2025-06-17 – Added manual Stage 2 merge screen with final text field.
+* 2025-06-18 – Voting route rejects ballots when a stage is locked.
 
 
 

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -413,3 +413,63 @@ def test_stage2_ballot_uses_final_text():
         with app.test_request_context("/vote/s2"):
             html = voting.ballot_token("s2")
             assert "Merged" in html
+
+
+def test_stage1_locked_rejects_vote():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM", stage1_locked=True)
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(
+            meeting_id=meeting.id,
+            title="M1",
+            text_md="Text",
+            category="motion",
+            threshold="normal",
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name="A", email="a@e.co")
+        db.session.add(member)
+        db.session.commit()
+        token = VoteToken(token="lock1", member_id=member.id, stage=1)
+        db.session.add(token)
+        db.session.commit()
+
+        with app.test_request_context("/vote/lock1"):
+            resp = voting.ballot_token("lock1")
+            assert resp[1] == 400
+            assert token.used_at is None
+
+
+def test_stage2_locked_rejects_vote():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM", stage2_locked=True)
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(
+            meeting_id=meeting.id,
+            title="M1",
+            text_md="Text",
+            category="motion",
+            threshold="normal",
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name="A", email="a@e.co")
+        db.session.add(member)
+        db.session.commit()
+        token = VoteToken(token="lock2", member_id=member.id, stage=2)
+        db.session.add(token)
+        db.session.commit()
+
+        with app.test_request_context("/vote/lock2"):
+            resp = voting.ballot_token("lock2")
+            assert resp[1] == 400
+            assert token.used_at is None


### PR DESCRIPTION
## Summary
- block voting when the returning officer locks a stage
- note locked stage check in the PRD
- test that locked stages reject ballots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e728758b4832ba0f004521dd0dfd5