### PR TITLE
Add breadcrumb component

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -994,3 +994,26 @@ a:focus-visible {
   background-color: #002D59;
   color: #FFFFFF;
 }
+
+/* Breadcrumb component */
+.bp-breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.bp-link {
+  color: #002D59; /* bp-blue */
+  text-decoration: underline;
+}
+
+.bp-link:hover,
+.bp-link:focus-visible {
+  text-decoration-thickness: 2px;
+}
+
+/* Spacing utilities */
+.bp-gap-xs { gap: 0.25rem; }
+.bp-gap-sm { gap: 0.5rem; }
+.bp-gap-md { gap: 1rem; }
+.bp-gap-lg { gap: 1.5rem; }

--- a/app/templates/_macros.html
+++ b/app/templates/_macros.html
@@ -1,0 +1,16 @@
+{% macro breadcrumbs(items) %}
+<nav aria-label="Breadcrumb" class="mb-4">
+  <ol class="bp-breadcrumbs bp-gap-sm text-sm">
+  {%- for label, url in items %}
+    <li class="inline-flex items-center">
+      {%- if not loop.first %}<span class="mx-1 text-bp-grey-700">&rsaquo;</span>{% endif -%}
+      {% if loop.last or not url %}
+        <span class="font-semibold">{{ label }}</span>
+      {% else %}
+        <a href="{{ url }}" class="bp-link">{{ label }}</a>
+      {% endif %}
+    </li>
+  {%- endfor %}
+  </ol>
+</nav>
+{% endmacro %}

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard'))]) }}
 <div class="bp-card space-y-4">
   <h2 class="font-bold text-bp-blue">Admin Dashboard</h2>
   <p>Welcome to {{ setting('site_title', 'VoteBuddy') }} administration.</p>

--- a/app/templates/admin/objections.html
+++ b/app/templates/admin/objections.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Objections', url_for('admin.list_objections'))]) }}
 <h2 class="font-bold text-bp-blue mb-4">Amendment Objections</h2>
 <table class="bp-table w-full">
   <thead>

--- a/app/templates/admin/role_form.html
+++ b/app/templates/admin/role_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Roles', url_for('admin.list_roles')), ('Edit Role' if role else 'Create Role', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if role else 'Create' }} Role</h2>
 <form method="post" class="bp-form bp-card space-y-6">
   {{ form.hidden_tag() }}

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Roles', url_for('admin.list_roles'))]) }}
 <h2 class="font-bold text-bp-blue mb-4">Roles</h2>
 <div class="bp-card">
 <table class="bp-table">

--- a/app/templates/admin/settings_form.html
+++ b/app/templates/admin/settings_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Settings', url_for('admin.manage_settings'))]) }}
 <div class="bp-card max-w-lg space-y-4">
   <h2 class="font-bold text-bp-blue">Application Settings</h2>
   <form method="post">

--- a/app/templates/admin/user_form.html
+++ b/app/templates/admin/user_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Users', url_for('admin.list_users')), ('Edit User' if user else 'Create User', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if user else 'Create' }} User</h2>
 <form method="post" class="bp-form bp-card space-y-6">
   {{ form.hidden_tag() }}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Users', url_for('admin.list_users'))]) }}
 <h2 class="font-bold text-bp-blue mb-4">User Accounts</h2>
 
 <form class="mb-4 bp-card bp-form" hx-get="{{ url_for('admin.list_users') }}" hx-target="#user-table-body" hx-trigger="keyup changed delay:300ms" hx-push-url="true">

--- a/app/templates/meetings/amendment_form.html
+++ b/app/templates/meetings/amendment_form.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{% set label = 'Edit Amendment' if amendment else 'Add Amendment' %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (label, None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">{{ 'Edit Amendment' if amendment else 'Add Amendment' }}</h2>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Edit Meeting' if meeting else 'Create Meeting', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if meeting else 'Create' }} Meeting</h2>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/motion_form.html
+++ b/app/templates/meetings/motion_form.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{% set label = 'Edit Motion' if motion else 'Create Motion' %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (label, None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if motion else 'Create' }} Motion</h2>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/objection_form.html
+++ b/app/templates/meetings/objection_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Submit Objection', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">Submit Objection</h2>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}

--- a/app/templates/voting/ballot.html
+++ b/app/templates/voting/ballot.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), ('Amendment Vote', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">Amendment Vote</h2>
 <div class="bp-card mb-4">
   {{ amendment.text_md or 'No amendment text.' }}

--- a/app/templates/voting/combined_ballot.html
+++ b/app/templates/voting/combined_ballot.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Combined', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">Combined Ballot</h2>
 {% set current_stage = 1 %}
 {% include '_stepper.html' %}

--- a/app/templates/voting/runoff_ballot.html
+++ b/app/templates/voting/runoff_ballot.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Run-off', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">Run-off Vote</h2>
 {% set current_stage = 1 %}
 {% include '_stepper.html' %}

--- a/app/templates/voting/stage1_ballot.html
+++ b/app/templates/voting/stage1_ballot.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Stage 1', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">Stage 1 – Amendment Votes</h2>
 {% set current_stage = 1 %}
 {% include '_stepper.html' %}

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Stage 2', None)]) }}
 <h2 class="font-bold text-bp-blue mb-4">Stage 2 – Vote on Motion</h2>
 {% set current_stage = 2 %}
 {% include '_stepper.html' %}


### PR DESCRIPTION
## Summary
- create reusable breadcrumbs macro
- style breadcrumb links and spacing
- show breadcrumbs in admin templates
- show breadcrumbs on meeting forms
- show breadcrumbs on ballot pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask and other packages)*

------
https://chatgpt.com/codex/tasks/task_b_685030d354c4832ba70ef5057e4e31c1