### PR TITLE
Add countdown headers to ballot pages

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -92,6 +92,17 @@ class Meeting(db.Model):
         minutes = rem // 60
         return f"{hours}h {minutes}m"
 
+    def stage2_time_remaining(self) -> str:
+        """Return human-friendly countdown until Stage-2 closes."""
+        if not self.closes_at_stage2:
+            return "N/A"
+        delta = self.closes_at_stage2 - datetime.utcnow()
+        if delta.total_seconds() <= 0:
+            return "Closed"
+        hours, rem = divmod(int(delta.total_seconds()), 3600)
+        minutes = rem // 60
+        return f"{hours}h {minutes}m"
+
 class Member(db.Model):
     __tablename__ = 'members'
     id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/voting/combined_ballot.html
+++ b/app/templates/voting/combined_ballot.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">Combined Ballot</h2>
+<header class="mb-4">
+  <h2 class="font-bold text-bp-blue">Combined Ballot</h2>
+  <p class="text-sm">Closes in {{ meeting.stage1_time_remaining() }}</p>
+</header>
 {% if proxy_for %}
 <div class="bp-alert-warning text-center mb-4">
   Casting votes as proxy for {{ proxy_for.name }}.

--- a/app/templates/voting/stage1_ballot.html
+++ b/app/templates/voting/stage1_ballot.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">Stage 1 – Amendment Votes</h2>
+<header class="mb-4">
+  <h2 class="font-bold text-bp-blue">Stage 1 – Amendment Votes</h2>
+  <p class="text-sm">Closes in {{ meeting.stage1_time_remaining() }}</p>
+</header>
 {% if proxy_for %}
 <div class="bp-alert-warning text-center mb-4">
   Casting votes as proxy for {{ proxy_for.name }}.

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">Stage 2 – Vote on Motion</h2>
+<header class="mb-4">
+  <h2 class="font-bold text-bp-blue">Stage 2 – Vote on Motion</h2>
+  <p class="text-sm">Closes in {{ meeting.stage2_time_remaining() }}</p>
+</header>
 {% if proxy_for %}
 <div class="bp-alert-warning text-center mb-4">
   Casting votes as proxy for {{ proxy_for.name }}.


### PR DESCRIPTION
## Summary
- show time remaining on ballot templates
- pass hashed token in email test
- test countdown display on ballot pages
- add stage2 time remaining helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ed3bd4ac8832b9c783d9f4bca583d