### PR TITLE
Fix receipt emails include unsubscribe link

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -108,19 +108,24 @@ def send_stage1_reminder(member: Member, token: str, meeting: Meeting) -> None:
 
 def send_vote_receipt(member: Member, meeting: Meeting, hashes: list[str]) -> None:
     """Email a receipt containing vote hashes."""
+    unsubscribe = _unsubscribe_url(member)
     msg = Message(
         subject=f"Your vote receipt for {meeting.title}",
         recipients=[member.email],
         sender=_sender(),
     )
     msg.body = render_template(
-        "email/receipt.txt", member=member, meeting=meeting, hashes=hashes
+        "email/receipt.txt",
+        member=member,
+        meeting=meeting,
+        hashes=hashes,
+        unsubscribe_url=unsubscribe,
     )
     msg.html = render_template(
         "email/receipt.html",
         member=member,
         meeting=meeting,
         hashes=hashes,
-        unsubscribe_url="#",
+        unsubscribe_url=unsubscribe,
     )
     mail.send(msg)

--- a/app/templates/email/receipt.txt
+++ b/app/templates/email/receipt.txt
@@ -5,3 +5,5 @@ Receipt hashes:
 {% for h in hashes %}
 - {{ h }}
 {% endfor %}
+
+To stop these emails, visit {{ unsubscribe_url }}

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -89,3 +89,4 @@ def test_send_vote_receipt_includes_hash():
                 mock_send.assert_called_once()
                 sent_msg = mock_send.call_args[0][0]
                 assert 'abc123' in sent_msg.body
+                assert '/unsubscribe/' in sent_msg.body


### PR DESCRIPTION
## Summary
- include unsubscribe URL in `send_vote_receipt`
- add unsubscribe text to `receipt.txt`
- test receipt emails for unsubscribe links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684fa6e8fdcc832bbe0cfa8cfb94bddd