### PR TITLE
Fix create meeting button link

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -24,5 +24,5 @@
   <p>No meetings available.</p>
   {% endfor %}
 </div>
-<a href="#" class="bp-btn-primary bp-float-btn">Create Meeting</a>
+<a href="{{ url_for('meetings.create_meeting') }}" class="bp-btn-primary bp-float-btn">Create Meeting</a>
 {% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -331,6 +331,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Introduced role management pages secured by 'manage_users'.
 * 2025-06-15 – Added help page explaining voting stages and token links.
 * 2025-06-15 – Added OWASP ZAP baseline scan script for penetration testing.
+* 2025-06-15 – Fixed floating “Create Meeting” button on admin dashboard link.
 
 
 ---


### PR DESCRIPTION
## Summary
- link the floating **Create Meeting** button on the admin dashboard to the create_meeting route
- document the UI fix in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ece8981b0832b9cb621fd7ee86239