### PR TITLE
Fix run-off invite link

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -57,7 +57,7 @@ def send_runoff_invite(member: Member, token: str, meeting: Meeting) -> None:
     """Email run-off voting link after Stage 1."""
     if member.email_opt_out:
         return
-    link = url_for('voting.ballot_token', token=token, _external=True)
+    link = url_for('voting.runoff_ballot', token=token, _external=True)
     unsubscribe = _unsubscribe_url(member)
     msg = Message(
         subject=f"Run-off vote for {meeting.title}",

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -322,6 +322,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Added manual Stage 2 merge screen with final text field.
 * 2025-06-15 – Voting route rejects ballots when a stage is locked.
 * 2025-06-15 – Run-off and reminder emails now link to `/vote/<token>`.
+* 2025-06-16 – Run-off invite emails now use `/vote/runoff/<token>` links.
 * 2025-06-15 – Added `aria-describedby` error hints on admin and meeting forms.
 * 2025-06-15 – Dashboard shows countdown to next reminder using badge design.
 * 2025-06-15 – Added quorum percentage banner with countdown on dashboards.

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -54,7 +54,7 @@ def test_send_runoff_invite_uses_token_url():
                 send_runoff_invite(member, 'abc123', meeting)
                 mock_send.assert_called_once()
                 sent_msg = mock_send.call_args[0][0]
-                assert '/vote/abc123' in sent_msg.body
+                assert '/vote/runoff/abc123' in sent_msg.body
 
 
 def test_send_stage1_reminder_uses_token_url():


### PR DESCRIPTION
## Summary
- correct link generator for run-off invites
- adjust email service unit test
- update PRD changelog

## Testing
- `pytest tests/test_email_service.py::test_send_runoff_invite_uses_token_url -q`
- `pytest -q` *(fails: test_receipt_email_sent_after_vote)*

------
https://chatgpt.com/codex/tasks/task_b_684ed3d0b5b8832b9488fd2a903dc9f2