### PR TITLE
Promote page headings

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -3,7 +3,7 @@
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard'))]) }}
 <div class="bp-card space-y-4">
-  <h2 class="font-bold text-bp-blue">Admin Dashboard</h2>
+  <h1 class="font-bold text-bp-blue">Admin Dashboard</h1>
   <p>Welcome to {{ setting('site_title', 'VoteBuddy') }} administration.</p>
   <a href="{{ url_for('admin.list_users') }}" class="bp-btn-primary">Manage Users</a>
   <a href="{{ url_for('admin.list_objections') }}" class="bp-btn-secondary ml-2">View Objections</a>

--- a/app/templates/admin/objections.html
+++ b/app/templates/admin/objections.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Objections', url_for('admin.list_objections'))]) }}
-<h2 class="font-bold text-bp-blue mb-4">Amendment Objections</h2>
+<h1 class="font-bold text-bp-blue mb-4">Amendment Objections</h1>
 <table class="bp-table w-full">
   <thead>
     <tr><th>Amendment</th><th>Member</th><th>Date</th><th></th></tr>

--- a/app/templates/admin/role_form.html
+++ b/app/templates/admin/role_form.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Roles', url_for('admin.list_roles')), ('Edit Role' if role else 'Create Role', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if role else 'Create' }} Role</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if role else 'Create' }} Role</h1>
 <form method="post" class="bp-form bp-card space-y-6">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Roles', url_for('admin.list_roles'))]) }}
-<h2 class="font-bold text-bp-blue mb-4">Roles</h2>
+<h1 class="font-bold text-bp-blue mb-4">Roles</h1>
 <div class="bp-card">
 <table class="bp-table">
   <thead class="bg-bp-grey-50">

--- a/app/templates/admin/settings_form.html
+++ b/app/templates/admin/settings_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Settings', url_for('admin.manage_settings'))]) }}
 <div class="bp-card max-w-lg space-y-4">
-  <h2 class="font-bold text-bp-blue">Application Settings</h2>
+  <h1 class="font-bold text-bp-blue">Application Settings</h1>
   <form method="post">
     {{ form.hidden_tag() }}
     <div class="mb-4">

--- a/app/templates/admin/user_form.html
+++ b/app/templates/admin/user_form.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Users', url_for('admin.list_users')), ('Edit User' if user else 'Create User', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if user else 'Create' }} User</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if user else 'Create' }} User</h1>
 <form method="post" class="bp-form bp-card space-y-6">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Users', url_for('admin.list_users'))]) }}
-<h2 class="font-bold text-bp-blue mb-4">User Accounts</h2>
+<h1 class="font-bold text-bp-blue mb-4">User Accounts</h1>
 
 <form class="mb-4 bp-card bp-form" hx-get="{{ url_for('admin.list_users') }}" hx-target="#user-table-body" hx-trigger="keyup changed delay:300ms" hx-push-url="true">
   <label for="q" class="sr-only">Search users</label>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Admin Login</h2>
+<h1>Admin Login</h1>
 
 <form method="post" class="bp-form bp-card">
   <div>

