### PR TITLE
Fix failing tests

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -6,11 +6,18 @@ import pytest
 from werkzeug.exceptions import Forbidden
 from flask import abort
 from app import create_app
+from app.extensions import db
 from unittest.mock import patch
 from flask_login import AnonymousUserMixin
 
 from app.permissions import permission_required
 from app.models import User, Role, Permission
+
+
+def _setup_app():
+    app = create_app()
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    return app
 
 
 @permission_required('view_dashboard')
@@ -41,9 +48,11 @@ def test_permission_required_forbidden_when_anonymous():
             _protected()
 
 
+
 def test_403_template_loads():
-    app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
 
     @app.route('/deny')
     def deny():

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -2,10 +2,19 @@ import os, sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app import create_app
+from app.extensions import db
+
+
+def _setup_app():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    return app
 
 
 def test_csp_header_present():
-    app = create_app()
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
     with app.test_client() as client:
         resp = client.get('/')
         assert resp.headers.get('Content-Security-Policy') == (


### PR DESCRIPTION
## Summary
- fix `test_403_template_loads` by creating DB tables
- fix `test_csp_header_present` by initializing the DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850339a8c98832ba3197e289d3b82c7