### PR TITLE
Update help route to use markdown helper

### DIFF
--- a/app/help/routes.py
+++ b/app/help/routes.py
@@ -1,8 +1,7 @@
 from flask import Blueprint, render_template, current_app
-from markupsafe import Markup
 from pathlib import Path
-import markdown
-import bleach
+
+from app.utils import markdown_to_html
 
 bp = Blueprint('help', __name__)
 
@@ -11,7 +10,5 @@ def show_help():
     docs_path = Path(current_app.root_path).parent / 'docs' / 'help-voting.md'
     with open(docs_path, 'r', encoding='utf-8') as f:
         content_md = f.read()
-    unsafe_html = markdown.markdown(content_md)
-    cleaned = bleach.clean(unsafe_html)
-    html_content = Markup(cleaned)
+    html_content = markdown_to_html(content_md)
     return render_template('help/help.html', content=html_content)


### PR DESCRIPTION
## Summary
- refactor help route to use `markdown_to_html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68505f2bfe6c832bb2966b5dafbf5b06