### PR TITLE
Increase default rate limit

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,7 +30,7 @@ class Config:
         "MOVE_TEXT",
         "The Board may place this change in the Articles or Bylaws as most appropriate.",
     )
-    RATELIMIT_DEFAULT = os.getenv("RATELIMIT_DEFAULT", "200 per day")
+    RATELIMIT_DEFAULT = os.getenv("RATELIMIT_DEFAULT", "1000 per day")
     RATELIMIT_STORAGE_URL = os.getenv("RATELIMIT_STORAGE_URL", "memory://")
 
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -365,6 +365,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-16 – Added `node_modules/` to `.gitignore` to ignore Node packages.
 * 2025-06-16 – Documented Python package installation in README.
 * 2025-06-16 – Added rate limiting to login and vote routes using Flask-Limiter.
+* 2025-06-17 – Increased default rate limit to 1000 per day.
 
 
 


### PR DESCRIPTION
## Summary
- bump the default rate limit from 200/day to 1000/day
- document the change in the changelog

## Testing
- `flask db upgrade` *(fails: multiple head revisions)*
- `flask --app app run -p 5051`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685060894e18832b868afe4b032808d3