### PR TITLE
Add amendment editing and deletion routes

### DIFF
--- a/app/templates/meetings/amendment_form.html
+++ b/app/templates/meetings/amendment_form.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">Add Amendment</h2>
+<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if amendment else 'Add' }} Amendment</h2>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/meetings/view_motion.html
+++ b/app/templates/meetings/view_motion.html
@@ -19,6 +19,14 @@
     {% if conf_list %}
     <p class="text-sm text-bp-grey-600">Conflicts with: {{ ', '.join(conf_list) }}</p>
     {% endif %}
+    {% if current_user.has_permission('manage_meetings') %}
+    <div class="mt-2 flex gap-2">
+      <a href="{{ url_for('meetings.edit_amendment', amendment_id=amend.id) }}" class="bp-btn-secondary">Edit</a>
+      <form method="post" action="{{ url_for('meetings.delete_amendment', amendment_id=amend.id) }}">
+        <button class="bp-btn-secondary">Delete</button>
+      </form>
+    </div>
+    {% endif %}
   </div>
 {% else %}
   <p>No amendments submitted.</p>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -347,6 +347,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-18 – Added site footer credit linking to Scorchsoft.
 * 2025-06-15 – MeetingForm enforces minimum stage durations (7d/5d/1d gaps)
 * 2025-06-23 – Added amendment conflict management UI with database links for combined amendments
+* 2025-06-24 – Added amendment edit and delete routes with permission checks
 
 
 ---


### PR DESCRIPTION
## Summary
- support editing and deleting amendments
- show Edit/Delete controls on motion view
- allow AmendmentForm to display Edit heading
- log new feature in the PRD
- test amendment edit and delete functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fbde54384832b9d2167c49ef5dfd8