--- a/app/templates/meetings/amendment_form.html
+++ b/app/templates/meetings/amendment_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% set label = 'Edit Amendment' if amendment else 'Add Amendment' %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (label, None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit Amendment' if amendment else 'Add Amendment' }}</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ 'Edit Amendment' if amendment else 'Add Amendment' }}</h1>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/meetings/import_members.html
+++ b/app/templates/meetings/import_members.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">Import Members</h2>
+<h1 class="font-bold text-bp-blue mb-4">Import Members</h1>
 <form method="post" enctype="multipart/form-data" class="bp-form bp-card space-y-6">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/meetings/manage_conflicts.html
+++ b/app/templates/meetings/manage_conflicts.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">{{ motion.title }} - Manage Conflicts</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ motion.title }} - Manage Conflicts</h1>
 <form method="post" class="bp-form bp-card space-y-4 mb-6">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Edit Meeting' if meeting else 'Create Meeting', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if meeting else 'Create' }} Meeting</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if meeting else 'Create' }} Meeting</h1>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/meetings/motion_form.html
+++ b/app/templates/meetings/motion_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% set label = 'Edit Motion' if motion else 'Create Motion' %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (label, None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">{{ 'Edit' if motion else 'Create' }} Motion</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if motion else 'Create' }} Motion</h1>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Motions</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Motions</h1>
 <div class="space-y-4">
   {% for m in motions %}
     <div class="bp-card">

--- a/app/templates/meetings/objection_form.html
+++ b/app/templates/meetings/objection_form.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Submit Objection', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">Submit Objection</h2>
+<h1 class="font-bold text-bp-blue mb-4">Submit Objection</h1>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}
   <div>

--- a/app/templates/meetings/prepare_stage2.html
+++ b/app/templates/meetings/prepare_stage2.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Finalise Motion Text</h2>
+<h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Finalise Motion Text</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 <form method="post" class="space-y-6">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Stage 1 Results</h2>
+<h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Stage 1 Results</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 <table class="bp-table w-full">
   <thead>

--- a/app/templates/meetings/view_motion.html
+++ b/app/templates/meetings/view_motion.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">{{ motion.title }}</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ motion.title }}</h1>
 <div class="bp-card bp-glow mb-4">{{ (motion.text_md or 'No motion text.')|markdown_to_html|safe }}</div>
 <h3 class="font-bold mb-2">Amendments</h3>
 <a href="{{ url_for('meetings.manage_conflicts', motion_id=motion.id) }}" class="bp-btn-secondary mb-4 inline-block">Manage Conflicts</a>

--- a/app/templates/meetings_list.html
+++ b/app/templates/meetings_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">Meetings</h2>
+<h1 class="font-bold text-bp-blue mb-4">Meetings</h1>
 
 <form class="mb-4 bp-card bp-form"
       hx-get="{{ url_for('meetings.list_meetings') }}"

--- a/app/templates/public_results.html
+++ b/app/templates/public_results.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-2">{{ meeting.title }} – Results</h2>
+<h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} – Results</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 <div class="space-y-8">
   <div class="bp-card">

--- a/app/templates/results_index.html
+++ b/app/templates/results_index.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">Results</h2>
+<h1 class="font-bold text-bp-blue mb-4">Results</h1>
 <div class="bp-card">
   <ul class="space-y-2">
     {% for meeting in meetings %}

--- a/app/templates/ro/dashboard.html
+++ b/app/templates/ro/dashboard.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">Returning Officer Dashboard</h2>
+<h1 class="font-bold text-bp-blue mb-4">Returning Officer Dashboard</h1>
 <div class="bp-card mb-4">
   <table class="bp-table">
     <thead class="bg-bp-grey-50">

--- a/app/templates/ro/tie_break_form.html
+++ b/app/templates/ro/tie_break_form.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Tie Breaks</h2>
+<h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Tie Breaks</h1>
 <form method="post" class="space-y-6">
   {{ form.hidden_tag() }}
   {% for amend in amendments %}

--- a/app/templates/voting/ballot.html
+++ b/app/templates/voting/ballot.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), ('Amendment Vote', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">Amendment Vote</h2>
+<h1 class="font-bold text-bp-blue mb-4">Amendment Vote</h1>
 <div class="bp-card mb-4">
   {{ amendment.text_md or 'No amendment text.' }}
 </div>

--- a/app/templates/voting/combined_ballot.html
+++ b/app/templates/voting/combined_ballot.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Combined', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">Combined Ballot</h2>
+<h1 class="font-bold text-bp-blue mb-4">Combined Ballot</h1>
 {% set current_stage = 1 %}
 {% include '_stepper.html' %}
 {% if proxy_for %}

--- a/app/templates/voting/runoff_ballot.html
+++ b/app/templates/voting/runoff_ballot.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Run-off', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">Run-off Vote</h2>
+<h1 class="font-bold text-bp-blue mb-4">Run-off Vote</h1>
 {% set current_stage = 1 %}
 {% include '_stepper.html' %}
 <div class="bp-alert-warning mb-4">These amendments conflict. Choose which one should proceed.</div>

--- a/app/templates/voting/stage1_ballot.html
+++ b/app/templates/voting/stage1_ballot.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Stage 1', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">Stage 1 – Amendment Votes</h2>
+<h1 class="font-bold text-bp-blue mb-4">Stage 1 – Amendment Votes</h1>
 {% set current_stage = 1 %}
 {% include '_stepper.html' %}
 {% if proxy_for %}

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Stage 2', None)]) }}
-<h2 class="font-bold text-bp-blue mb-4">Stage 2 – Vote on Motion</h2>
+<h1 class="font-bold text-bp-blue mb-4">Stage 2 – Vote on Motion</h1>
 {% set current_stage = 2 %}
 {% include '_stepper.html' %}
 {% if proxy_for %}


### PR DESCRIPTION
## Summary
- update templates to use `<h1>` as the top-level heading

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685060da45b8832b941297242d0b07ed