### PR TITLE
Add tie-break admin page

### DIFF
--- a/app/templates/ro/tie_break_form.html
+++ b/app/templates/ro/tie_break_form.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Tie Breaks</h2>
+<form method="post" class="space-y-6">
+  {{ form.hidden_tag() }}
+  {% for amend in amendments %}
+  <div class="bp-card p-4 space-y-2">
+    <p class="font-semibold">Amendment {{ amend.order }}</p>
+    <div class="border p-2 whitespace-pre-wrap">{{ amend.text_md }}</div>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div>
+        {{ form['decision_' ~ amend.id].label(class='block font-semibold') }}
+        {{ form['decision_' ~ amend.id](class='border p-2 rounded w-full') }}
+      </div>
+      <div>
+        {{ form['method_' ~ amend.id].label(class='block font-semibold') }}
+        {{ form['method_' ~ amend.id](class='border p-2 rounded w-full') }}
+      </div>
+    </div>
+  </div>
+  {% else %}
+  <p>No tied amendments.</p>
+  {% endfor %}
+  <button type="submit" class="bp-btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -355,6 +355,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-16 – Added motion form options for clerical fixes and Articles/Bylaws placement
 * 2025-06-17 – Added amendment edit/delete routes and template.
 * 2025-06-17 – Added tallies JSON endpoint for Returning Officers
+* 2025-06-18 – Added tie-break admin page storing decisions per amendment
 
 
 ---

--- a/tests/test_runoff.py
+++ b/tests/test_runoff.py
@@ -150,7 +150,9 @@ def test_close_stage1_tie_resolved_by_chair():
         Vote.record(member_id=member.id, amendment_id=a2.id, choice='for', salt='s')
         Vote.record(member_id=member.id, amendment_id=a2.id, choice='against', salt='s')
 
-        app.config['TIE_BREAK_DECISIONS'] = {a1.id: {'result': 'carried', 'method': 'chair'}}
+        a1.status = 'carried'
+        a1.tie_break_method = 'chair'
+        db.session.commit()
 
         ro.close_stage1(meeting)
 


### PR DESCRIPTION
## Summary
- allow Returning Officers to save tie-break results per amendment
- consult Amendment.tie_break_method when closing Stage 1
- document new feature
- test updates

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest tests/test_runoff.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6850234a5ef8832b99babd328796e44e