### PR TITLE
Add auth requirement for motions list

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -204,6 +204,8 @@ def import_members(meeting_id):
 
 
 @bp.route('/<int:meeting_id>/motions')
+@login_required
+@permission_required('manage_meetings')
 def list_motions(meeting_id):
     meeting = Meeting.query.get_or_404(meeting_id)
     motions = Motion.query.filter_by(meeting_id=meeting.id).order_by(Motion.ordering).all()


### PR DESCRIPTION
## Summary
- require login and manage_meetings permission for the motions list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fa7042e00832ba76cd6aa44f9bca9