### PR TITLE
Add default motion options for clerical fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ REMINDER_HOURS_BEFORE_CLOSE=6
 REMINDER_COOLDOWN_HOURS=24
 REMINDER_TEMPLATE=email/reminder
 # TIE_BREAK_DECISIONS={}
+CLERICAL_TEXT=The Board may correct typographical or numbering errors with no change to meaning.
+MOVE_TEXT=The Board may place this change in the Articles or Bylaws as most appropriate.

--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -13,36 +13,37 @@ from wtforms.validators import DataRequired, Email, Optional
 
 
 class UserForm(FlaskForm):
-    email = StringField('Email', validators=[DataRequired(), Email()])
-    password = PasswordField('Password', validators=[Optional()])
-    role_id = SelectField('Role', coerce=int, validators=[DataRequired()])
-    is_active = BooleanField('Active', default=True)
-    submit = SubmitField('Save')
+    email = StringField("Email", validators=[DataRequired(), Email()])
+    password = PasswordField("Password", validators=[Optional()])
+    role_id = SelectField("Role", coerce=int, validators=[DataRequired()])
+    is_active = BooleanField("Active", default=True)
+    submit = SubmitField("Save")
 
 
 class UserCreateForm(UserForm):
-    password = PasswordField('Password', validators=[DataRequired()])
+    password = PasswordField("Password", validators=[DataRequired()])
 
 
 class RoleForm(FlaskForm):
-    name = StringField('Name', validators=[DataRequired()])
-    permission_ids = SelectMultipleField('Permissions', coerce=int)
-    submit = SubmitField('Save')
+    name = StringField("Name", validators=[DataRequired()])
+    permission_ids = SelectMultipleField("Permissions", coerce=int)
+    submit = SubmitField("Save")
 
 
 class PermissionForm(FlaskForm):
-    name = StringField('Name', validators=[DataRequired()])
-    submit = SubmitField('Save')
+    name = StringField("Name", validators=[DataRequired()])
+    submit = SubmitField("Save")
 
 
 class SettingsForm(FlaskForm):
-    site_title = StringField('Site Title', validators=[DataRequired()])
-    site_logo = StringField('Site Logo', validators=[Optional()])
-    from_email = StringField('From Email', validators=[DataRequired(), Email()])
-    runoff_extension_minutes = IntegerField('Run-off Extension Minutes')
-    reminder_hours_before_close = IntegerField('Reminder Hours Before Close')
-    reminder_cooldown_hours = IntegerField('Reminder Cooldown Hours')
-    reminder_template = StringField('Reminder Template')
-    tie_break_decisions = TextAreaField('Tie Break Decisions', validators=[Optional()])
-    submit = SubmitField('Save')
-
+    site_title = StringField("Site Title", validators=[DataRequired()])
+    site_logo = StringField("Site Logo", validators=[Optional()])
+    from_email = StringField("From Email", validators=[DataRequired(), Email()])
+    runoff_extension_minutes = IntegerField("Run-off Extension Minutes")
+    reminder_hours_before_close = IntegerField("Reminder Hours Before Close")
+    reminder_cooldown_hours = IntegerField("Reminder Cooldown Hours")
+    reminder_template = StringField("Reminder Template")
+    tie_break_decisions = TextAreaField("Tie Break Decisions", validators=[Optional()])
+    clerical_text = TextAreaField("Clerical Amendment Text", validators=[Optional()])
+    move_text = TextAreaField("Articles/Bylaws Placement Text", validators=[Optional()])
+    submit = SubmitField("Save")

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,4 +1,12 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    current_app,
+)
 import json
 from flask_login import login_required
 from ..extensions import db
@@ -7,53 +15,54 @@ from .forms import UserForm, UserCreateForm, RoleForm, SettingsForm
 
 from ..permissions import permission_required
 
-bp = Blueprint('admin', __name__, url_prefix='/admin')
+bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
-@bp.route('/')
+@bp.route("/")
 @login_required
-@permission_required('view_dashboard')
+@permission_required("view_dashboard")
 def dashboard():
     meetings = Meeting.query.all()
