### PR TITLE
Add dark mode with toggle

### DIFF
--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -1,0 +1,105 @@
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #0f172a;
+    color: #F7F7F9;
+  }
+  .bg-bp-blue {
+    background-color: #001836;
+  }
+  .bg-bp-grey-50 {
+    background-color: #1e293b;
+  }
+  .text-bp-grey-700 {
+    color: #e2e8f0;
+  }
+  .bg-white {
+    background-color: #283446;
+  }
+  .hover\:bg-bp-grey-50:hover {
+    background-color: #334155;
+  }
+  .bp-card {
+    background-color: #1e293b;
+    border-color: #334155;
+  }
+  .bp-btn-secondary {
+    background-color: #1e293b;
+    color: #fff;
+    border-color: #fff;
+  }
+  .bp-nav-drawer {
+    background-color: #001836;
+  }
+  .bp-sticky-footer {
+    background-color: #1e293b;
+    border-color: #334155;
+    box-shadow: 0 -2px 5px rgba(0,0,0,0.4);
+  }
+  .bp-table th,
+  .bp-table td {
+    border-color: #334155;
+  }
+  .bp-table th,
+  .bp-table tbody tr:nth-child(even) {
+    background-color: #1e293b;
+  }
+  a.bp-link {
+    color: #93c5fd;
+  }
+  .bp-badge {
+    background-color: #334155;
+    color: #F7F7F9;
+  }
+}
+
+[data-theme="dark"] body {
+  background-color: #0f172a;
+  color: #F7F7F9;
+}
+[data-theme="dark"] .bg-bp-blue {
+  background-color: #001836;
+}
+[data-theme="dark"] .bg-bp-grey-50 {
+  background-color: #1e293b;
+}
+[data-theme="dark"] .text-bp-grey-700 {
+  color: #e2e8f0;
+}
+[data-theme="dark"] .bg-white {
+  background-color: #283446;
+}
+[data-theme="dark"] .hover\:bg-bp-grey-50:hover {
+  background-color: #334155;
+}
+[data-theme="dark"] .bp-card {
+  background-color: #1e293b;
+  border-color: #334155;
+}
+[data-theme="dark"] .bp-btn-secondary {
+  background-color: #1e293b;
+  color: #fff;
+  border-color: #fff;
+}
+[data-theme="dark"] .bp-nav-drawer {
+  background-color: #001836;
+}
+[data-theme="dark"] .bp-sticky-footer {
+  background-color: #1e293b;
+  border-color: #334155;
+  box-shadow: 0 -2px 5px rgba(0,0,0,0.4);
+}
+[data-theme="dark"] .bp-table th,
+[data-theme="dark"] .bp-table td {
+  border-color: #334155;
+}
+[data-theme="dark"] .bp-table th,
+[data-theme="dark"] .bp-table tbody tr:nth-child(even) {
+  background-color: #1e293b;
+}
+[data-theme="dark"] a.bp-link {
+  color: #93c5fd;
+}
+[data-theme="dark"] .bp-badge {
+  background-color: #334155;
+  color: #F7F7F9;
+}

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -1,16 +1,33 @@
 document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.getElementById('nav-toggle');
   const drawer = document.getElementById('nav-drawer');
-  if (!toggle || !drawer) return;
-  toggle.addEventListener('click', () => {
-    const expanded = toggle.getAttribute('aria-expanded') === 'true';
-    toggle.setAttribute('aria-expanded', String(!expanded));
-    if (expanded) {
-      drawer.classList.remove('open');
-      drawer.setAttribute('hidden', '');
-    } else {
-      drawer.removeAttribute('hidden');
-      requestAnimationFrame(() => drawer.classList.add('open'));
-    }
-  });
+  if (toggle && drawer) {
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', String(!expanded));
+      if (expanded) {
+        drawer.classList.remove('open');
+        drawer.setAttribute('hidden', '');
+      } else {
+        drawer.removeAttribute('hidden');
+        requestAnimationFrame(() => drawer.classList.add('open'));
+      }
+    });
+  }
+
+  const themeBtn = document.getElementById('theme-toggle');
+  const root = document.documentElement;
+  if (themeBtn) {
+    const saved = localStorage.getItem('theme');
+    if (saved) root.dataset.theme = saved;
+    themeBtn.addEventListener('click', () => {
+      const newTheme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+      root.dataset.theme = newTheme;
+      localStorage.setItem('theme', newTheme);
+      themeBtn.setAttribute(
+        'aria-label',
+        newTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+      );
+    });
+  }
 });

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ setting('site_title', 'VoteBuddy') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/dark.css') }}">
   </head>
   <body hx-boost="true" class="flex flex-col min-h-screen bg-bp-grey-50 font-sans">
     <header>
@@ -20,6 +21,9 @@
           <button id="nav-toggle" class="bp-nav-toggle" aria-expanded="false" aria-controls="nav-drawer">
             <span class="sr-only">Menu</span>
             &#9776;
+          </button>
+          <button id="theme-toggle" class="bp-nav-toggle" aria-label="Switch to dark mode">
+            <span aria-hidden="true">🌙</span>
           </button>
           <div id="nav-drawer" class="bp-nav-drawer" hidden>
             <ul class="bp-nav-items">

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -293,6 +293,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-14 – Added secondary button, table, badge and card styles.
 * 2025-06-14 – Added dotenv loading with SQLite fallback when `DATABASE_URL` is unset.
 * 2025-06-14 – Added focus-visible outlines for buttons and links.
+* 2025-06-15 – Implemented dark mode with optional theme toggle.
 * 2025-06-14 – Expanded UI/UX design guidance with extended design patterns.
 * 2025-06-14 – Implemented meetings list view with table layout.
 * 2025-06-14 – Enhanced meetings list with htmx search and sort.

--- a/docs/ui-ux-design-guidance.md
+++ b/docs/ui-ux-design-guidance.md
@@ -131,6 +131,7 @@ Data tables follow a simple pattern:
 5 Accessibility Rules (WCAG 2.2 AA)
 
 Colour contrast ≥ 4.5 : 1 (already met with bp‑blue / white).
+Dark mode uses a dark‑blue/grey palette and is enabled automatically with an optional toggle in the header.
 
 All interactive elements reachable via Tab order; visible focus ring (outline-offset: 2px).
 


### PR DESCRIPTION
## Summary
- add dark mode stylesheet and auto/override rules
- toggle theme in nav and persist choice
- link dark.css in base template
- document dark mode in design guidance
- note new feature in PRD

## Testing
- `pip install -r requirements.txt`
- `flask --app app db upgrade heads`
- `pytest -q` *(fails: sqlalchemy OperationalError)*
- `flask --app app run -p 5050`
- `docker-compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685033c81ef4832bbf3335c88173972b