### PR TITLE
Add board seconding option for amendments

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -10,7 +10,7 @@ from wtforms import (
     TextAreaField,
     SubmitField,
 )
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, Optional
 
 
 class MeetingForm(FlaskForm):
@@ -43,9 +43,7 @@ class MeetingForm(FlaskForm):
 
         # check Stage 1 opens in the future
         if self.opens_at_stage1.data and self.opens_at_stage1.data <= now:
-            self.opens_at_stage1.errors.append(
-                'Stage 1 must open in the future.'
-            )
+            self.opens_at_stage1.errors.append("Stage 1 must open in the future.")
             is_valid = False
 
         # check Stage 2 opens after Stage 1 opens
@@ -54,9 +52,7 @@ class MeetingForm(FlaskForm):
             and self.opens_at_stage2.data
             and self.opens_at_stage2.data <= self.opens_at_stage1.data
         ):
-            self.opens_at_stage2.errors.append(
-                'Stage 2 must open after Stage 1 opens.'
-            )
+            self.opens_at_stage2.errors.append("Stage 2 must open after Stage 1 opens.")
             is_valid = False
 
         # check Stage 1 duration >= 7 days
@@ -102,7 +98,8 @@ class MemberImportForm(FlaskForm):
 class AmendmentForm(FlaskForm):
     text_md = TextAreaField("Amendment Text", validators=[DataRequired()])
     proposer_id = SelectField("Proposer", coerce=int, validators=[DataRequired()])
-    seconder_id = SelectField("Seconder", coerce=int, validators=[DataRequired()])
+    seconder_id = SelectField("Seconder", coerce=int, validators=[Optional()])
+    board_seconded = BooleanField("Seconded by Board/Chair")
     submit = SubmitField("Save")
 
 

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -314,7 +314,7 @@ def add_amendment(motion_id):
     )
     choices = [(m.id, m.name) for m in members]
     form.proposer_id.choices = choices
-    form.seconder_id.choices = choices
+    form.seconder_id.choices = [(0, "")] + choices
     if form.validate_on_submit():
         meeting = Meeting.query.get(motion.meeting_id)
         if meeting.opens_at_stage1:
@@ -325,7 +325,12 @@ def add_amendment(motion_id):
                     "meetings/amendment_form.html", form=form, motion=motion
                 )
 
-        if form.proposer_id.data == form.seconder_id.data:
+        if not form.seconder_id.data and not form.board_seconded.data:
+            flash("Select a seconder or confirm board approval.", "error")
+            return render_template(
+                "meetings/amendment_form.html", form=form, motion=motion
+            )
+        if form.seconder_id.data and form.proposer_id.data == form.seconder_id.data:
             flash("Proposer cannot second their own amendment.", "error")
             return render_template(
                 "meetings/amendment_form.html", form=form, motion=motion
@@ -348,7 +353,12 @@ def add_amendment(motion_id):
             text_md=form.text_md.data,
             order=order,
             proposer_id=form.proposer_id.data,
-            seconder_id=form.seconder_id.data,
+            seconder_id=(
+                (form.seconder_id.data or None)
+                if not form.board_seconded.data
+                else None
+            ),
+            board_seconded=form.board_seconded.data,
         )
         db.session.add(amendment)
         db.session.flush()
@@ -376,12 +386,10 @@ def edit_amendment(amendment_id: int):
     meeting = Meeting.query.get(amendment.meeting_id)
 
     form = AmendmentForm(obj=amendment)
-    members = (
-        Member.query.filter_by(meeting_id=meeting.id).order_by(Member.name).all()
-    )
+    members = Member.query.filter_by(meeting_id=meeting.id).order_by(Member.name).all()
     choices = [(m.id, m.name) for m in members]
     form.proposer_id.choices = choices
-    form.seconder_id.choices = choices
+    form.seconder_id.choices = [(0, "")] + choices
 
     if form.validate_on_submit():
         if meeting.opens_at_stage1:
@@ -395,7 +403,15 @@ def edit_amendment(amendment_id: int):
                     amendment=amendment,
                 )
 
-        if form.proposer_id.data == form.seconder_id.data:
+        if not form.seconder_id.data and not form.board_seconded.data:
+            flash("Select a seconder or confirm board approval.", "error")
+            return render_template(
+                "meetings/amendment_form.html",
+                form=form,
+                motion=motion,
+                amendment=amendment,
+            )
+        if form.seconder_id.data and form.proposer_id.data == form.seconder_id.data:
             flash("Proposer cannot second their own amendment.", "error")
             return render_template(
                 "meetings/amendment_form.html",
@@ -406,7 +422,10 @@ def edit_amendment(amendment_id: int):
 
         amendment.text_md = form.text_md.data
         amendment.proposer_id = form.proposer_id.data
-        amendment.seconder_id = form.seconder_id.data
+        amendment.seconder_id = (
+            form.seconder_id.data or None if not form.board_seconded.data else None
+        )
+        amendment.board_seconded = form.board_seconded.data
         db.session.commit()
         flash("Amendment updated", "success")
         return redirect(url_for("meetings.view_motion", motion_id=motion.id))
@@ -757,37 +776,37 @@ def results_stage2_docx(meeting_id: int):
     )
 
 
