### PR TITLE
Add results index page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, abort
+from flask import Blueprint, render_template, abort, request
 from .extensions import db
 from .models import Meeting, Amendment, Motion, Vote
 from sqlalchemy import func
@@ -21,6 +21,20 @@ def _vote_counts(query):
     for choice, count in rows:
         counts[choice] = count
     return counts
+
+
+@bp.route('/results')
+def results_index():
+    """List meetings with publicly visible results."""
+    page = request.args.get('page', 1, type=int)
+    pagination = (
+        Meeting.query.filter_by(public_results=True)
+        .order_by(Meeting.opens_at_stage1.desc())
+        .paginate(page=page, per_page=10, error_out=False)
+    )
+    return render_template(
+        'results_index.html', meetings=pagination.items, pagination=pagination
+    )
 
 
 @bp.route('/results/<int:meeting_id>')

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,7 +14,7 @@
           <ul class="flex space-x-4 text-sm">
             <li><a href="{{ url_for('main.index') }}" class="hover:underline">Home</a></li>
             <li><a href="{{ url_for('meetings.list_meetings') }}" class="hover:underline">Meetings</a></li>
-            <li><a href="#" class="hover:underline">Results</a></li>
+            <li><a href="{{ url_for('main.results_index') }}" class="hover:underline">Results</a></li>
             <li><a href="{{ url_for('help.show_help') }}" class="hover:underline">Help</a></li>
           </ul>
         </div>

--- a/app/templates/results_index.html
+++ b/app/templates/results_index.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">Meeting Results</h2>
+<div class="bp-card-grid mb-4">
+  {% for meeting in meetings %}
+  <a href="{{ url_for('main.public_results', meeting_id=meeting.id) }}" class="bp-card block hover:shadow-md">
+    <h3 class="font-semibold mb-1">{{ meeting.title }}</h3>
+    <p class="text-sm">{{ meeting.status or 'Concluded' }}</p>
+  </a>
+  {% else %}
+  <p>No public results yet.</p>
+  {% endfor %}
+</div>
+{% if pagination.pages > 1 %}
+<ul class="bp-pagination">
+  {% if pagination.has_prev %}
+  <li><a href="{{ url_for('main.results_index', page=pagination.prev_num) }}">&laquo; Prev</a></li>
+  {% else %}
+  <li class="disabled">&laquo; Prev</li>
+  {% endif %}
+  {% for p in pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+    {% if p %}
+      {% if p == pagination.page %}
+      <li class="bp-active">{{ p }}</li>
+      {% else %}
+      <li><a href="{{ url_for('main.results_index', page=p) }}">{{ p }}</a></li>
+      {% endif %}
+    {% else %}
+      <li class="disabled">&hellip;</li>
+    {% endif %}
+  {% endfor %}
+  {% if pagination.has_next %}
+  <li><a href="{{ url_for('main.results_index', page=pagination.next_num) }}">Next &raquo;</a></li>
+  {% else %}
+  <li class="disabled">Next &raquo;</li>
+  {% endif %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -316,6 +316,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Added APScheduler reminders with configurable timing.
 * 2025-06-15 – Proxy votes now store an additional record for the represented member and display a proxy banner.
 * 2025-06-15 – Implemented public results visibility toggle and results page.
+* 2025-06-16 – Introduced public results index page listing all meetings.
 * 2025-06-15 – Corrected email invite links to use `/vote/<token>`.
 * 2025-06-15 – Stage 2 ballot now shows compiled motion text with carried amendments.
 * 2025-06-16 – Added audit log CSV download for Returning Officers.

--- a/tests/test_results_index.py
+++ b/tests/test_results_index.py
@@ -1,0 +1,27 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+from app.extensions import db
+from app.models import Meeting
+from app import routes as main
+
+
+def _setup_app():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    return app
+
+
+def test_results_index_lists_only_public():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        m1 = Meeting(title='AGM', public_results=True)
+        m2 = Meeting(title='EGM', public_results=False)
+        db.session.add_all([m1, m2])
+        db.session.commit()
+        with app.test_request_context('/results'):
+            html = main.results_index()
+            assert 'AGM' in html
+            assert 'EGM' not in html


### PR DESCRIPTION
## Summary
- list meetings with public results using `/results`
- link to results index in navigation
- add pagination with `.bp-pagination`
- document new public results index in PRD
- test that only meetings with public results are listed

## Testing
- `docker-compose up --build` *(fails: command not found)*
- `flask --app app run --port 5001` *(manual stop)*
- `pytest -q tests/test_results_index.py`
- `pytest -q` *(fails: test_receipt_email_sent_after_vote)*

------
https://chatgpt.com/codex/tasks/task_b_684ed3ca83f4832bbbdbe50496f95f6f