### PR TITLE
Add safe URL check for login

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from flask_login import login_user, logout_user
+
 from ..models import User
+from .utils import is_safe_url
 
 bp = Blueprint('auth', __name__, url_prefix='/auth')
 
@@ -14,7 +16,8 @@ def login():
         user = User.query.filter_by(email=email).first()
         if user and user.check_password(password):
             login_user(user)
-            return redirect(next_page or url_for('admin.dashboard'))
+            destination = next_page if is_safe_url(next_page) else url_for('admin.dashboard')
+            return redirect(destination)
         flash('Invalid credentials')
     return render_template('auth/login.html', next=next_page)
 

--- a/app/auth/utils.py
+++ b/app/auth/utils.py
@@ -1,0 +1,8 @@
+from urllib.parse import urlparse
+
+
+def is_safe_url(target: str) -> bool:
+    """Return True if the URL targets this host."""
+    if not target:
+        return False
+    return urlparse(target).netloc == ''

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,33 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+from app.extensions import db
+from app.models import User
+
+
+def _setup_app():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['WTF_CSRF_ENABLED'] = False
+    return app
+
+
+def test_login_ignores_external_next_url():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        user = User(email='foo@example.com')
+        user.set_password('secret')
+        user.is_active = True
+        db.session.add(user)
+        db.session.commit()
+
+    client = app.test_client()
+    resp = client.post('/auth/login?next=http://evil.com', data={
+        'email': 'foo@example.com',
+        'password': 'secret'
+    }, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/admin/')
+


### PR DESCRIPTION
## Summary
- guard against open redirects by implementing `is_safe_url`
- default login redirect to dashboard when next URL is external
- cover the regression with a new auth test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ecfb56f7c832bacb4bf8ea5a08f3d