-@bp.route('/<int:meeting_id>/stage1.ics')
+@bp.route("/<int:meeting_id>/stage1.ics")
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def stage1_ics(meeting_id: int):
     """Download Stage 1 calendar file."""
     meeting = Meeting.query.get_or_404(meeting_id)
     ics = generate_stage_ics(meeting, 1)
     return send_file(
         io.BytesIO(ics),
-        mimetype='text/calendar',
+        mimetype="text/calendar",
         as_attachment=True,
-        download_name='stage1.ics',
+        download_name="stage1.ics",
     )
 
 
-@bp.route('/<int:meeting_id>/stage2.ics')
+@bp.route("/<int:meeting_id>/stage2.ics")
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def stage2_ics(meeting_id: int):
     """Download Stage 2 calendar file."""
     meeting = Meeting.query.get_or_404(meeting_id)
     ics = generate_stage_ics(meeting, 2)
     return send_file(
         io.BytesIO(ics),
-        mimetype='text/calendar',
+        mimetype="text/calendar",
         as_attachment=True,
-        download_name='stage2.ics',
+        download_name="stage2.ics",
     )
 
 
-@bp.route('/<int:meeting_id>/close-stage2', methods=['POST'])
+@bp.route("/<int:meeting_id>/close-stage2", methods=["POST"])
 @login_required
 @permission_required("manage_meetings")
 def close_stage2(meeting_id: int):
@@ -804,26 +823,24 @@ def close_stage2(meeting_id: int):
         if motion.threshold == "special":
             carried = ratio >= 0.75
         else:
-            carried = counts['for'] > counts['against']
-        motion.status = 'carried' if carried else 'failed'
+            carried = counts["for"] > counts["against"]
+        motion.status = "carried" if carried else "failed"
 
-    meeting.status = 'Completed'
+    meeting.status = "Completed"
     db.session.commit()
-    flash('Stage 2 closed and motions tallied', 'success')
-    return redirect(url_for('meetings.results_summary', meeting_id=meeting.id))
+    flash("Stage 2 closed and motions tallied", "success")
+    return redirect(url_for("meetings.results_summary", meeting_id=meeting.id))
 
 
-@bp.route('/<int:meeting_id>/members/<int:member_id>/resend', methods=['POST'])
+@bp.route("/<int:meeting_id>/members/<int:member_id>/resend", methods=["POST"])
 @login_required
-@permission_required('manage_meetings')
+@permission_required("manage_meetings")
 def resend_member_link(meeting_id: int, member_id: int):
     """Generate a new voting token for the current stage and email it."""
     meeting = Meeting.query.get_or_404(meeting_id)
-    member = (
-        Member.query.filter_by(id=member_id, meeting_id=meeting.id).first_or_404()
-    )
+    member = Member.query.filter_by(id=member_id, meeting_id=meeting.id).first_or_404()
 
