### PR TITLE
Sanitize Markdown output

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,21 @@
 from markdown import markdown
 from markupsafe import Markup
+import bleach
+
+ALLOWED_TAGS = (
+    bleach.sanitizer.ALLOWED_TAGS
+    | {
+        'p',
+        'pre',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'br',
+    }
+)
 from flask import current_app
 from .models import AppSetting
 import json
@@ -40,7 +56,9 @@ def config_or_setting(
 
 def markdown_to_html(text: str) -> Markup:
     """Convert Markdown text to safe HTML."""
-    return Markup(markdown(text or ""))
+    raw_html = markdown(text or "")
+    cleaned = bleach.clean(raw_html, tags=ALLOWED_TAGS, strip=True)
+    return Markup(cleaned)
 
 from uuid import uuid4
 from datetime import datetime

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.utils import markdown_to_html
+from markupsafe import Markup
+
+
+def test_markdown_to_html_sanitizes_and_marks_safe():
+    md = '# Title\n<script>alert(1)</script>'
+    html = markdown_to_html(md)
+    assert '<script>' not in html
+    assert '<h1>' in html
+    assert isinstance(html, Markup)


### PR DESCRIPTION
## Summary
- sanitize Markdown in app utilities using bleach
- test that markdown_to_html strips unsafe tags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685036d737d0832b988bd2e5cb78c9b7