### PR TITLE
Add motion edit/delete functionality

### DIFF
--- a/app/templates/meetings/motion_form.html
+++ b/app/templates/meetings/motion_form.html
@@ -5,23 +5,28 @@
   {{ form.hidden_tag() }}
   <div>
     {{ form.title.label(class_='block font-semibold') }}
-    {{ form.title(class_='border p-3 rounded w-full') }}
+    {{ form.title(class_='border p-3 rounded w-full', **{'aria-describedby': form.title.id + '-error'}) }}
+    <p id="{{ form.title.id }}-error" class="bp-error-text">{{ form.title.errors[0] if form.title.errors else '' }}</p>
   </div>
   <div>
     {{ form.text_md.label(class_='block font-semibold') }}
-    {{ form.text_md(class_='border p-3 rounded w-full') }}
+    {{ form.text_md(class_='border p-3 rounded w-full', **{'aria-describedby': form.text_md.id + '-error'}) }}
+    <p id="{{ form.text_md.id }}-error" class="bp-error-text">{{ form.text_md.errors[0] if form.text_md.errors else '' }}</p>
   </div>
   <div>
     {{ form.category.label(class_='block font-semibold') }}
-    {{ form.category(class_='border p-3 rounded w-full') }}
+    {{ form.category(class_='border p-3 rounded w-full', **{'aria-describedby': form.category.id + '-error'}) }}
+    <p id="{{ form.category.id }}-error" class="bp-error-text">{{ form.category.errors[0] if form.category.errors else '' }}</p>
   </div>
   <div>
     {{ form.threshold.label(class_='block font-semibold') }}
-    {{ form.threshold(class_='border p-3 rounded w-full') }}
+    {{ form.threshold(class_='border p-3 rounded w-full', **{'aria-describedby': form.threshold.id + '-error'}) }}
+    <p id="{{ form.threshold.id }}-error" class="bp-error-text">{{ form.threshold.errors[0] if form.threshold.errors else '' }}</p>
   </div>
   <div>
     {{ form.options.label(class_='block font-semibold') }}
-    {{ form.options(class_='border p-3 rounded w-full') }}
+    {{ form.options(class_='border p-3 rounded w-full', **{'aria-describedby': form.options.id + '-error'}) }}
+    <p id="{{ form.options.id }}-error" class="bp-error-text">{{ form.options.errors[0] if form.options.errors else '' }}</p>
   </div>
   <button type="submit" class="bp-btn-primary">Save</button>
 </form>

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -6,7 +6,13 @@
     <div class="bp-card">
       <h3 class="font-semibold mb-1">{{ m.title }}</h3>
       <p class="mb-2">Category: {{ m.category }}</p>
-      <a href="{{ url_for('meetings.view_motion', motion_id=m.id) }}" class="bp-btn-secondary">View</a>
+      <div class="flex space-x-2">
+        <a href="{{ url_for('meetings.view_motion', motion_id=m.id) }}" class="bp-btn-secondary">View</a>
+        <a href="{{ url_for('meetings.edit_motion', motion_id=m.id) }}" class="bp-btn-secondary">Edit</a>
+        <form method="post" action="{{ url_for('meetings.delete_motion', motion_id=m.id) }}">
+          <button class="bp-btn-secondary">Delete</button>
+        </form>
+      </div>
     </div>
   {% else %}
     <p>No motions yet.</p>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -347,6 +347,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-18 – Added site footer credit linking to Scorchsoft.
 * 2025-06-15 – MeetingForm enforces minimum stage durations (7d/5d/1d gaps)
 * 2025-06-23 – Added amendment conflict management UI with database links for combined amendments
+* 2025-06-24 – Added motion edit/delete routes with template updates and tests.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement `_save_motion` helper
- add motion edit and delete routes with permission checks
- enhance motion form template for error display
- link edit/delete actions from motions list
- test edit and delete motion flows
- document new routes in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684fbde26128832b8fd9db1e9e9be9ca