### PR TITLE
Add audit log CSV download

### DIFF
--- a/app/templates/ro/dashboard.html
+++ b/app/templates/ro/dashboard.html
@@ -37,6 +37,7 @@
             <a href="{{ url_for('ro.lock_stage', meeting_id=meeting.id, stage=2) }}" class="bp-btn-primary text-sm">Lock S2</a>
           {% endif %}
           <a href="{{ url_for('ro.download_tallies', meeting_id=meeting.id) }}" class="bp-btn-secondary text-sm">CSV</a>
+          <a href="{{ url_for('ro.download_audit_log', meeting_id=meeting.id) }}" class="bp-btn-secondary text-sm">Audit</a>
         </td>
       </tr>
       {% else %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -318,6 +318,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Implemented public results visibility toggle and results page.
 * 2025-06-15 – Corrected email invite links to use `/vote/<token>`.
 * 2025-06-15 – Stage 2 ballot now shows compiled motion text with carried amendments.
+* 2025-06-16 – Added audit log CSV download for Returning Officers.
 * 2025-06-15 – Added manual Stage 2 merge screen with final text field.
 * 2025-06-15 – Voting route rejects ballots when a stage is locked.
 * 2025-06-15 – Run-off and reminder emails now link to `/vote/<token>`.


### PR DESCRIPTION
## Summary
- support download of vote audit logs per meeting
- link audit log CSV from RO dashboard
- test access to audit log CSV
- document feature in PRD

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684ece8e5268832b8d116a3d4c71ef71