-    stage = 2 if meeting.status in {'Stage 2', 'Pending Stage 2'} else 1
+    stage = 2 if meeting.status in {"Stage 2", "Pending Stage 2"} else 1
 
     token_obj, plain = VoteToken.create(
         member_id=member.id, stage=stage, salt=current_app.config["TOKEN_SALT"]
@@ -838,5 +855,5 @@ def resend_member_link(meeting_id: int, member_id: int):
         else:
             send_vote_invite(member, plain, meeting)
 
-    flash('Voting link resent', 'success')
-    return redirect(url_for('meetings.results_summary', meeting_id=meeting.id))
+    flash("Voting link resent", "success")
+    return redirect(url_for("meetings.results_summary", meeting_id=meeting.id))

--- a/app/templates/meetings/amendment_form.html
+++ b/app/templates/meetings/amendment_form.html
@@ -15,6 +15,10 @@
     {{ form.seconder_id.label(class_='block font-semibold') }}
     {{ form.seconder_id(class_='border p-2 rounded w-full') }}
   </div>
+  <div class="flex items-center space-x-2">
+    {{ form.board_seconded() }}
+    {{ form.board_seconded.label(class_='font-semibold') }}
+  </div>
   <button type="submit" class="bp-btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/docs/full-database-structure.md
+++ b/docs/full-database-structure.md
@@ -96,6 +96,7 @@ This document summarises all tables and columns created by the Alembic migration
 | status | String(50) | |
 | proposer_id | Integer | FK `members.id` |
 | seconder_id | Integer | FK `members.id` |
+| board_seconded | Boolean | |
 | tie_break_method | String(20) | |
 
 ### amendment_conflicts

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -355,6 +355,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-16 – Added motion form options for clerical fixes and Articles/Bylaws placement
 * 2025-06-17 – Added amendment edit/delete routes and template.
 * 2025-06-17 – Added tallies JSON endpoint for Returning Officers
+* 2025-06-16 – Added board seconding option for amendments
 
 
 ---

--- a/migrations/versions/bb1234567890_add_board_seconded.py
+++ b/migrations/versions/bb1234567890_add_board_seconded.py
@@ -1,0 +1,28 @@
+"""add board_seconded to amendments
+
+Revision ID: bb1234567890
+Revises: 1a2b3c4d5e6f
+Create Date: 2025-06-16 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "bb1234567890"
+down_revision = "1a2b3c4d5e6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("amendments", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "board_seconded", sa.Boolean(), nullable=True, server_default=sa.false()
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("amendments", schema=None) as batch_op:
+        batch_op.drop_column("board_seconded")

--- a/tests/test_form_templates.py
+++ b/tests/test_form_templates.py
@@ -7,7 +7,7 @@ from app import create_app
 from app.extensions import db
 from app.models import Role
 from app.admin.forms import UserCreateForm
-from app.meetings.forms import MeetingForm, MotionForm
+from app.meetings.forms import MeetingForm, MotionForm, AmendmentForm
 
 
 def _setup_app():
@@ -65,3 +65,23 @@ def test_motion_form_has_labels():
             assert f'for="{form.title.id}"' in html
             assert f'for="{form.allow_clerical.id}"' in html
             assert f'for="{form.allow_move.id}"' in html
+
+
+def test_amendment_form_has_labels():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        with app.test_request_context("/meetings/motions/1/amendments/add"):
+            form = AmendmentForm()
+            form.proposer_id.choices = [(1, "A")]
+            form.seconder_id.choices = [(1, "A")]
+            html = render_template(
+                "meetings/amendment_form.html",
+                form=form,
+                motion=None,
+                amendment=None,
+            )
+            assert f'for="{form.text_md.id}"' in html
+            assert f'for="{form.proposer_id.id}"' in html
+            assert f'for="{form.seconder_id.id}"' in html
+            assert f'for="{form.board_seconded.id}"' in html

--- a/tests/test_meetings_routes.py
+++ b/tests/test_meetings_routes.py
@@ -1,5 +1,6 @@
 import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from unittest.mock import patch
 from werkzeug.exceptions import Forbidden
@@ -29,7 +30,7 @@ from app.models import AmendmentConflict
 
 
 def _make_user(has_permission: bool):
-    perm = Permission(name='manage_meetings') if has_permission else None
+    perm = Permission(name="manage_meetings") if has_permission else None
     role = Role(permissions=[perm] if perm else [])
     user = User(role=role)
     user.is_active = True
@@ -38,46 +39,46 @@ def _make_user(has_permission: bool):
 
 def test_list_meetings_requires_permission():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.create_all()
-        with app.test_request_context('/meetings/'):
+        with app.test_request_context("/meetings/"):
             user = _make_user(True)
-            with patch('flask_login.utils._get_user', return_value=user):
+            with patch("flask_login.utils._get_user", return_value=user):
                 meetings.list_meetings()
 
-        with app.test_request_context('/meetings/'):
+        with app.test_request_context("/meetings/"):
             user = _make_user(False)
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch('app.meetings.routes.flash'):
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch("app.meetings.routes.flash"):
                     try:
                         meetings.list_meetings()
                     except Forbidden:
                         pass
                     else:
-                        assert False, 'expected Forbidden'
+                        assert False, "expected Forbidden"
 
 
 def test_list_meetings_contains_create_link():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.create_all()
-        with app.test_request_context('/meetings/'):
+        with app.test_request_context("/meetings/"):
             user = _make_user(True)
-            with patch('flask_login.utils._get_user', return_value=user):
+            with patch("flask_login.utils._get_user", return_value=user):
                 html = meetings.list_meetings()
-                href = url_for('meetings.create_meeting')
+                href = url_for("meetings.create_meeting")
                 assert href in html
-                assert 'bp-btn-primary' in html
+                assert "bp-btn-primary" in html
 
 
 def test_import_members_sends_invites_and_tokens():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='Test')
+        meeting = Meeting(title="Test")
         db.session.add(meeting)
         db.session.commit()
 
@@ -85,20 +86,20 @@ def test_import_members_sends_invites_and_tokens():
             "member_id,name,email,vote_weight,proxy_for\n"
             "1,Alice,alice@example.com,1,\n"
         )
-        data = {
-            'csv_file': (io.BytesIO(csv_content.encode()), 'members.csv')
-        }
+        data = {"csv_file": (io.BytesIO(csv_content.encode()), "members.csv")}
         with app.test_request_context(
-            f'/meetings/{meeting.id}/import-members', method='POST', data=data
+            f"/meetings/{meeting.id}/import-members", method="POST", data=data
         ):
             user = _make_user(True)
             dummy_form = SimpleNamespace(
                 csv_file=SimpleNamespace(data=io.BytesIO(csv_content.encode()))
             )
             dummy_form.validate_on_submit = lambda: True
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch('app.meetings.routes.MemberImportForm', return_value=dummy_form):
-                    with patch('app.meetings.routes.send_vote_invite') as mock_send:
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch(
+                    "app.meetings.routes.MemberImportForm", return_value=dummy_form
+                ):
+                    with patch("app.meetings.routes.send_vote_invite") as mock_send:
                         meetings.import_members(meeting.id)
                         mock_send.assert_called_once()
                         assert VoteToken.query.count() == 1
@@ -106,43 +107,47 @@ def test_import_members_sends_invites_and_tokens():
 
 def test_close_stage1_creates_stage2_tokens_and_emails():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['MAIL_SUPPRESS_SEND'] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["MAIL_SUPPRESS_SEND"] = True
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='Test')
+        meeting = Meeting(title="Test")
         db.session.add(meeting)
         db.session.flush()
-        member = Member(meeting_id=meeting.id, name='Bob', email='b@example.com')
+        member = Member(meeting_id=meeting.id, name="Bob", email="b@example.com")
         db.session.add(member)
         db.session.commit()
 
         with app.test_request_context(
-            f'/meetings/{meeting.id}/close-stage1', method='POST'
+            f"/meetings/{meeting.id}/close-stage1", method="POST"
         ):
             user = _make_user(True)
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch('app.meetings.routes.runoff.close_stage1', return_value=([], [])):
-                    with patch('app.meetings.routes.send_stage2_invite') as mock_send:
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch(
+                    "app.meetings.routes.runoff.close_stage1", return_value=([], [])
+                ):
+                    with patch("app.meetings.routes.send_stage2_invite") as mock_send:
                         meetings.close_stage1(meeting.id)
                         mock_send.assert_not_called()
                         assert (
-                            VoteToken.query.filter_by(member_id=member.id, stage=2).count()
+                            VoteToken.query.filter_by(
+                                member_id=member.id, stage=2
+                            ).count()
                             == 0
                         )
-                        assert meeting.status == 'Pending Stage 2'
+                        assert meeting.status == "Pending Stage 2"
 
 
 def test_close_stage1_runoff_triggers_emails_and_tokens():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['MAIL_SUPPRESS_SEND'] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["MAIL_SUPPRESS_SEND"] = True
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='Test')
+        meeting = Meeting(title="Test")
         db.session.add(meeting)
         db.session.flush()
-        member = Member(meeting_id=meeting.id, name='Bob', email='b@example.com')
+        member = Member(meeting_id=meeting.id, name="Bob", email="b@example.com")
         db.session.add(member)
         db.session.commit()
 
@@ -154,75 +159,88 @@ def test_close_stage1_runoff_triggers_emails_and_tokens():
             return [runoff_obj], [(member, plain)]
 
         with app.test_request_context(
-            f'/meetings/{meeting.id}/close-stage1', method='POST'
+            f"/meetings/{meeting.id}/close-stage1", method="POST"
         ):
             user = _make_user(True)
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch('app.meetings.routes.runoff.close_stage1', side_effect=_runoff_side_effect):
-                    with patch('app.meetings.routes.send_runoff_invite') as mock_send:
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch(
+                    "app.meetings.routes.runoff.close_stage1",
+                    side_effect=_runoff_side_effect,
+                ):
+                    with patch("app.meetings.routes.send_runoff_invite") as mock_send:
                         meetings.close_stage1(meeting.id)
                         mock_send.assert_called_once()
                         assert (
-                            VoteToken.query.filter_by(member_id=member.id, stage=1).count()
+                            VoteToken.query.filter_by(
+                                member_id=member.id, stage=1
+                            ).count()
                             == 1
                         )
 
 
 def test_close_stage1_below_quorum_voids_vote():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='Test', quorum=5)
+        meeting = Meeting(title="Test", quorum=5)
         db.session.add(meeting)
         db.session.flush()
-        member = Member(meeting_id=meeting.id, name='Bob', email='b@example.com')
+        member = Member(meeting_id=meeting.id, name="Bob", email="b@example.com")
         db.session.add(member)
         db.session.commit()
 
         with app.test_request_context(
-            f'/meetings/{meeting.id}/close-stage1', method='POST'
+            f"/meetings/{meeting.id}/close-stage1", method="POST"
         ):
             user = _make_user(True)
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch.object(Meeting, 'stage1_votes_count', return_value=2):
-                    with patch('app.meetings.routes.runoff.close_stage1') as mock_close:
-                        with patch('app.meetings.routes.send_stage2_invite') as mock_stage2:
-                            with patch('app.meetings.routes.send_runoff_invite') as mock_runoff:
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch.object(Meeting, "stage1_votes_count", return_value=2):
+                    with patch("app.meetings.routes.runoff.close_stage1") as mock_close:
+                        with patch(
+                            "app.meetings.routes.send_stage2_invite"
+                        ) as mock_stage2:
+                            with patch(
+                                "app.meetings.routes.send_runoff_invite"
+                            ) as mock_runoff:
                                 meetings.close_stage1(meeting.id)
                                 mock_close.assert_not_called()
                                 mock_stage2.assert_not_called()
                                 mock_runoff.assert_not_called()
-                                assert meeting.status == 'Quorum not met'
+                                assert meeting.status == "Quorum not met"
                                 assert (
-                                    VoteToken.query.filter_by(member_id=member.id, stage=2).count()
+                                    VoteToken.query.filter_by(
+                                        member_id=member.id, stage=2
+                                    ).count()
                                     == 0
                                 )
 
 
 def test_add_amendment_validations():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['WTF_CSRF_ENABLED'] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["WTF_CSRF_ENABLED"] = False
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='Test', opens_at_stage1=datetime.utcnow() + timedelta(days=30))
+        meeting = Meeting(
+            title="Test", opens_at_stage1=datetime.utcnow() + timedelta(days=30)
+        )
         db.session.add(meeting)
         db.session.flush()
         members = [
-            Member(meeting_id=meeting.id, name='A', email='a@example.com'),
-            Member(meeting_id=meeting.id, name='B', email='b@example.com'),
-            Member(meeting_id=meeting.id, name='C', email='c@example.com'),
+            Member(meeting_id=meeting.id, name="A", email="a@example.com"),
+            Member(meeting_id=meeting.id, name="B", email="b@example.com"),
+            Member(meeting_id=meeting.id, name="C", email="c@example.com"),
         ]
         for m in members:
             db.session.add(m)
         db.session.flush()
         motion = Motion(
             meeting_id=meeting.id,
-            title='M1',
-            text_md='text',
-            category='motion',
-            threshold='normal',
+            title="M1",
+            text_md="text",
+            category="motion",
+            threshold="normal",
             ordering=1,
         )
         db.session.add(motion)
@@ -230,88 +248,133 @@ def test_add_amendment_validations():
 
         user = _make_user(True)
         data = {
-            'text_md': 'A1',
-            'proposer_id': members[0].id,
-            'seconder_id': members[1].id,
+            "text_md": "A1",
+            "proposer_id": members[0].id,
+            "seconder_id": members[1].id,
         }
-        with app.test_request_context(f'/meetings/motions/{motion.id}/amendments/add', method='POST', data=data):
-            with patch('flask_login.utils._get_user', return_value=user):
+        with app.test_request_context(
+            f"/meetings/motions/{motion.id}/amendments/add", method="POST", data=data
+        ):
+            with patch("flask_login.utils._get_user", return_value=user):
                 meetings.add_amendment(motion.id)
 
         assert Amendment.query.count() == 1
 
         # fourth amendment by same proposer should fail
-        for i in range(2,5):
+        for i in range(2, 5):
             with app.test_request_context(
-                f'/meetings/motions/{motion.id}/amendments/add',
-                method='POST',
-                data={'text_md': f'A{i}', 'proposer_id': members[0].id, 'seconder_id': members[2].id},
+                f"/meetings/motions/{motion.id}/amendments/add",
+                method="POST",
+                data={
+                    "text_md": f"A{i}",
+                    "proposer_id": members[0].id,
+                    "seconder_id": members[2].id,
+                },
             ):
-                with patch('flask_login.utils._get_user', return_value=user):
+                with patch("flask_login.utils._get_user", return_value=user):
                     if i < 4:
                         meetings.add_amendment(motion.id)
                     else:
-                        with patch('app.meetings.routes.flash') as fl:
+                        with patch("app.meetings.routes.flash") as fl:
                             meetings.add_amendment(motion.id)
                             fl.assert_called()
 
         assert Amendment.query.count() == 3
 
+        # board seconded amendment
+        data = {
+            "text_md": "board",
+            "proposer_id": members[1].id,
+            "seconder_id": "0",
+            "board_seconded": "y",
+        }
+        with app.test_request_context(
+            f"/meetings/motions/{motion.id}/amendments/add",
+            method="POST",
+            data=data,
+        ):
+            with patch("flask_login.utils._get_user", return_value=user):
+                meetings.add_amendment(motion.id)
+
+        assert Amendment.query.count() == 4
+
+        # missing seconder should fail
+        data = {
+            "text_md": "fail",
+            "proposer_id": members[2].id,
+            "seconder_id": "0",
+        }
+        with app.test_request_context(
+            f"/meetings/motions/{motion.id}/amendments/add",
+            method="POST",
+            data=data,
+        ):
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch("app.meetings.routes.flash") as fl:
+                    meetings.add_amendment(motion.id)
+                    fl.assert_called()
+
+        assert Amendment.query.count() == 4
+
         # deadline validation
         meeting.opens_at_stage1 = datetime.utcnow() + timedelta(days=10)
         db.session.commit()
         with app.test_request_context(
-            f'/meetings/motions/{motion.id}/amendments/add',
-            method='POST',
-            data={'text_md': 'late', 'proposer_id': members[2].id, 'seconder_id': members[1].id},
+            f"/meetings/motions/{motion.id}/amendments/add",
+            method="POST",
+            data={
+                "text_md": "late",
+                "proposer_id": members[2].id,
+                "seconder_id": members[1].id,
+            },
         ):
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch('app.meetings.routes.flash') as fl:
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch("app.meetings.routes.flash") as fl:
                     meetings.add_amendment(motion.id)
                     fl.assert_called()
 
-        assert Amendment.query.count() == 3
+        assert Amendment.query.count() == 4
 
 
 def test_results_stage2_docx_returns_file():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='AGM')
+        meeting = Meeting(title="AGM")
         db.session.add(meeting)
         db.session.flush()
         motion = Motion(
             meeting_id=meeting.id,
-            title='M1',
-            text_md='Motion text',
-            category='motion',
-            threshold='normal',
+            title="M1",
+            text_md="Motion text",
+            category="motion",
+            threshold="normal",
             ordering=1,
         )
         db.session.add(motion)
-        member = Member(meeting_id=meeting.id, name='Alice')
+        member = Member(meeting_id=meeting.id, name="Alice")
         db.session.add(member)
         db.session.flush()
-        Vote.record(member_id=member.id, motion_id=motion.id, choice='for', salt='s')
+        Vote.record(member_id=member.id, motion_id=motion.id, choice="for", salt="s")
 
         user = _make_user(True)
-        with app.test_request_context(f'/meetings/{meeting.id}/results-stage2.docx'):
-            with patch('flask_login.utils._get_user', return_value=user):
+        with app.test_request_context(f"/meetings/{meeting.id}/results-stage2.docx"):
+            with patch("flask_login.utils._get_user", return_value=user):
                 resp = meetings.results_stage2_docx(meeting.id)
                 assert resp.mimetype == (
-                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                 )
 
 
 def test_stage_ics_downloads_with_headers():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.create_all()
         now = datetime.utcnow()
         meeting = Meeting(
-            title='AGM',
+            title="AGM",
             opens_at_stage1=now,
             closes_at_stage1=now + timedelta(days=7),
             opens_at_stage2=now + timedelta(days=8),
@@ -320,130 +383,171 @@ def test_stage_ics_downloads_with_headers():
         db.session.add(meeting)
         db.session.commit()
         user = _make_user(True)
-        with app.test_request_context(f'/meetings/{meeting.id}/stage1.ics'):
-            with patch('flask_login.utils._get_user', return_value=user):
+        with app.test_request_context(f"/meetings/{meeting.id}/stage1.ics"):
+            with patch("flask_login.utils._get_user", return_value=user):
                 resp1 = meetings.stage1_ics(meeting.id)
-                assert resp1.mimetype == 'text/calendar'
-                cd1 = resp1.headers['Content-Disposition']
-                assert 'stage1.ics' in cd1
+                assert resp1.mimetype == "text/calendar"
+                cd1 = resp1.headers["Content-Disposition"]
+                assert "stage1.ics" in cd1
 
-        with app.test_request_context(f'/meetings/{meeting.id}/stage2.ics'):
-            with patch('flask_login.utils._get_user', return_value=user):
+        with app.test_request_context(f"/meetings/{meeting.id}/stage2.ics"):
+            with patch("flask_login.utils._get_user", return_value=user):
                 resp2 = meetings.stage2_ics(meeting.id)
-                assert resp2.mimetype == 'text/calendar'
-                cd2 = resp2.headers['Content-Disposition']
-                assert 'stage2.ics' in cd2
+                assert resp2.mimetype == "text/calendar"
+                cd2 = resp2.headers["Content-Disposition"]
+                assert "stage2.ics" in cd2
 
 
 def test_close_stage2_sets_motion_statuses():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='AGM')
+        meeting = Meeting(title="AGM")
         db.session.add(meeting)
         db.session.flush()
         m1 = Motion(
             meeting_id=meeting.id,
-            title='M1',
-            text_md='text1',
-            category='motion',
-            threshold='normal',
+            title="M1",
+            text_md="text1",
+            category="motion",
+            threshold="normal",
             ordering=1,
         )
         m2 = Motion(
             meeting_id=meeting.id,
-            title='M2',
-            text_md='text2',
-            category='motion',
-            threshold='special',
+            title="M2",
+            text_md="text2",
+            category="motion",
+            threshold="special",
             ordering=2,
         )
         db.session.add_all([m1, m2])
-        members = [Member(meeting_id=meeting.id, name=f'M{i}') for i in range(4)]
+        members = [Member(meeting_id=meeting.id, name=f"M{i}") for i in range(4)]
         for mem in members:
             db.session.add(mem)
         db.session.flush()
-        Vote.record(member_id=members[0].id, motion_id=m1.id, choice='for', salt='s')
-        Vote.record(member_id=members[1].id, motion_id=m1.id, choice='for', salt='s')
-        Vote.record(member_id=members[2].id, motion_id=m1.id, choice='against', salt='s')
+        Vote.record(member_id=members[0].id, motion_id=m1.id, choice="for", salt="s")
+        Vote.record(member_id=members[1].id, motion_id=m1.id, choice="for", salt="s")
+        Vote.record(
+            member_id=members[2].id, motion_id=m1.id, choice="against", salt="s"
+        )
 
-        Vote.record(member_id=members[0].id, motion_id=m2.id, choice='for', salt='s')
-        Vote.record(member_id=members[1].id, motion_id=m2.id, choice='for', salt='s')
-        Vote.record(member_id=members[2].id, motion_id=m2.id, choice='for', salt='s')
-        Vote.record(member_id=members[3].id, motion_id=m2.id, choice='against', salt='s')
+        Vote.record(member_id=members[0].id, motion_id=m2.id, choice="for", salt="s")
+        Vote.record(member_id=members[1].id, motion_id=m2.id, choice="for", salt="s")
+        Vote.record(member_id=members[2].id, motion_id=m2.id, choice="for", salt="s")
+        Vote.record(
+            member_id=members[3].id, motion_id=m2.id, choice="against", salt="s"
+        )
 
         user = _make_user(True)
-        with app.test_request_context(f'/meetings/{meeting.id}/close-stage2', method='POST'):
-            with patch('flask_login.utils._get_user', return_value=user):
+        with app.test_request_context(
+            f"/meetings/{meeting.id}/close-stage2", method="POST"
+        ):
+            with patch("flask_login.utils._get_user", return_value=user):
                 meetings.close_stage2(meeting.id)
 
-        assert m1.status == 'carried'
-        assert m2.status == 'carried'
-        assert meeting.status == 'Completed'
-        
+        assert m1.status == "carried"
+        assert m2.status == "carried"
+        assert meeting.status == "Completed"
+
+
 def test_meeting_form_duration_validations():
     app = create_app()
-    app.config['WTF_CSRF_ENABLED'] = False
+    app.config["WTF_CSRF_ENABLED"] = False
     with app.app_context():
         now = datetime.utcnow()
 
         # Stage 1 shorter than 7 days
-        data = MultiDict({
-            'title': 'AGM',
-            'opens_at_stage1': now.strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage1': (now + timedelta(days=6)).strftime('%Y-%m-%dT%H:%M'),
-            'opens_at_stage2': (now + timedelta(days=7)).strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage2': (now + timedelta(days=12)).strftime('%Y-%m-%dT%H:%M'),
-        })
+        data = MultiDict(
+            {
+                "title": "AGM",
+                "opens_at_stage1": now.strftime("%Y-%m-%dT%H:%M"),
+                "closes_at_stage1": (now + timedelta(days=6)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+                "opens_at_stage2": (now + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M"),
+                "closes_at_stage2": (now + timedelta(days=12)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+            }
+        )
         form = MeetingForm(formdata=data)
         assert not form.validate()
         assert form.closes_at_stage1.errors
 
         # Stage 2 opens less than 1 day after Stage 1 closes
-        data = MultiDict({
-            'title': 'AGM',
-            'opens_at_stage1': now.strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage1': (now + timedelta(days=7)).strftime('%Y-%m-%dT%H:%M'),
-            'opens_at_stage2': (now + timedelta(days=7, hours=12)).strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage2': (now + timedelta(days=12)).strftime('%Y-%m-%dT%H:%M'),
-        })
+        data = MultiDict(
+            {
+                "title": "AGM",
+                "opens_at_stage1": now.strftime("%Y-%m-%dT%H:%M"),
+                "closes_at_stage1": (now + timedelta(days=7)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+                "opens_at_stage2": (now + timedelta(days=7, hours=12)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+                "closes_at_stage2": (now + timedelta(days=12)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+            }
+        )
         form = MeetingForm(formdata=data)
         assert not form.validate()
         assert form.opens_at_stage2.errors
 
         # Stage 2 shorter than 5 days
-        data = MultiDict({
-            'title': 'AGM',
-            'opens_at_stage1': now.strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage1': (now + timedelta(days=7)).strftime('%Y-%m-%dT%H:%M'),
-            'opens_at_stage2': (now + timedelta(days=8)).strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage2': (now + timedelta(days=11)).strftime('%Y-%m-%dT%H:%M'),
-        })
+        data = MultiDict(
+            {
+                "title": "AGM",
+                "opens_at_stage1": now.strftime("%Y-%m-%dT%H:%M"),
+                "closes_at_stage1": (now + timedelta(days=7)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+                "opens_at_stage2": (now + timedelta(days=8)).strftime("%Y-%m-%dT%H:%M"),
+                "closes_at_stage2": (now + timedelta(days=11)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+            }
+        )
         form = MeetingForm(formdata=data)
         assert not form.validate()
         assert form.closes_at_stage2.errors
 
         # Stage 1 opens in the past
-        data = MultiDict({
-            'title': 'AGM',
-            'opens_at_stage1': (now - timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage1': (now + timedelta(days=7)).strftime('%Y-%m-%dT%H:%M'),
-            'opens_at_stage2': (now + timedelta(days=8)).strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage2': (now + timedelta(days=13)).strftime('%Y-%m-%dT%H:%M'),
-        })
+        data = MultiDict(
+            {
+                "title": "AGM",
+                "opens_at_stage1": (now - timedelta(hours=1)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+                "closes_at_stage1": (now + timedelta(days=7)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+                "opens_at_stage2": (now + timedelta(days=8)).strftime("%Y-%m-%dT%H:%M"),
+                "closes_at_stage2": (now + timedelta(days=13)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+            }
+        )
         form = MeetingForm(formdata=data)
         assert not form.validate()
         assert form.opens_at_stage1.errors
 
         # Stage 2 opens before Stage 1 opens
-        data = MultiDict({
-            'title': 'AGM',
-            'opens_at_stage1': (now + timedelta(days=1)).strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage1': (now + timedelta(days=8)).strftime('%Y-%m-%dT%H:%M'),
-            'opens_at_stage2': now.strftime('%Y-%m-%dT%H:%M'),
-            'closes_at_stage2': (now + timedelta(days=15)).strftime('%Y-%m-%dT%H:%M'),
-        })
+        data = MultiDict(
+            {
+                "title": "AGM",
+                "opens_at_stage1": (now + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M"),
+                "closes_at_stage1": (now + timedelta(days=8)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+                "opens_at_stage2": now.strftime("%Y-%m-%dT%H:%M"),
+                "closes_at_stage2": (now + timedelta(days=15)).strftime(
+                    "%Y-%m-%dT%H:%M"
+                ),
+            }
+        )
         form = MeetingForm(formdata=data)
         assert not form.validate()
         assert form.opens_at_stage2.errors
@@ -451,43 +555,47 @@ def test_meeting_form_duration_validations():
 
 def test_create_and_delete_conflict():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['WTF_CSRF_ENABLED'] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["WTF_CSRF_ENABLED"] = False
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='AGM')
+        meeting = Meeting(title="AGM")
         db.session.add(meeting)
         db.session.flush()
         motion = Motion(
             meeting_id=meeting.id,
-            title='M',
-            text_md='x',
-            category='motion',
-            threshold='normal',
+            title="M",
+            text_md="x",
+            category="motion",
+            threshold="normal",
             ordering=1,
         )
         db.session.add(motion)
         db.session.flush()
-        a1 = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A1', order=1)
-        a2 = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A2', order=2)
+        a1 = Amendment(
+            meeting_id=meeting.id, motion_id=motion.id, text_md="A1", order=1
+        )
+        a2 = Amendment(
+            meeting_id=meeting.id, motion_id=motion.id, text_md="A2", order=2
+        )
         db.session.add_all([a1, a2])
         db.session.commit()
 
         user = _make_user(True)
-        data = {'amendment_a_id': a1.id, 'amendment_b_id': a2.id}
+        data = {"amendment_a_id": a1.id, "amendment_b_id": a2.id}
         with app.test_request_context(
-            f'/meetings/motions/{motion.id}/conflicts', method='POST', data=data
+            f"/meetings/motions/{motion.id}/conflicts", method="POST", data=data
         ):
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch('app.meetings.routes.flash'):
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch("app.meetings.routes.flash"):
                     meetings.manage_conflicts(motion.id)
         assert AmendmentConflict.query.count() == 1
         conflict = AmendmentConflict.query.first()
 
         with app.test_request_context(
-            f'/meetings/conflicts/{conflict.id}/delete', method='POST'
+            f"/meetings/conflicts/{conflict.id}/delete", method="POST"
         ):
-            with patch('flask_login.utils._get_user', return_value=user):
+            with patch("flask_login.utils._get_user", return_value=user):
                 meetings.delete_conflict(conflict.id)
 
         assert AmendmentConflict.query.count() == 0
@@ -495,71 +603,79 @@ def test_create_and_delete_conflict():
 
 def test_resend_member_token_stage1():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['TOKEN_SALT'] = 's'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TOKEN_SALT"] = "s"
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='AGM')
+        meeting = Meeting(title="AGM")
         db.session.add(meeting)
         db.session.flush()
-        member = Member(meeting_id=meeting.id, name='A', email='a@example.com')
+        member = Member(meeting_id=meeting.id, name="A", email="a@example.com")
         db.session.add(member)
         db.session.commit()
 
         with app.test_request_context(
-            f'/meetings/{meeting.id}/members/{member.id}/resend', method='POST'
+            f"/meetings/{meeting.id}/members/{member.id}/resend", method="POST"
         ):
             user = _make_user(True)
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch('app.meetings.routes.send_vote_invite') as mock_send:
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch("app.meetings.routes.send_vote_invite") as mock_send:
                     meetings.resend_member_link(meeting.id, member.id)
                     mock_send.assert_called_once()
-                    assert VoteToken.query.filter_by(member_id=member.id, stage=1).count() == 1
+                    assert (
+                        VoteToken.query.filter_by(member_id=member.id, stage=1).count()
+                        == 1
+                    )
 
 
 def test_resend_member_token_stage2():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['TOKEN_SALT'] = 's'
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TOKEN_SALT"] = "s"
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='AGM', status='Stage 2')
+        meeting = Meeting(title="AGM", status="Stage 2")
         db.session.add(meeting)
         db.session.flush()
-        member = Member(meeting_id=meeting.id, name='B', email='b@example.com')
+        member = Member(meeting_id=meeting.id, name="B", email="b@example.com")
         db.session.add(member)
         db.session.commit()
 
         with app.test_request_context(
-            f'/meetings/{meeting.id}/members/{member.id}/resend', method='POST'
+            f"/meetings/{meeting.id}/members/{member.id}/resend", method="POST"
         ):
             user = _make_user(True)
-            with patch('flask_login.utils._get_user', return_value=user):
-                with patch('app.meetings.routes.send_stage2_invite') as mock_send:
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch("app.meetings.routes.send_stage2_invite") as mock_send:
                     meetings.resend_member_link(meeting.id, member.id)
                     mock_send.assert_called_once()
-                    assert VoteToken.query.filter_by(member_id=member.id, stage=2).count() == 1
+                    assert (
+                        VoteToken.query.filter_by(member_id=member.id, stage=2).count()
+                        == 1
+                    )
 
 
 def test_edit_and_delete_amendment():
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['WTF_CSRF_ENABLED'] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["WTF_CSRF_ENABLED"] = False
     with app.app_context():
         db.create_all()
-        meeting = Meeting(title='AGM', opens_at_stage1=datetime.utcnow() + timedelta(days=30))
+        meeting = Meeting(
+            title="AGM", opens_at_stage1=datetime.utcnow() + timedelta(days=30)
+        )
         db.session.add(meeting)
         db.session.flush()
-        m1 = Member(meeting_id=meeting.id, name='A')
-        m2 = Member(meeting_id=meeting.id, name='B')
+        m1 = Member(meeting_id=meeting.id, name="A")
+        m2 = Member(meeting_id=meeting.id, name="B")
         db.session.add_all([m1, m2])
         db.session.flush()
         motion = Motion(
             meeting_id=meeting.id,
-            title='M1',
-            text_md='x',
-            category='motion',
-            threshold='normal',
+            title="M1",
+            text_md="x",
+            category="motion",
+            threshold="normal",
             ordering=1,
         )
         db.session.add(motion)
@@ -567,7 +683,7 @@ def test_edit_and_delete_amendment():
         amend = Amendment(
             meeting_id=meeting.id,
             motion_id=motion.id,
-            text_md='A1',
+            text_md="A1",
             order=1,
             proposer_id=m1.id,
             seconder_id=m2.id,
@@ -577,23 +693,22 @@ def test_edit_and_delete_amendment():
 
         user = _make_user(True)
         data = {
-            'text_md': 'changed',
-            'proposer_id': m2.id,
-            'seconder_id': m1.id,
+            "text_md": "changed",
+            "proposer_id": m2.id,
+            "seconder_id": m1.id,
         }
         with app.test_request_context(
-            f'/meetings/amendments/{amend.id}/edit', method='POST', data=data
+            f"/meetings/amendments/{amend.id}/edit", method="POST", data=data
         ):
-            with patch('flask_login.utils._get_user', return_value=user):
+            with patch("flask_login.utils._get_user", return_value=user):
                 meetings.edit_amendment(amend.id)
 
-        assert Amendment.query.get(amend.id).text_md == 'changed'
+        assert Amendment.query.get(amend.id).text_md == "changed"
 
         with app.test_request_context(
-            f'/meetings/amendments/{amend.id}/delete', method='POST'
+            f"/meetings/amendments/{amend.id}/delete", method="POST"
         ):
-            with patch('flask_login.utils._get_user', return_value=user):
+            with patch("flask_login.utils._get_user", return_value=user):
                 meetings.delete_amendment(amend.id)
 
         assert Amendment.query.count() == 0
-


### PR DESCRIPTION
## Summary
- allow board/Chair to approve amendments when no seconder is provided
- add board_seconded column to amendments
- update amendment form UI and validations
- document new column and feature
- add migration and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68502345b500832bb8e5edc346657231