-    return render_template('admin/dashboard.html', meetings=meetings)
+    return render_template("admin/dashboard.html", meetings=meetings)
 
 
-@bp.route('/meetings/<int:meeting_id>/toggle-public', methods=['POST'])
+@bp.route("/meetings/<int:meeting_id>/toggle-public", methods=["POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def toggle_public_results(meeting_id: int):
     meeting = Meeting.query.get_or_404(meeting_id)
     meeting.public_results = not meeting.public_results
     db.session.commit()
-    return redirect(url_for('admin.dashboard'))
+    return redirect(url_for("admin.dashboard"))
 
 
-@bp.route('/users')
+@bp.route("/users")
 @login_required
-@permission_required('manage_users')
+@permission_required("manage_users")
 def list_users():
-    q = request.args.get('q', '').strip()
-    sort = request.args.get('sort', 'email')
-    direction = request.args.get('direction', 'asc')
+    q = request.args.get("q", "").strip()
+    sort = request.args.get("sort", "email")
+    direction = request.args.get("direction", "asc")
 
     query = User.query
     if q:
         search = f"%{q}%"
         query = query.filter(User.email.ilike(search))
 
-    if sort == 'created_at':
+    if sort == "created_at":
         order_attr = User.created_at
     else:
         order_attr = User.email
     query = query.order_by(
-        order_attr.asc() if direction == 'asc' else order_attr.desc()
+        order_attr.asc() if direction == "asc" else order_attr.desc()
     )
 
     users = query.all()
 
     template = (
-        'admin/_user_rows.html' if request.headers.get('HX-Request')
-        else 'admin/users.html'
+        "admin/_user_rows.html"
+        if request.headers.get("HX-Request")
+        else "admin/users.html"
     )
     return render_template(
         template,
@@ -80,29 +89,29 @@ def _save_user(form: UserForm, user: User | None = None) -> User:
     return user
 
 
-@bp.route('/users/create', methods=['GET', 'POST'])
+@bp.route("/users/create", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_users')
+@permission_required("manage_users")
 def create_user():
     form = UserCreateForm()
     form.role_id.choices = [(r.id, r.name) for r in Role.query.order_by(Role.name)]
     if form.validate_on_submit():
         _save_user(form)
-        return redirect(url_for('admin.list_users'))
-    return render_template('admin/user_form.html', form=form, user=None)
+        return redirect(url_for("admin.list_users"))
+    return render_template("admin/user_form.html", form=form, user=None)
 
 
-@bp.route('/users/<int:user_id>/edit', methods=['GET', 'POST'])
+@bp.route("/users/<int:user_id>/edit", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_users')
+@permission_required("manage_users")
 def edit_user(user_id):
     user = User.query.get_or_404(user_id)
     form = UserForm(obj=user)
     form.role_id.choices = [(r.id, r.name) for r in Role.query.order_by(Role.name)]
     if form.validate_on_submit():
         _save_user(form, user)
-        return redirect(url_for('admin.list_users'))
-    return render_template('admin/user_form.html', form=form, user=user)
+        return redirect(url_for("admin.list_users"))
+    return render_template("admin/user_form.html", form=form, user=user)
 
 
 def _save_role(form: RoleForm, role: Role | None = None) -> Role:
@@ -111,26 +120,26 @@ def _save_role(form: RoleForm, role: Role | None = None) -> Role:
         role = Role()
 
     role.name = form.name.data
-    role.permissions = (
-        Permission.query.filter(Permission.id.in_(form.permission_ids.data)).all()
-    )
+    role.permissions = Permission.query.filter(
+        Permission.id.in_(form.permission_ids.data)
+    ).all()
 
     db.session.add(role)
     db.session.commit()
     return role
 
 
-@bp.route('/roles')
+@bp.route("/roles")
 @login_required
-@permission_required('manage_users')
+@permission_required("manage_users")
 def list_roles():
     roles = Role.query.order_by(Role.name).all()
-    return render_template('admin/roles.html', roles=roles)
+    return render_template("admin/roles.html", roles=roles)
 
 
-@bp.route('/roles/create', methods=['GET', 'POST'])
+@bp.route("/roles/create", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_users')
+@permission_required("manage_users")
 def create_role():
     form = RoleForm()
     form.permission_ids.choices = [
@@ -138,81 +147,97 @@ def create_role():
     ]
     if form.validate_on_submit():
         _save_role(form)
-        return redirect(url_for('admin.list_roles'))
-    return render_template('admin/role_form.html', form=form, role=None)
+        return redirect(url_for("admin.list_roles"))
+    return render_template("admin/role_form.html", form=form, role=None)
 
 
-@bp.route('/roles/<int:role_id>/edit', methods=['GET', 'POST'])
+@bp.route("/roles/<int:role_id>/edit", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_users')
+@permission_required("manage_users")
 def edit_role(role_id):
     role = Role.query.get_or_404(role_id)
     form = RoleForm(obj=role)
     form.permission_ids.choices = [
         (p.id, p.name) for p in Permission.query.order_by(Permission.name)
     ]
-    if request.method == 'GET':
+    if request.method == "GET":
         form.permission_ids.data = [p.id for p in role.permissions]
     if form.validate_on_submit():
         _save_role(form, role)
-        return redirect(url_for('admin.list_roles'))
-    return render_template('admin/role_form.html', form=form, role=role)
+        return redirect(url_for("admin.list_roles"))
+    return render_template("admin/role_form.html", form=form, role=role)
 
 
-@bp.route('/settings', methods=['GET', 'POST'])
+@bp.route("/settings", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_settings')
+@permission_required("manage_settings")
 def manage_settings():
     form = SettingsForm()
-    if request.method == 'GET':
-        form.site_title.data = AppSetting.get('site_title', 'VoteBuddy')
-        form.site_logo.data = AppSetting.get('site_logo', '')
+    if request.method == "GET":
+        form.site_title.data = AppSetting.get("site_title", "VoteBuddy")
+        form.site_logo.data = AppSetting.get("site_logo", "")
         form.from_email.data = AppSetting.get(
-            'from_email', current_app.config.get('MAIL_DEFAULT_SENDER', 'noreply@example.com')
+            "from_email",
+            current_app.config.get("MAIL_DEFAULT_SENDER", "noreply@example.com"),
         )
         form.runoff_extension_minutes.data = int(
             AppSetting.get(
-                'runoff_extension_minutes',
-                current_app.config.get('RUNOFF_EXTENSION_MINUTES', 2880),
+                "runoff_extension_minutes",
+                current_app.config.get("RUNOFF_EXTENSION_MINUTES", 2880),
             )
         )
         form.reminder_hours_before_close.data = int(
             AppSetting.get(
-                'reminder_hours_before_close',
-                current_app.config.get('REMINDER_HOURS_BEFORE_CLOSE', 6),
+                "reminder_hours_before_close",
+                current_app.config.get("REMINDER_HOURS_BEFORE_CLOSE", 6),
             )
         )
         form.reminder_cooldown_hours.data = int(
             AppSetting.get(
-                'reminder_cooldown_hours',
-                current_app.config.get('REMINDER_COOLDOWN_HOURS', 24),
+                "reminder_cooldown_hours",
+                current_app.config.get("REMINDER_COOLDOWN_HOURS", 24),
             )
         )
         form.reminder_template.data = AppSetting.get(
-            'reminder_template', current_app.config.get('REMINDER_TEMPLATE', 'email/reminder')
+            "reminder_template",
+            current_app.config.get("REMINDER_TEMPLATE", "email/reminder"),
         )
         form.tie_break_decisions.data = AppSetting.get(
-            'tie_break_decisions',
-            json.dumps(current_app.config.get('TIE_BREAK_DECISIONS', {})),
+            "tie_break_decisions",
+            json.dumps(current_app.config.get("TIE_BREAK_DECISIONS", {})),
+        )
+        form.clerical_text.data = AppSetting.get(
+            "clerical_text", current_app.config.get("CLERICAL_TEXT")
+        )
+        form.move_text.data = AppSetting.get(
+            "move_text", current_app.config.get("MOVE_TEXT")
         )
     if form.validate_on_submit():
-        AppSetting.set('site_title', form.site_title.data)
-        AppSetting.set('site_logo', form.site_logo.data)
-        AppSetting.set('from_email', form.from_email.data)
-        AppSetting.set('runoff_extension_minutes', str(form.runoff_extension_minutes.data))
-        AppSetting.set('reminder_hours_before_close', str(form.reminder_hours_before_close.data))
-        AppSetting.set('reminder_cooldown_hours', str(form.reminder_cooldown_hours.data))
-        AppSetting.set('reminder_template', form.reminder_template.data)
-        AppSetting.set('tie_break_decisions', form.tie_break_decisions.data)
-        flash('Settings updated', 'success')
-        return redirect(url_for('admin.manage_settings'))
-    return render_template('admin/settings_form.html', form=form)
+        AppSetting.set("site_title", form.site_title.data)
+        AppSetting.set("site_logo", form.site_logo.data)
+        AppSetting.set("from_email", form.from_email.data)
+        AppSetting.set(
+            "runoff_extension_minutes", str(form.runoff_extension_minutes.data)
+        )
+        AppSetting.set(
+            "reminder_hours_before_close", str(form.reminder_hours_before_close.data)
+        )
+        AppSetting.set(
+            "reminder_cooldown_hours", str(form.reminder_cooldown_hours.data)
+        )
+        AppSetting.set("reminder_template", form.reminder_template.data)
+        AppSetting.set("tie_break_decisions", form.tie_break_decisions.data)
+        AppSetting.set("clerical_text", form.clerical_text.data)
+        AppSetting.set("move_text", form.move_text.data)
+        flash("Settings updated", "success")
+        return redirect(url_for("admin.manage_settings"))
+    return render_template("admin/settings_form.html", form=form)
 
 
-@bp.route('/settings/reset/<key>', methods=['POST'])
+@bp.route("/settings/reset/<key>", methods=["POST"])
 @login_required
-@permission_required('manage_settings')
+@permission_required("manage_settings")
 def reset_setting(key: str):
     AppSetting.delete(key)
-    flash('Setting reset to default', 'success')
-    return redirect(url_for('admin.manage_settings'))
+    flash("Setting reset to default", "success")
+    return redirect(url_for("admin.manage_settings"))

--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -12,20 +12,28 @@ from wtforms import (
 )
 from wtforms.validators import DataRequired
 
+
 class MeetingForm(FlaskForm):
-    title = StringField('Title', validators=[DataRequired()])
-    type = SelectField('Type', choices=[('AGM', 'AGM'), ('EGM', 'EGM')])
-    opens_at_stage1 = DateTimeLocalField('Stage 1 Opens', format='%Y-%m-%dT%H:%M')
-    closes_at_stage1 = DateTimeLocalField('Stage 1 Closes', format='%Y-%m-%dT%H:%M')
-    opens_at_stage2 = DateTimeLocalField('Stage 2 Opens', format='%Y-%m-%dT%H:%M')
-    closes_at_stage2 = DateTimeLocalField('Stage 2 Closes', format='%Y-%m-%dT%H:%M')
-    ballot_mode = SelectField('Ballot Mode', choices=[('two-stage', 'Two-stage'), ('combined', 'Combined'), ('in-person', 'In-person/Hybrid')])
-    revoting_allowed = BooleanField('Revoting Allowed')
-    public_results = BooleanField('Public Results')
-    quorum = IntegerField('Quorum')
-    status = StringField('Status')
-    chair_notes_md = TextAreaField('Chair Notes')
-    submit = SubmitField('Save')
+    title = StringField("Title", validators=[DataRequired()])
+    type = SelectField("Type", choices=[("AGM", "AGM"), ("EGM", "EGM")])
+    opens_at_stage1 = DateTimeLocalField("Stage 1 Opens", format="%Y-%m-%dT%H:%M")
+    closes_at_stage1 = DateTimeLocalField("Stage 1 Closes", format="%Y-%m-%dT%H:%M")
+    opens_at_stage2 = DateTimeLocalField("Stage 2 Opens", format="%Y-%m-%dT%H:%M")
+    closes_at_stage2 = DateTimeLocalField("Stage 2 Closes", format="%Y-%m-%dT%H:%M")
+    ballot_mode = SelectField(
+        "Ballot Mode",
+        choices=[
+            ("two-stage", "Two-stage"),
+            ("combined", "Combined"),
+            ("in-person", "In-person/Hybrid"),
+        ],
+    )
+    revoting_allowed = BooleanField("Revoting Allowed")
+    public_results = BooleanField("Public Results")
+    quorum = IntegerField("Quorum")
+    status = StringField("Status")
+    chair_notes_md = TextAreaField("Chair Notes")
+    submit = SubmitField("Save")
 
     def validate(self, extra_validators=None):
         """Cross-field validations for meeting timelines."""
@@ -33,25 +41,31 @@ class MeetingForm(FlaskForm):
 
         # check Stage 1 duration >= 7 days
         if self.opens_at_stage1.data and self.closes_at_stage1.data:
-            if self.closes_at_stage1.data - self.opens_at_stage1.data < timedelta(days=7):
+            if self.closes_at_stage1.data - self.opens_at_stage1.data < timedelta(
+                days=7
+            ):
                 self.closes_at_stage1.errors.append(
-                    'Stage 1 must remain open for at least 7 days.'
+                    "Stage 1 must remain open for at least 7 days."
                 )
                 is_valid = False
 
         # check Stage 2 duration >= 5 days
         if self.opens_at_stage2.data and self.closes_at_stage2.data:
-            if self.closes_at_stage2.data - self.opens_at_stage2.data < timedelta(days=5):
+            if self.closes_at_stage2.data - self.opens_at_stage2.data < timedelta(
+                days=5
+            ):
                 self.closes_at_stage2.errors.append(
-                    'Stage 2 must remain open for at least 5 days.'
+                    "Stage 2 must remain open for at least 5 days."
                 )
                 is_valid = False
 
         # check Stage 2 opens >= 1 day after Stage 1 closes
         if self.closes_at_stage1.data and self.opens_at_stage2.data:
-            if self.opens_at_stage2.data - self.closes_at_stage1.data < timedelta(days=1):
+            if self.opens_at_stage2.data - self.closes_at_stage1.data < timedelta(
+                days=1
+            ):
                 self.opens_at_stage2.errors.append(
-                    'Stage 2 must open at least 1 day after Stage 1 closes.'
+                    "Stage 2 must open at least 1 day after Stage 1 closes."
                 )
                 is_valid = False
 
@@ -61,37 +75,45 @@ class MeetingForm(FlaskForm):
 class MemberImportForm(FlaskForm):
     """Upload CSV file of members."""
 
-    csv_file = FileField('CSV File', validators=[FileRequired()])
-    submit = SubmitField('Upload')
+    csv_file = FileField("CSV File", validators=[FileRequired()])
+    submit = SubmitField("Upload")
 
 
 class AmendmentForm(FlaskForm):
-    text_md = TextAreaField('Amendment Text', validators=[DataRequired()])
-    proposer_id = SelectField('Proposer', coerce=int, validators=[DataRequired()])
-    seconder_id = SelectField('Seconder', coerce=int, validators=[DataRequired()])
-    submit = SubmitField('Save')
+    text_md = TextAreaField("Amendment Text", validators=[DataRequired()])
+    proposer_id = SelectField("Proposer", coerce=int, validators=[DataRequired()])
+    seconder_id = SelectField("Seconder", coerce=int, validators=[DataRequired()])
+    submit = SubmitField("Save")
 
 
 class ConflictForm(FlaskForm):
-    amendment_a_id = SelectField('Amendment A', coerce=int)
-    amendment_b_id = SelectField('Amendment B', coerce=int)
-    submit = SubmitField('Add Conflict')
+    amendment_a_id = SelectField("Amendment A", coerce=int)
+    amendment_b_id = SelectField("Amendment B", coerce=int)
+    submit = SubmitField("Add Conflict")
 
 
 class MotionForm(FlaskForm):
-    title = StringField('Title', validators=[DataRequired()])
-    text_md = TextAreaField('Motion Text', validators=[DataRequired()])
+    title = StringField("Title", validators=[DataRequired()])
+    text_md = TextAreaField("Motion Text", validators=[DataRequired()])
     category = SelectField(
-        'Category',
+        "Category",
         choices=[
-            ('motion', 'Motion'),
-            ('directors_report', "Director's Report"),
-            ('multiple_choice', 'Multiple Choice'),
+            ("motion", "Motion"),
+            ("directors_report", "Director's Report"),
+            ("multiple_choice", "Multiple Choice"),
         ],
     )
     threshold = SelectField(
-        'Voting Threshold',
-        choices=[('normal', 'Normal'), ('special', 'Special')],
+        "Voting Threshold",
+        choices=[("normal", "Normal"), ("special", "Special")],
     )
-    options = TextAreaField('Options (one per line)')
-    submit = SubmitField('Save')
+    options = TextAreaField("Options (one per line)")
+    allow_clerical = BooleanField(
+        "Allow clerical corrections",
+        default=True,
+    )
+    allow_move = BooleanField(
+        "Allow Articles/Bylaws placement",
+        default=True,
+    )
+    submit = SubmitField("Save")

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1,4 +1,13 @@
-from flask import Blueprint, render_template, redirect, url_for, request, flash, send_file, current_app
+from flask import (
+    Blueprint,
+    render_template,
+    redirect,
+    url_for,
+    request,
+    flash,
+    send_file,
+    current_app,
+)
 from flask_wtf import FlaskForm
 from wtforms import TextAreaField, SubmitField
 from wtforms.validators import DataRequired
@@ -40,9 +49,10 @@ from docx.shared import RGBColor, Inches, Pt
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import parse_xml
 from docx.oxml.ns import nsdecls
+from ..utils import config_or_setting
 import os
 
-bp = Blueprint('meetings', __name__, url_prefix='/meetings')
+bp = Blueprint("meetings", __name__, url_prefix="/meetings")
 
 
 def _shade_cell(cell, color_hex: str) -> None:
@@ -86,36 +96,37 @@ def _styled_doc(title: str, include_logo: bool) -> Document:
 
     return doc
 
-@bp.route('/')
+
+@bp.route("/")
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def list_meetings():
-    q = request.args.get('q', '').strip()
-    sort = request.args.get('sort', 'title')
-    direction = request.args.get('direction', 'asc')
+    q = request.args.get("q", "").strip()
+    sort = request.args.get("sort", "title")
+    direction = request.args.get("direction", "asc")
 
     query = Meeting.query
     if q:
         search = f"%{q}%"
         query = query.filter(Meeting.title.ilike(search))
 
-    if sort == 'type':
+    if sort == "type":
         order_attr = Meeting.type
-    elif sort == 'status':
+    elif sort == "status":
         order_attr = Meeting.status
     else:
         order_attr = Meeting.title
 
     query = query.order_by(
-        order_attr.asc() if direction == 'asc' else order_attr.desc()
+        order_attr.asc() if direction == "asc" else order_attr.desc()
     )
 
     meetings = query.all()
 
     template = (
-        'meetings/_meeting_rows.html'
-        if request.headers.get('HX-Request')
-        else 'meetings_list.html'
+        "meetings/_meeting_rows.html"
+        if request.headers.get("HX-Request")
+        else "meetings_list.html"
     )
     return render_template(
         template,
@@ -137,32 +148,32 @@ def _save_meeting(form: MeetingForm, meeting: Meeting | None = None) -> Meeting:
     return meeting
 
 
-@bp.route('/create', methods=['GET', 'POST'])
+@bp.route("/create", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def create_meeting():
     form = MeetingForm()
     if form.validate_on_submit():
         _save_meeting(form)
-        return redirect(url_for('meetings.list_meetings'))
-    return render_template('meetings/meetings_form.html', form=form)
+        return redirect(url_for("meetings.list_meetings"))
+    return render_template("meetings/meetings_form.html", form=form)
 
 
-@bp.route('/<int:meeting_id>/edit', methods=['GET', 'POST'])
+@bp.route("/<int:meeting_id>/edit", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def edit_meeting(meeting_id):
     meeting = Meeting.query.get_or_404(meeting_id)
     form = MeetingForm(obj=meeting)
     if form.validate_on_submit():
         _save_meeting(form, meeting)
-        return redirect(url_for('meetings.list_meetings'))
-    return render_template('meetings/meetings_form.html', form=form, meeting=meeting)
+        return redirect(url_for("meetings.list_meetings"))
+    return render_template("meetings/meetings_form.html", form=form, meeting=meeting)
 
 
-@bp.route('/<int:meeting_id>/import-members', methods=['GET', 'POST'])
+@bp.route("/<int:meeting_id>/import-members", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def import_members(meeting_id):
     """Upload a CSV of members and generate vote tokens."""
 
@@ -170,28 +181,32 @@ def import_members(meeting_id):
     form = MemberImportForm()
     if form.validate_on_submit():
         file_data = form.csv_file.data
-        csv_text = file_data.read().decode('utf-8-sig')
+        csv_text = file_data.read().decode("utf-8-sig")
         reader = csv.DictReader(io.StringIO(csv_text))
-        expected = ['member_id', 'name', 'email', 'vote_weight', 'proxy_for']
+        expected = ["member_id", "name", "email", "vote_weight", "proxy_for"]
         if reader.fieldnames != expected:
-            flash('CSV headers must be: ' + ', '.join(expected), 'error')
-            return render_template('meetings/import_members.html', form=form, meeting=meeting)
+            flash("CSV headers must be: " + ", ".join(expected), "error")
+            return render_template(
+                "meetings/import_members.html", form=form, meeting=meeting
+            )
 
         seen_emails: set[str] = set()
         tokens_to_send: list[tuple[Member, str]] = []
         for row in reader:
-            email = row['email'].strip().lower()
+            email = row["email"].strip().lower()
             if email in seen_emails:
-                flash(f'Duplicate email: {email}', 'error')
-                return render_template('meetings/import_members.html', form=form, meeting=meeting)
+                flash(f"Duplicate email: {email}", "error")
+                return render_template(
+                    "meetings/import_members.html", form=form, meeting=meeting
+                )
             seen_emails.add(email)
 
             member = Member(
                 meeting_id=meeting.id,
-                name=row['name'].strip(),
+                name=row["name"].strip(),
                 email=email,
-                proxy_for=(row.get('proxy_for') or '').strip() or None,
-                weight=int(row.get('vote_weight') or 1),
+                proxy_for=(row.get("proxy_for") or "").strip() or None,
+                weight=int(row.get("vote_weight") or 1),
             )
             db.session.add(member)
             db.session.flush()
@@ -205,56 +220,71 @@ def import_members(meeting_id):
         db.session.commit()
         for m, t in tokens_to_send:
             send_vote_invite(m, t, meeting)
-        flash('Members imported successfully', 'success')
-        return redirect(url_for('meetings.list_meetings'))
+        flash("Members imported successfully", "success")
+        return redirect(url_for("meetings.list_meetings"))
 
-    return render_template('meetings/import_members.html', form=form, meeting=meeting)
+    return render_template("meetings/import_members.html", form=form, meeting=meeting)
 
 
-@bp.route('/<int:meeting_id>/motions')
+@bp.route("/<int:meeting_id>/motions")
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def list_motions(meeting_id):
     meeting = Meeting.query.get_or_404(meeting_id)
-    motions = Motion.query.filter_by(meeting_id=meeting.id).order_by(Motion.ordering).all()
-    return render_template('meetings/motions_list.html', meeting=meeting, motions=motions)
+    motions = (
+        Motion.query.filter_by(meeting_id=meeting.id).order_by(Motion.ordering).all()
+    )
+    return render_template(
+        "meetings/motions_list.html", meeting=meeting, motions=motions
+    )
 
 
-@bp.route('/<int:meeting_id>/motions/create', methods=['GET', 'POST'])
+@bp.route("/<int:meeting_id>/motions/create", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def create_motion(meeting_id):
     meeting = Meeting.query.get_or_404(meeting_id)
     form = MotionForm()
+    clerical_text = config_or_setting("CLERICAL_TEXT", "")
+    move_text = config_or_setting("MOVE_TEXT", "")
     if form.validate_on_submit():
         ordering = Motion.query.filter_by(meeting_id=meeting.id).count() + 1
+        text_md = form.text_md.data
+        if form.allow_clerical.data and clerical_text:
+            text_md += f"\n\n{clerical_text}"
+        if form.allow_move.data and move_text:
+            text_md += f"\n\n{move_text}"
         motion = Motion(
             meeting_id=meeting.id,
             title=form.title.data,
-            text_md=form.text_md.data,
+            text_md=text_md,
             category=form.category.data,
             threshold=form.threshold.data,
             ordering=ordering,
         )
         db.session.add(motion)
         db.session.flush()
-        if form.category.data == 'multiple_choice' and form.options.data:
+        if form.category.data == "multiple_choice" and form.options.data:
             for line in form.options.data.splitlines():
                 text = line.strip()
                 if text:
                     db.session.add(MotionOption(motion_id=motion.id, text=text))
         db.session.commit()
-        return redirect(url_for('meetings.list_motions', meeting_id=meeting.id))
-    return render_template('meetings/motion_form.html', form=form, motion=None)
+        return redirect(url_for("meetings.list_motions", meeting_id=meeting.id))
+    return render_template(
+        "meetings/motion_form.html",
+        form=form,
+        motion=None,
+        clerical_text=clerical_text,
+        move_text=move_text,
+    )
 
 
-@bp.route('/motions/<int:motion_id>')
+@bp.route("/motions/<int:motion_id>")
 def view_motion(motion_id):
     motion = Motion.query.get_or_404(motion_id)
     amendments = (
-        Amendment.query.filter_by(motion_id=motion.id)
-        .order_by(Amendment.order)
-        .all()
+        Amendment.query.filter_by(motion_id=motion.id).order_by(Amendment.order).all()
     )
     conflicts = (
         AmendmentConflict.query.join(
@@ -264,23 +294,21 @@ def view_motion(motion_id):
         .all()
     )
     return render_template(
-        'meetings/view_motion.html',
+        "meetings/view_motion.html",
         motion=motion,
         amendments=amendments,
         conflicts=conflicts,
     )
 
 
-@bp.route('/motions/<int:motion_id>/amendments/add', methods=['GET', 'POST'])
+@bp.route("/motions/<int:motion_id>/amendments/add", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def add_amendment(motion_id):
     motion = Motion.query.get_or_404(motion_id)
     form = AmendmentForm()
     members = (
-        Member.query.filter_by(meeting_id=motion.meeting_id)
-        .order_by(Member.name)
-        .all()
+        Member.query.filter_by(meeting_id=motion.meeting_id).order_by(Member.name).all()
     )
     choices = [(m.id, m.name) for m in members]
     form.proposer_id.choices = choices
@@ -290,20 +318,26 @@ def add_amendment(motion_id):
         if meeting.opens_at_stage1:
             deadline = meeting.opens_at_stage1 - timedelta(days=21)
             if datetime.utcnow() > deadline:
-                flash('Amendment deadline has passed.', 'error')
-                return render_template('meetings/amendment_form.html', form=form, motion=motion)
+                flash("Amendment deadline has passed.", "error")
+                return render_template(
+                    "meetings/amendment_form.html", form=form, motion=motion
+                )
 
         if form.proposer_id.data == form.seconder_id.data:
-            flash('Proposer cannot second their own amendment.', 'error')
-            return render_template('meetings/amendment_form.html', form=form, motion=motion)
+            flash("Proposer cannot second their own amendment.", "error")
+            return render_template(
+                "meetings/amendment_form.html", form=form, motion=motion
+            )
 
         count = Amendment.query.filter_by(
             motion_id=motion.id,
             proposer_id=form.proposer_id.data,
         ).count()
         if count >= 3:
-            flash('A member may propose at most three amendments per motion.', 'error')
-            return render_template('meetings/amendment_form.html', form=form, motion=motion)
+            flash("A member may propose at most three amendments per motion.", "error")
+            return render_template(
+                "meetings/amendment_form.html", form=form, motion=motion
+            )
 
         order = Amendment.query.filter_by(motion_id=motion.id).count() + 1
         amendment = Amendment(
@@ -317,28 +351,26 @@ def add_amendment(motion_id):
         db.session.add(amendment)
         db.session.flush()
 
-        combine_param = request.args.get('combine')
+        combine_param = request.args.get("combine")
         if combine_param:
-            ids = [int(i) for i in combine_param.split(',') if i.isdigit()]
+            ids = [int(i) for i in combine_param.split(",") if i.isdigit()]
             for src_id in ids:
                 db.session.add(
                     AmendmentMerge(combined_id=amendment.id, source_id=src_id)
                 )
 
         db.session.commit()
-        return redirect(url_for('meetings.view_motion', motion_id=motion.id))
-    return render_template('meetings/amendment_form.html', form=form, motion=motion)
+        return redirect(url_for("meetings.view_motion", motion_id=motion.id))
+    return render_template("meetings/amendment_form.html", form=form, motion=motion)
 
 
-@bp.route('/motions/<int:motion_id>/conflicts', methods=['GET', 'POST'])
+@bp.route("/motions/<int:motion_id>/conflicts", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def manage_conflicts(motion_id: int):
     motion = Motion.query.get_or_404(motion_id)
     amendments = (
-        Amendment.query.filter_by(motion_id=motion.id)
-        .order_by(Amendment.order)
-        .all()
+        Amendment.query.filter_by(motion_id=motion.id).order_by(Amendment.order).all()
     )
     form = ConflictForm()
     choices = [(a.id, f"A{a.order}") for a in amendments]
@@ -372,9 +404,9 @@ def manage_conflicts(motion_id: int):
                     )
                 )
                 db.session.commit()
-                flash('Conflict recorded', 'success')
-            return redirect(url_for('meetings.manage_conflicts', motion_id=motion.id))
-        flash('Select two different amendments', 'error')
+                flash("Conflict recorded", "success")
+            return redirect(url_for("meetings.manage_conflicts", motion_id=motion.id))
+        flash("Select two different amendments", "error")
 
     conflicts = (
         AmendmentConflict.query.join(
@@ -384,7 +416,7 @@ def manage_conflicts(motion_id: int):
         .all()
     )
     return render_template(
-        'meetings/manage_conflicts.html',
+        "meetings/manage_conflicts.html",
         motion=motion,
         amendments=amendments,
         conflicts=conflicts,
@@ -392,31 +424,29 @@ def manage_conflicts(motion_id: int):
     )
 
 
-@bp.route('/conflicts/<int:conflict_id>/delete', methods=['POST'])
+@bp.route("/conflicts/<int:conflict_id>/delete", methods=["POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def delete_conflict(conflict_id: int):
     conflict = AmendmentConflict.query.get_or_404(conflict_id)
     motion_id = Amendment.query.get(conflict.amendment_a_id).motion_id
     db.session.delete(conflict)
     db.session.commit()
-    flash('Conflict removed', 'success')
-    return redirect(url_for('meetings.manage_conflicts', motion_id=motion_id))
+    flash("Conflict removed", "success")
+    return redirect(url_for("meetings.manage_conflicts", motion_id=motion_id))
 
 
 def _amendment_results(meeting: Meeting) -> list[tuple[Amendment, dict]]:
     """Return vote counts for each amendment."""
     amendments = (
-        Amendment.query.filter_by(meeting_id=meeting.id)
-        .order_by(Amendment.order)
-        .all()
+        Amendment.query.filter_by(meeting_id=meeting.id).order_by(Amendment.order).all()
     )
     results = []
     for amend in amendments:
         counts = {
-            'for': 0,
-            'against': 0,
-            'abstain': 0,
+            "for": 0,
+            "against": 0,
+            "abstain": 0,
         }
         rows = (
             db.session.query(Vote.choice, func.count(Vote.id))
@@ -433,9 +463,7 @@ def _amendment_results(meeting: Meeting) -> list[tuple[Amendment, dict]]:
 def _motion_results(meeting: Meeting) -> list[tuple[Motion, dict]]:
     """Return vote counts for each motion."""
     motions = (
-        Motion.query.filter_by(meeting_id=meeting.id)
-        .order_by(Motion.ordering)
-        .all()
+        Motion.query.filter_by(meeting_id=meeting.id).order_by(Motion.ordering).all()
     )
     results: list[tuple[Motion, dict]] = []
     for motion in motions:
@@ -459,29 +487,29 @@ def _motion_results(meeting: Meeting) -> list[tuple[Motion, dict]]:
 def _merge_form(motions: list[Motion]) -> FlaskForm:
     fields = {}
     for motion in motions:
-        fields[f'motion_{motion.id}'] = TextAreaField(
-            'Final Motion Text', validators=[DataRequired()]
+        fields[f"motion_{motion.id}"] = TextAreaField(
+            "Final Motion Text", validators=[DataRequired()]
         )
-    fields['submit'] = SubmitField('Save and Send Stage 2 Links')
-    return type('MergeForm', (FlaskForm,), fields)()
+    fields["submit"] = SubmitField("Save and Send Stage 2 Links")
+    return type("MergeForm", (FlaskForm,), fields)()
 
 
-@bp.route('/<int:meeting_id>/close-stage1', methods=['POST'])
+@bp.route("/<int:meeting_id>/close-stage1", methods=["POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def close_stage1(meeting_id: int):
     """Close Stage 1 and handle run-offs or open Stage 2."""
     meeting = Meeting.query.get_or_404(meeting_id)
 
     # check whether Stage 1 reached quorum
     if meeting.stage1_votes_count() < meeting.quorum:
-        meeting.status = 'Quorum not met'
+        meeting.status = "Quorum not met"
         db.session.commit()
         flash(
-            'Stage 1 quorum not met – vote void under Articles 112(d)–(f).',
-            'error',
+            "Stage 1 quorum not met – vote void under Articles 112(d)–(f).",
+            "error",
         )
-        return redirect(url_for('meetings.results_summary', meeting_id=meeting.id))
+        return redirect(url_for("meetings.results_summary", meeting_id=meeting.id))
 
     # finalize Stage 1 results and create run-off ballots if required
     runoffs, tokens_to_send = runoff.close_stage1(meeting)
@@ -489,28 +517,31 @@ def close_stage1(meeting_id: int):
     if runoffs:
         for member, token in tokens_to_send:
             send_runoff_invite(member, token, meeting)
-        flash('Run-off ballot issued; Stage 2 start delayed', 'success')
+        flash("Run-off ballot issued; Stage 2 start delayed", "success")
     else:
-        meeting.status = 'Pending Stage 2'
+        meeting.status = "Pending Stage 2"
         db.session.commit()
-        flash('Stage 1 closed. Prepare final motion text before opening Stage 2', 'success')
-    return redirect(url_for('meetings.results_summary', meeting_id=meeting.id))
+        flash(
+            "Stage 1 closed. Prepare final motion text before opening Stage 2",
+            "success",
+        )
+    return redirect(url_for("meetings.results_summary", meeting_id=meeting.id))
 
 
-@bp.route('/<int:meeting_id>/results')
+@bp.route("/<int:meeting_id>/results")
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def results_summary(meeting_id: int):
     meeting = Meeting.query.get_or_404(meeting_id)
     results = _amendment_results(meeting)
     return render_template(
-        'meetings/results_summary.html', meeting=meeting, results=results
+        "meetings/results_summary.html", meeting=meeting, results=results
     )
 
 
-@bp.route('/<int:meeting_id>/results.docx')
+@bp.route("/<int:meeting_id>/results.docx")
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def results_docx(meeting_id: int):
     meeting = Meeting.query.get_or_404(meeting_id)
     results = _amendment_results(meeting)
@@ -542,28 +573,26 @@ def results_docx(meeting_id: int):
     return send_file(
         buf,
         mimetype=(
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         ),
         as_attachment=True,
-        download_name='results.docx',
+        download_name="results.docx",
     )
 
 
-@bp.route('/<int:meeting_id>/prepare-stage2', methods=['GET', 'POST'])
+@bp.route("/<int:meeting_id>/prepare-stage2", methods=["GET", "POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def prepare_stage2(meeting_id: int):
     """Allow a human to merge amendments into final motion text."""
     meeting = Meeting.query.get_or_404(meeting_id)
     motions = (
-        Motion.query.filter_by(meeting_id=meeting.id)
-        .order_by(Motion.ordering)
-        .all()
+        Motion.query.filter_by(meeting_id=meeting.id).order_by(Motion.ordering).all()
     )
     form = _merge_form(motions)
     if form.validate_on_submit():
         for motion in motions:
-            data = form[f'motion_{motion.id}'].data
+            data = form[f"motion_{motion.id}"].data
             motion.final_text_md = data
         members = Member.query.filter_by(meeting_id=meeting.id).all()
         tokens_to_send: list[tuple[Member, str]] = []
@@ -574,19 +603,19 @@ def prepare_stage2(meeting_id: int):
                 salt=current_app.config["TOKEN_SALT"],
             )
             tokens_to_send.append((member, plain))
-        meeting.status = 'Stage 2'
+        meeting.status = "Stage 2"
         db.session.commit()
         for m, t in tokens_to_send:
             send_stage2_invite(m, t, meeting)
-        flash('Stage 2 voting links sent', 'success')
-        return redirect(url_for('meetings.results_summary', meeting_id=meeting.id))
+        flash("Stage 2 voting links sent", "success")
+        return redirect(url_for("meetings.results_summary", meeting_id=meeting.id))
 
     for motion in motions:
-        field = form[f'motion_{motion.id}']
+        field = form[f"motion_{motion.id}"]
         field.data = motion.final_text_md or compile_motion_text(motion)
 
     return render_template(
-        'meetings/prepare_stage2.html',
+        "meetings/prepare_stage2.html",
         meeting=meeting,
         motions=motions,
         form=form,
@@ -594,9 +623,9 @@ def prepare_stage2(meeting_id: int):
     )
 
 
-@bp.route('/<int:meeting_id>/results-stage2.docx')
+@bp.route("/<int:meeting_id>/results-stage2.docx")
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def results_stage2_docx(meeting_id: int):
     """Download DOCX summarising carried amendments and final motion results."""
     meeting = Meeting.query.get_or_404(meeting_id)
@@ -646,31 +675,31 @@ def results_stage2_docx(meeting_id: int):
     buf.seek(0)
     return send_file(
         buf,
-        mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         as_attachment=True,
-        download_name='final_results.docx',
+        download_name="final_results.docx",
     )
 
 
-@bp.route('/<int:meeting_id>/close-stage2', methods=['POST'])
+@bp.route("/<int:meeting_id>/close-stage2", methods=["POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def close_stage2(meeting_id: int):
     """Finalize Stage 2 results and record motion outcomes."""
     meeting = Meeting.query.get_or_404(meeting_id)
     motion_results = _motion_results(meeting)
 
     for motion, counts in motion_results:
-        total = counts['for'] + counts['against'] + counts['abstain']
+        total = counts["for"] + counts["against"] + counts["abstain"]
         if total == 0:
-            motion.status = 'failed'
+            motion.status = "failed"
             continue
-        ratio = counts['for'] / total
-        if motion.threshold == 'special':
+        ratio = counts["for"] / total
+        if motion.threshold == "special":
             carried = ratio >= 0.75
         else:
-            carried = counts['for'] > counts['against']
-        motion.status = 'carried' if carried else 'failed'
+            carried = counts["for"] > counts["against"]
+        motion.status = "carried" if carried else "failed"
     db.session.commit()
-    flash('Stage 2 closed and motions tallied', 'success')
-    return redirect(url_for('meetings.results_summary', meeting_id=meeting.id))
+    flash("Stage 2 closed and motions tallied", "success")
+    return redirect(url_for("meetings.results_summary", meeting_id=meeting.id))

--- a/app/static/js/modal.js
+++ b/app/static/js/modal.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-modal-target]').forEach(link => {
+    const id = link.getAttribute('data-modal-target');
+    const modal = document.getElementById(id);
+    if (!modal) return;
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      modal.showModal();
+    });
+    modal.querySelectorAll('[data-close-modal]').forEach(btn => {
+      btn.addEventListener('click', () => modal.close());
+    });
+  });
+});

--- a/app/templates/admin/settings_form.html
+++ b/app/templates/admin/settings_form.html
@@ -72,6 +72,26 @@
         </form>
       </div>
     </div>
+    <div class="mb-4">
+      {{ form.clerical_text.label(class='block mb-1') }}
+      <div class="flex gap-2">
+        {{ form.clerical_text(class='bp-input w-full h-32') }}
+        <form action="{{ url_for('admin.reset_setting', key='clerical_text') }}" method="post">
+          {{ csrf_token() }}
+          <button type="submit" class="text-sm underline">Reset default</button>
+        </form>
+      </div>
+    </div>
+    <div class="mb-4">
+      {{ form.move_text.label(class='block mb-1') }}
+      <div class="flex gap-2">
+        {{ form.move_text(class='bp-input w-full h-32') }}
+        <form action="{{ url_for('admin.reset_setting', key='move_text') }}" method="post">
+          {{ csrf_token() }}
+          <button type="submit" class="text-sm underline">Reset default</button>
+        </form>
+      </div>
+    </div>
     {{ form.submit(class='bp-btn-primary') }}
   </form>
 </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -71,5 +71,6 @@
       , a web and app development agency, to support British Powerlifting.
     </footer>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="{{ url_for('static', filename='js/modal.js') }}"></script>
   </body>
 </html>

--- a/app/templates/meetings/motion_form.html
+++ b/app/templates/meetings/motion_form.html
@@ -23,6 +23,25 @@
     {{ form.options.label(class_='block font-semibold') }}
     {{ form.options(class_='border p-3 rounded w-full') }}
   </div>
+  <div class="flex items-center space-x-2">
+    {{ form.allow_clerical() }}
+    {{ form.allow_clerical.label(class_='font-semibold') }}
+    <a href="#" data-modal-target="clerical-modal" class="text-sm underline">View text</a>
+  </div>
+  <div class="flex items-center space-x-2">
+    {{ form.allow_move() }}
+    {{ form.allow_move.label(class_='font-semibold') }}
+    <a href="#" data-modal-target="move-modal" class="text-sm underline">View text</a>
+  </div>
   <button type="submit" class="bp-btn-primary">Save</button>
 </form>
+
+<dialog id="clerical-modal" class="bp-card w-full max-w-md">
+  <p class="mb-4">{{ clerical_text|markdown_to_html|safe }}</p>
+  <button class="bp-btn-secondary" data-close-modal>Close</button>
+</dialog>
+<dialog id="move-modal" class="bp-card w-full max-w-md">
+  <p class="mb-4">{{ move_text|markdown_to_html|safe }}</p>
+  <button class="bp-btn-secondary" data-close-modal>Close</button>
+</dialog>
 {% endblock %}

--- a/config.py
+++ b/config.py
@@ -3,26 +3,37 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
 class Config:
-    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///:memory:')
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///:memory:")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SECRET_KEY = os.getenv('SECRET_KEY', 'change-me')
-    MAIL_SERVER = os.getenv('MAIL_SERVER')
-    MAIL_PORT = int(os.getenv('MAIL_PORT', 25))
-    MAIL_USERNAME = os.getenv('MAIL_USERNAME')
-    MAIL_PASSWORD = os.getenv('MAIL_PASSWORD')
-    MAIL_USE_TLS = os.getenv('MAIL_USE_TLS', 'true').lower() in ['1', 'true']
-    MAIL_DEFAULT_SENDER = os.getenv('MAIL_DEFAULT_SENDER')
-    VOTE_SALT = os.getenv('VOTE_SALT', 'static-salt')
-    TOKEN_SALT = os.getenv('TOKEN_SALT', 'token-salt')
-    RUNOFF_EXTENSION_MINUTES = int(os.getenv('RUNOFF_EXTENSION_MINUTES', '2880'))
-    REMINDER_HOURS_BEFORE_CLOSE = int(os.getenv('REMINDER_HOURS_BEFORE_CLOSE', '6'))
-    REMINDER_COOLDOWN_HOURS = int(os.getenv('REMINDER_COOLDOWN_HOURS', '24'))
-    REMINDER_TEMPLATE = os.getenv('REMINDER_TEMPLATE', 'email/reminder')
-    TIE_BREAK_DECISIONS = os.getenv('TIE_BREAK_DECISIONS', '{}')
+    SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
+    MAIL_SERVER = os.getenv("MAIL_SERVER")
+    MAIL_PORT = int(os.getenv("MAIL_PORT", 25))
+    MAIL_USERNAME = os.getenv("MAIL_USERNAME")
+    MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
+    MAIL_USE_TLS = os.getenv("MAIL_USE_TLS", "true").lower() in ["1", "true"]
+    MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER")
+    VOTE_SALT = os.getenv("VOTE_SALT", "static-salt")
+    TOKEN_SALT = os.getenv("TOKEN_SALT", "token-salt")
+    RUNOFF_EXTENSION_MINUTES = int(os.getenv("RUNOFF_EXTENSION_MINUTES", "2880"))
+    REMINDER_HOURS_BEFORE_CLOSE = int(os.getenv("REMINDER_HOURS_BEFORE_CLOSE", "6"))
+    REMINDER_COOLDOWN_HOURS = int(os.getenv("REMINDER_COOLDOWN_HOURS", "24"))
+    REMINDER_TEMPLATE = os.getenv("REMINDER_TEMPLATE", "email/reminder")
+    TIE_BREAK_DECISIONS = os.getenv("TIE_BREAK_DECISIONS", "{}")
+    CLERICAL_TEXT = os.getenv(
+        "CLERICAL_TEXT",
+        "The Board may correct typographical or numbering errors with no change to meaning.",
+    )
+    MOVE_TEXT = os.getenv(
+        "MOVE_TEXT",
+        "The Board may place this change in the Articles or Bylaws as most appropriate.",
+    )
+
 
 class DevelopmentConfig(Config):
     DEBUG = True
+
 
 class ProductionConfig(Config):
     DEBUG = False

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -347,6 +347,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-18 – Added site footer credit linking to Scorchsoft.
 * 2025-06-15 – MeetingForm enforces minimum stage durations (7d/5d/1d gaps)
 * 2025-06-23 – Added amendment conflict management UI with database links for combined amendments
+* 2025-06-23 – Added motion form options for clerical fixes and Articles/Bylaws placement
 
 
 ---

--- a/tests/test_form_templates.py
+++ b/tests/test_form_templates.py
@@ -1,18 +1,19 @@
 import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from flask import render_template
 from app import create_app
 from app.extensions import db
 from app.models import Role
 from app.admin.forms import UserCreateForm
-from app.meetings.forms import MeetingForm
+from app.meetings.forms import MeetingForm, MotionForm
 
 
 def _setup_app():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['WTF_CSRF_ENABLED'] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["WTF_CSRF_ENABLED"] = False
     return app
 
 
@@ -20,13 +21,13 @@ def test_admin_user_form_has_labels():
     app = _setup_app()
     with app.app_context():
         db.create_all()
-        role = Role(name='Admin')
+        role = Role(name="Admin")
         db.session.add(role)
         db.session.commit()
-        with app.test_request_context('/admin/users/create'):
+        with app.test_request_context("/admin/users/create"):
             form = UserCreateForm()
             form.role_id.choices = [(role.id, role.name)]
-            html = render_template('admin/user_form.html', form=form, user=None)
+            html = render_template("admin/user_form.html", form=form, user=None)
             assert f'for="{form.email.id}"' in html
             assert f'for="{form.password.id}"' in html
             assert f'for="{form.role_id.id}"' in html
@@ -37,11 +38,30 @@ def test_meeting_form_has_labels():
     app = _setup_app()
     with app.app_context():
         db.create_all()
-        with app.test_request_context('/meetings/create'):
+        with app.test_request_context("/meetings/create"):
             form = MeetingForm()
-            html = render_template('meetings/meetings_form.html', form=form, meeting=None)
+            html = render_template(
+                "meetings/meetings_form.html", form=form, meeting=None
+            )
             assert f'for="{form.title.id}"' in html
             assert f'for="{form.type.id}"' in html
             assert f'for="{form.opens_at_stage1.id}"' in html
             assert f'for="{form.revoting_allowed.id}"' in html
 
+
+def test_motion_form_has_labels():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        with app.test_request_context("/meetings/1/motions/create"):
+            form = MotionForm()
+            html = render_template(
+                "meetings/motion_form.html",
+                form=form,
+                motion=None,
+                clerical_text="",
+                move_text="",
+            )
+            assert f'for="{form.title.id}"' in html
+            assert f'for="{form.allow_clerical.id}"' in html
+            assert f'for="{form.allow_move.id}"' in html


### PR DESCRIPTION
## Summary
- allow motions to optionally include clerical and Articles/Bylaws text snippets
- store snippet wording in application settings
- show snippet wording via modal on the motion form
- expose new settings in the admin UI
- include modal.js and load globally
- document change

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684fc738d6dc832bab37978753a4db7d