### PR TITLE
Indicate carried amendments

### DIFF
--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -6,9 +6,14 @@
     <tr><th>Amendment</th><th>For</th><th>Against</th><th>Abstain</th></tr>
   </thead>
   <tbody>
-  {% for amend, counts in results %}
+  {% for amend, counts, carried in results %}
     <tr class="border-t">
-      <td class="p-2">{{ amend.text_md|markdown_to_html|safe }}</td>
+      <td class="p-2">
+        {{ amend.text_md|markdown_to_html|safe }}
+        {% if carried %}
+        <span class="text-bp-red font-bold ml-1" title="Carried">&#10003;</span>
+        {% endif %}
+      </td>
       <td class="p-2 text-center">{{ counts.for }}</td>
       <td class="p-2 text-center">{{ counts.against }}</td>
       <td class="p-2 text-center">{{ counts.abstain }}</td>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -347,6 +347,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-18 – Added site footer credit linking to Scorchsoft.
 * 2025-06-15 – MeetingForm enforces minimum stage durations (7d/5d/1d gaps)
 * 2025-06-23 – Added amendment conflict management UI with database links for combined amendments
+* 2025-06-24 – Stage 1 results now show a bp-red tick beside carried amendments
 
 
 ---


### PR DESCRIPTION
## Summary
- show a bp-red tick in Stage 1 results when an amendment carries
- expose carried flag from `_amendment_results`
- adapt DOCX exports to new results format
- test that the tick renders on the results table
- document the behaviour in the changelog

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fbe7a81d0832ba7ec4818e2673999