### PR TITLE
Add public results index page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -10,6 +10,17 @@ def index():
     return render_template('index.html')
 
 
+@bp.route('/results')
+def results_index():
+    """List meetings with public results enabled."""
+    meetings = (
+        Meeting.query.filter_by(public_results=True)
+        .order_by(Meeting.title)
+        .all()
+    )
+    return render_template('results_index.html', meetings=meetings)
+
+
 def _vote_counts(query):
     counts = {'for': 0, 'against': 0, 'abstain': 0}
     rows = (

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,7 +14,7 @@
           <ul class="flex space-x-4 text-sm">
             <li><a href="{{ url_for('main.index') }}" class="hover:underline">Home</a></li>
             <li><a href="{{ url_for('meetings.list_meetings') }}" class="hover:underline">Meetings</a></li>
-            <li><a href="#" class="hover:underline">Results</a></li>
+            <li><a href="{{ url_for('main.results_index') }}" class="hover:underline">Results</a></li>
             <li><a href="{{ url_for('help.show_help') }}" class="hover:underline">Help</a></li>
           </ul>
         </div>

--- a/app/templates/results_index.html
+++ b/app/templates/results_index.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">Results</h2>
+<div class="bp-card">
+  <ul class="space-y-2">
+    {% for meeting in meetings %}
+    <li>
+      <a href="{{ url_for('main.public_results', meeting_id=meeting.id) }}" class="text-bp-blue hover:underline">{{ meeting.title }}</a>
+    </li>
+    {% else %}
+    <li>No public results available.</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -337,6 +337,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Vote tokens stored as SHA-256 hashes with server-side salt.
 * 2025-06-15 – Sanitised help page HTML using Bleach to strip script tags.
 * 2025-06-15 – Fixed floating “Create Meeting” button on admin dashboard link
+* 2025-06-17 – Added results index listing meetings with public results enabled.
 
 
 ---


### PR DESCRIPTION
## Summary
- list meetings with public results
- add results index link in navigation
- show results links
- test public results index
- note feature in PRD changelog

## Testing
- `pytest tests/test_public_results.py::test_results_index_lists_public_meetings -q`
- `pytest -q` *(fails: send_vote_receipt not called)*

------
https://chatgpt.com/codex/tasks/task_b_684ed3a55aec832bb42bd54c84e33948