### PR TITLE
Add Markdown rendering filter

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 import os
 from flask import Flask, render_template
+from .utils import markdown_to_html
 
 from .extensions import db, migrate, login_manager, bcrypt, csrf, mail, scheduler
 
@@ -50,6 +51,9 @@ def register_extensions(app):
         register_jobs()
         scheduler.start()
     login_manager.login_view = 'auth.login'
+
+    # register template filters
+    app.jinja_env.filters['markdown_to_html'] = markdown_to_html
 
     from .models import User
 

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -8,7 +8,7 @@
   <tbody>
   {% for amend, counts in results %}
     <tr class="border-t">
-      <td class="p-2">{{ amend.text_md }}</td>
+      <td class="p-2">{{ amend.text_md|markdown_to_html|safe }}</td>
       <td class="p-2 text-center">{{ counts.for }}</td>
       <td class="p-2 text-center">{{ counts.against }}</td>
       <td class="p-2 text-center">{{ counts.abstain }}</td>

--- a/app/templates/meetings/view_motion.html
+++ b/app/templates/meetings/view_motion.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2 class="font-bold text-bp-blue mb-4">{{ motion.title }}</h2>
-<div class="bp-card bp-glow mb-4">{{ motion.text_md or 'No motion text.' }}</div>
+<div class="bp-card bp-glow mb-4">{{ (motion.text_md or 'No motion text.')|markdown_to_html|safe }}</div>
 <h3 class="font-bold mb-2">Amendments</h3>
 {% for amend in amendments %}
   <div class="bp-card mb-2">
     <p class="font-semibold mb-1">Proposed by {{ amend.proposer.name }} – Seconded by {{ amend.seconder.name }}</p>
-    {{ amend.text_md }}
+    {{ amend.text_md|markdown_to_html|safe }}
   </div>
 {% else %}
   <p>No amendments submitted.</p>

--- a/app/templates/public_results.html
+++ b/app/templates/public_results.html
@@ -11,7 +11,7 @@
       <tbody>
         {% for amend, counts in stage1 %}
         <tr class="border-t">
-          <td class="p-2">{{ amend.text_md }}</td>
+          <td class="p-2">{{ amend.text_md|markdown_to_html|safe }}</td>
           <td class="p-2 text-center">{{ counts.for }}</td>
           <td class="p-2 text-center">{{ counts.against }}</td>
           <td class="p-2 text-center">{{ counts.abstain }}</td>

--- a/app/templates/voting/combined_ballot.html
+++ b/app/templates/voting/combined_ballot.html
@@ -9,10 +9,10 @@
 <form method="post" class="bp-form bp-card space-y-6">
   {{ form.hidden_tag() }}
   {% for motion, ams in motions %}
-    <div class="bp-card bp-glow mb-4">{{ motion.text_md }}</div>
+    <div class="bp-card bp-glow mb-4">{{ motion.text_md|markdown_to_html|safe }}</div>
     {% for amend in ams %}
       <div class="mb-4">
-        <div class="font-semibold mb-2">{{ amend.text_md }}</div>
+        <div class="font-semibold mb-2">{{ amend.text_md|markdown_to_html|safe }}</div>
         <div class="space-x-4">
           {% for sub in form['amend_' ~ amend.id] %}
             <label class="inline-flex items-center mr-4">{{ sub() }}<span>{{ sub.label.text }}</span></label>

--- a/app/templates/voting/stage1_ballot.html
+++ b/app/templates/voting/stage1_ballot.html
@@ -9,10 +9,10 @@
 <form method="post" class="bp-form bp-card space-y-6">
   {{ form.hidden_tag() }}
   {% for motion, ams in motions %}
-    <div class="bp-card bp-glow mb-4">{{ motion.text_md }}</div>
+    <div class="bp-card bp-glow mb-4">{{ motion.text_md|markdown_to_html|safe }}</div>
     {% for amend in ams %}
       <div class="mb-4">
-        <div class="font-semibold mb-2">{{ amend.text_md }}</div>
+        <div class="font-semibold mb-2">{{ amend.text_md|markdown_to_html|safe }}</div>
         <div class="space-x-4">
           {% for sub in form['amend_' ~ amend.id] %}
             <label class="inline-flex items-center mr-4">{{ sub() }}<span>{{ sub.label.text }}</span></label>

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -9,7 +9,7 @@
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}
   {% for motion, compiled in motions %}
-    <blockquote class="bp-card bp-glow mb-4 whitespace-pre-line">{{ compiled }}</blockquote>
+    <blockquote class="bp-card bp-glow mb-4 whitespace-pre-line">{{ compiled|markdown_to_html|safe }}</blockquote>
     <div class="space-x-4 mb-4">
       {% for sub in form['motion_' ~ motion.id] %}
         <label class="inline-flex items-center mr-4">{{ sub() }}<span>{{ sub.label.text }}</span></label>

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,8 @@
+from markdown import markdown
+from markupsafe import Markup
+
+
+def markdown_to_html(text: str) -> Markup:
+    """Convert Markdown text to safe HTML."""
+    return Markup(markdown(text or ""))
+


### PR DESCRIPTION
## Summary
- add `markdown_to_html` utility
- register `markdown_to_html` as a Jinja filter
- render motion and amendment text as Markdown across ballots, motion view and result templates

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test_receipt_email_sent_after_vote)*

------
https://chatgpt.com/codex/tasks/task_b_684ed3d70328832bb002737d0fa802cd