### PR TITLE
Add run-off voting route

### DIFF
--- a/app/templates/voting/runoff_ballot.html
+++ b/app/templates/voting/runoff_ballot.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">Run-off Vote</h2>
+<div class="bp-alert-warning mb-4">These amendments conflict. Choose which one should proceed.</div>
+{% if proxy_for %}
+<div class="bp-alert-warning text-center mb-4">
+  Casting votes as proxy for {{ proxy_for.name }}.
+</div>
+{% endif %}
+<form method="post" class="bp-form bp-card space-y-6">
+  {{ form.hidden_tag() }}
+  {% for runoff, amend_a, amend_b in runoffs %}
+    <div class="bp-card bp-glow mb-4 grid md:grid-cols-2 gap-4">
+      <div class="whitespace-pre-line">{{ amend_a.text_md }}</div>
+      <div class="whitespace-pre-line">{{ amend_b.text_md }}</div>
+    </div>
+    <div class="space-x-4 mb-4">
+      {% for sub in form['runoff_' ~ runoff.id] %}
+        <label class="inline-flex items-center mr-4">{{ sub() }}<span>{{ sub.label.text }}</span></label>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <button type="submit" class="bp-btn-primary">Submit vote</button>
+</form>
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -320,6 +320,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Stage 2 ballot now shows compiled motion text with carried amendments.
 * 2025-06-17 – Added manual Stage 2 merge screen with final text field.
 * 2025-06-18 – Voting route rejects ballots when a stage is locked.
+* 2025-06-18 – Implemented run-off ballot route and template.
 
 
 


### PR DESCRIPTION
## Summary
- add run-off ballot route and form
- create runoff ballot template
- test run-off ballot flow
- document new route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e73f3ed5c832b977fdb1d4150b6b7