### PR TITLE
Add RO tallies JSON endpoint

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -347,6 +347,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-18 – Added site footer credit linking to Scorchsoft.
 * 2025-06-15 – MeetingForm enforces minimum stage durations (7d/5d/1d gaps)
 * 2025-06-23 – Added amendment conflict management UI with database links for combined amendments
+* 2025-06-24 – Added tallies JSON endpoint for Returning Officers
 
 
 ---


### PR DESCRIPTION
## Summary
- expose tallies JSON route protected by `manage_meetings`
- test JSON tallies output
- document route in PRD changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fbe04b530832b9d1e569867483ea0