### PR TITLE
Update voting confirmation microcopy

### DIFF
--- a/app/templates/voting/confirmation.html
+++ b/app/templates/voting/confirmation.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="bp-alert-success text-center mb-4">
-  Thanks, you voted {{ choice.capitalize() }}.
+<div class="bp-card text-center space-y-4">
+    <svg class="w-16 h-16 mx-auto text-bp-red" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+    <p class="text-lg font-semibold">Vote recorded! You’ll get an e‑mail receipt shortly.</p>
+    <a href="{{ url_for('help.show_help') }}" class="bp-btn-secondary">Voting Help</a>
 </div>
-<a href="{{ url_for('main.index') }}" class="bp-btn-secondary">Return home</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enhance confirmation page UI with a big bp-red tick icon
- adjust microcopy and link to Voting Help

## Testing
- `pytest -q` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_b_685030f3d398832ba6a02a500c22bd2d