### PR TITLE
Add JSON tallies export for RO

### DIFF
--- a/app/ro/routes.py
+++ b/app/ro/routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from io import StringIO
 import csv
-from flask import Blueprint, render_template, redirect, url_for, Response
+from flask import Blueprint, render_template, redirect, url_for, Response, jsonify
 from flask_login import login_required
 
 from ..extensions import db
@@ -91,6 +91,38 @@ def download_tallies(meeting_id: int):
         f'attachment; filename=tallies_meeting_{meeting.id}.csv'
     )
     return response
+
+
+@bp.route('/<int:meeting_id>/tallies.json')
+@login_required
+@permission_required('manage_meetings')
+def download_tallies_json(meeting_id: int):
+    """Return tallies for amendments and motions as JSON."""
+    meeting = Meeting.query.get_or_404(meeting_id)
+    rows: list[dict[str, int | str]] = []
+    for amend in Amendment.query.filter_by(meeting_id=meeting.id).all():
+        rows.append(
+            {
+                'type': 'amendment',
+                'id': amend.id,
+                'text': amend.text_md[:40],
+                'for': Vote.query.filter_by(amendment_id=amend.id, choice='for').count(),
+                'against': Vote.query.filter_by(amendment_id=amend.id, choice='against').count(),
+                'abstain': Vote.query.filter_by(amendment_id=amend.id, choice='abstain').count(),
+            }
+        )
+    for motion in Motion.query.filter_by(meeting_id=meeting.id).all():
+        rows.append(
+            {
+                'type': 'motion',
+                'id': motion.id,
+                'text': motion.title,
+                'for': Vote.query.filter_by(motion_id=motion.id, choice='for').count(),
+                'against': Vote.query.filter_by(motion_id=motion.id, choice='against').count(),
+                'abstain': Vote.query.filter_by(motion_id=motion.id, choice='abstain').count(),
+            }
+        )
+    return jsonify({'meeting_id': meeting.id, 'tallies': rows})
 
 
 @bp.route('/<int:meeting_id>/stage2_tallies.csv')

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -353,6 +353,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-16 – Added coordinator resend token route and email flow
 * 2025-06-16 – Added Stage 2 motion tallies CSV download for Returning Officers
 * 2025-06-16 – Added motion form options for clerical fixes and Articles/Bylaws placement
+* 2025-06-17 – Added tallies JSON endpoint for Returning Officers
 
 
 ---

--- a/tests/test_ro_dashboard.py
+++ b/tests/test_ro_dashboard.py
@@ -70,6 +70,40 @@ def test_download_tallies_csv():
                 assert b'amendment' in resp.data
 
 
+def test_download_tallies_json():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(
+            meeting_id=meeting.id,
+            title='M1',
+            text_md='T',
+            category='motion',
+            threshold='normal',
+            ordering=1,
+        )
+        db.session.add(motion)
+        amend = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A', order=1)
+        db.session.add(amend)
+        member = Member(meeting_id=meeting.id, name='Alice')
+        db.session.add(member)
+        db.session.flush()
+        Vote.record(member_id=member.id, amendment_id=amend.id, choice='for', salt='s')
+        Vote.record(member_id=member.id, motion_id=motion.id, choice='against', salt='s')
+        user = _make_user()
+        with app.test_request_context(f'/ro/{meeting.id}/tallies.json'):
+            with patch('flask_login.utils._get_user', return_value=user):
+                resp = ro.download_tallies_json(meeting.id)
+                assert resp.status_code == 200
+                data = resp.get_json()
+                assert data['meeting_id'] == meeting.id
+                assert any(r['type'] == 'amendment' for r in data['tallies'])
+
+
 def test_download_stage2_tallies_csv():
     app = create_app()
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'


### PR DESCRIPTION
## Summary
- return vote tallies as JSON from RO dashboard
- test JSON tallies endpoint
- note endpoint in PRD changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fee8da92c832bb74592c2f300fc70