### PR TITLE
Replace deprecated query.get with session.get

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -82,7 +82,7 @@ def register_extensions(app):
 
     @login_manager.user_loader
     def load_user(user_id: str) -> User | None:
-        return User.query.get(int(user_id))
+        return db.session.get(User, int(user_id))
 
 
 def register_blueprints(app):

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -318,7 +318,7 @@ def add_amendment(motion_id):
     form.proposer_id.choices = choices
     form.seconder_id.choices = [(0, "")] + choices
     if form.validate_on_submit():
-        meeting = Meeting.query.get(motion.meeting_id)
+        meeting = db.session.get(Meeting, motion.meeting_id)
         if meeting.opens_at_stage1:
             deadline = meeting.opens_at_stage1 - timedelta(days=21)
             if datetime.utcnow() > deadline:
@@ -374,7 +374,7 @@ def add_amendment(motion_id):
                 db.session.add(
                     AmendmentMerge(combined_id=amendment.id, source_id=src_id)
                 )
-                src = Amendment.query.get(src_id)
+                src = db.session.get(Amendment, src_id)
                 if src:
                     src.status = "merged"
 
@@ -390,7 +390,7 @@ def edit_amendment(amendment_id: int):
     """Edit an existing amendment."""
     amendment = Amendment.query.get_or_404(amendment_id)
     motion = Motion.query.get_or_404(amendment.motion_id)
-    meeting = Meeting.query.get(amendment.meeting_id)
+    meeting = db.session.get(Meeting, amendment.meeting_id)
 
     form = AmendmentForm(obj=amendment)
     members = Member.query.filter_by(meeting_id=meeting.id).order_by(Member.name).all()
@@ -455,7 +455,7 @@ def edit_amendment(amendment_id: int):
 def delete_amendment(amendment_id: int):
     """Delete an amendment."""
     amendment = Amendment.query.get_or_404(amendment_id)
-    meeting = Meeting.query.get(amendment.meeting_id)
+    meeting = db.session.get(Meeting, amendment.meeting_id)
     motion_id = amendment.motion_id
 
     if meeting.opens_at_stage1:
@@ -580,7 +580,7 @@ def manage_conflicts(motion_id: int):
 @permission_required("manage_meetings")
 def delete_conflict(conflict_id: int):
     conflict = AmendmentConflict.query.get_or_404(conflict_id)
-    motion_id = Amendment.query.get(conflict.amendment_a_id).motion_id
+    motion_id = db.session.get(Amendment, conflict.amendment_a_id).motion_id
     db.session.delete(conflict)
     db.session.commit()
     flash("Conflict removed", "success")

--- a/app/services/runoff.py
+++ b/app/services/runoff.py
@@ -82,8 +82,8 @@ def _detect_runoffs(meeting: Meeting) -> list[Runoff]:
     runoffs_created: list[Runoff] = []
     conflicts = AmendmentConflict.query.filter_by(meeting_id=meeting.id).all()
     for conflict in conflicts:
-        a = Amendment.query.get(conflict.amendment_a_id)
-        b = Amendment.query.get(conflict.amendment_b_id)
+        a = db.session.get(Amendment, conflict.amendment_a_id)
+        b = db.session.get(Amendment, conflict.amendment_b_id)
         if a.status == 'carried' and b.status == 'carried':
             if not Runoff.query.filter_by(
                 meeting_id=meeting.id,

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -101,7 +101,7 @@ def ballot_token(token: str):
     proxy_member = None
     if member.proxy_for:
         try:
-            proxy_member = Member.query.get(int(member.proxy_for))
+            proxy_member = db.session.get(Member, int(member.proxy_for))
         except (ValueError, TypeError):
             proxy_member = None
 
@@ -307,7 +307,7 @@ def runoff_ballot(token: str):
     proxy_member = None
     if member.proxy_for:
         try:
-            proxy_member = Member.query.get(int(member.proxy_for))
+            proxy_member = db.session.get(Member, int(member.proxy_for))
         except (ValueError, TypeError):
             proxy_member = None
 
@@ -373,7 +373,11 @@ def runoff_ballot(token: str):
         return render_template("voting/confirmation.html", choice="recorded")
 
     pairs = [
-        (r, Amendment.query.get(r.amendment_a_id), Amendment.query.get(r.amendment_b_id))
+        (
+            r,
+            db.session.get(Amendment, r.amendment_a_id),
+            db.session.get(Amendment, r.amendment_b_id),
+        )
         for r in runoffs
     ]
     return render_template(


### PR DESCRIPTION
## Summary
- swap out `Model.query.get` calls for `db.session.get`
- keep imports consistent across modules

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68503a61e5ec832b974d762f5cac06b5