### PR TITLE
Add rate limiting

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,16 @@ from datetime import datetime
 from flask import Flask, render_template
 from .utils import markdown_to_html
 
-from .extensions import db, migrate, login_manager, bcrypt, csrf, mail, scheduler
+from .extensions import (
+    db,
+    migrate,
+    login_manager,
+    bcrypt,
+    csrf,
+    mail,
+    scheduler,
+    limiter,
+)
 
 
 def create_app(config_object='config.DevelopmentConfig'):
@@ -47,6 +56,7 @@ def register_extensions(app):
     bcrypt.init_app(app)
     csrf.init_app(app)
     mail.init_app(app)
+    limiter.init_app(app)
     if not scheduler.running:
         scheduler.init_app(app)
         from .tasks import register_jobs

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from flask_login import login_user, logout_user
+from ..extensions import limiter
 
 from ..models import User
 from .utils import is_safe_url
@@ -7,6 +8,7 @@ from .utils import is_safe_url
 bp = Blueprint('auth', __name__, url_prefix='/auth')
 
 @bp.route('/login', methods=['GET', 'POST'])
+@limiter.limit('5 per minute')
 def login():
     next_page = request.args.get('next')
     if request.method == 'POST':

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -5,6 +5,8 @@ from flask_bcrypt import Bcrypt
 from flask_wtf import CSRFProtect
 from flask_mail import Mail
 from flask_apscheduler import APScheduler
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 
 
 db = SQLAlchemy()
@@ -14,3 +16,4 @@ bcrypt = Bcrypt()
 csrf = CSRFProtect()
 mail = Mail()
 scheduler = APScheduler()
+limiter = Limiter(key_func=get_remote_address)

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -17,6 +17,7 @@ from flask_wtf import FlaskForm
 from wtforms import RadioField, SubmitField
 from wtforms.validators import DataRequired
 from app.services.email import send_vote_receipt
+from ..extensions import limiter
 
 bp = Blueprint("voting", __name__, url_prefix="/vote")
 
@@ -90,6 +91,7 @@ def compile_motion_text(motion: Motion) -> str:
 
 
 @bp.route("/<token>", methods=["GET", "POST"])
+@limiter.limit("10 per minute")
 def ballot_token(token: str):
     """Verify token and display the correct ballot stage."""
     vote_token = VoteToken.verify(token, current_app.config["TOKEN_SALT"])
@@ -296,6 +298,7 @@ def ballot_token(token: str):
 
 
 @bp.route("/runoff/<token>", methods=["GET", "POST"])
+@limiter.limit("10 per minute")
 def runoff_ballot(token: str):
     """Display a run-off ballot for conflicting amendments."""
     vote_token = VoteToken.verify(token, current_app.config["TOKEN_SALT"])

--- a/config.py
+++ b/config.py
@@ -30,6 +30,8 @@ class Config:
         "MOVE_TEXT",
         "The Board may place this change in the Articles or Bylaws as most appropriate.",
     )
+    RATELIMIT_DEFAULT = os.getenv("RATELIMIT_DEFAULT", "200 per day")
+    RATELIMIT_STORAGE_URL = os.getenv("RATELIMIT_STORAGE_URL", "memory://")
 
 
 class DevelopmentConfig(Config):

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -130,6 +130,7 @@
 * Pen‑test checklist aligns with OWASP Secure Coding Guide.
 * Every feature must enforce role permissions on pages and endpoints
   using `permission_required` to guard access.
+* Login and voting endpoints are rate limited with Flask-Limiter.
 
 ### 6.2 Accessibility & UX
 * Colour palette and logos per BP brand guide.  
@@ -363,6 +364,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-16 – Stage 1 closing now schedules Stage 2 close after the new open when no close was set.
 * 2025-06-16 – Added `node_modules/` to `.gitignore` to ignore Node packages.
 * 2025-06-16 – Documented Python package installation in README.
+* 2025-06-16 – Added rate limiting to login and vote routes using Flask-Limiter.
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-docx==1.1.0
 Flask-APScheduler==1.13.1
 Markdown==3.8
 bleach==6.0.0
+Flask-Limiter==3.12


### PR DESCRIPTION
## Summary
- add Flask-Limiter dependency and initialize extension
- apply per-route limits on login and voting endpoints
- expose rate limit config variables
- document new security measure

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `flask --app app run -p 5050` *(terminated after start)*
- `docker-compose up --build --no-start` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68505ed34eb8832b971fd0a014853ada