### PR TITLE
Enforce production secret key check

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, render_template
 
 from .extensions import db, migrate, login_manager, bcrypt, csrf, mail, scheduler
@@ -6,6 +7,11 @@ from .extensions import db, migrate, login_manager, bcrypt, csrf, mail, schedule
 def create_app(config_object='config.DevelopmentConfig'):
     app = Flask(__name__)
     app.config.from_object(config_object)
+
+    if os.getenv('FLASK_ENV') == 'production':
+        secret_key = app.config.get('SECRET_KEY', '')
+        if not secret_key or secret_key == 'change-me':
+            raise RuntimeError('SECRET_KEY must be set to a non-default value in production')
 
     register_extensions(app)
     register_blueprints(app)

--- a/tests/test_prod_secret.py
+++ b/tests/test_prod_secret.py
@@ -1,0 +1,16 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import importlib
+import config
+import app
+
+
+def test_secret_key_required_in_production(monkeypatch):
+    monkeypatch.setenv('FLASK_ENV', 'production')
+    monkeypatch.setenv('SECRET_KEY', 'change-me')
+    importlib.reload(config)
+    importlib.reload(app)
+    with pytest.raises(RuntimeError):
+        app.create_app()


### PR DESCRIPTION
## Summary
- error if production SECRET_KEY is unset or default
- test for SECRET_KEY validation

## Testing
- `timeout 3 flask --app app run --port 9999`
- `timeout 3 flask db upgrade`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684ecfc65108832bb13914fa259ddcff