### PR TITLE
Add scope attributes to table headers

### DIFF
--- a/app/templates/admin/objections.html
+++ b/app/templates/admin/objections.html
@@ -5,7 +5,7 @@
 <h1 class="font-bold text-bp-blue mb-4">Amendment Objections</h1>
 <table class="bp-table w-full">
   <thead>
-    <tr><th>Amendment</th><th>Member</th><th>Date</th><th></th></tr>
+    <tr><th scope="col">Amendment</th><th scope="col">Member</th><th scope="col">Date</th><th scope="col"></th></tr>
   </thead>
   <tbody>
   {% for obj, amend, member in objections %}

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -7,8 +7,8 @@
 <table class="bp-table">
   <thead class="bg-bp-grey-50">
     <tr>
-      <th class="text-left p-2">Name</th>
-      <th class="text-left p-2">Permissions</th>
+      <th scope="col" class="text-left p-2">Name</th>
+      <th scope="col" class="text-left p-2">Permissions</th>
     </tr>
   </thead>
   <tbody>

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -13,11 +13,11 @@
 <table class="bp-table">
   <thead class="bg-bp-grey-50">
     <tr>
-      <th class="text-left p-2">
+      <th scope="col" class="text-left p-2">
         <a hx-get="{{ url_for('admin.list_users', sort='email', direction='desc' if direction=='asc' and sort=='email' else 'asc', q=q) }}" hx-target="#user-table-body" hx-push-url="true" class="hover:underline">Email</a>
       </th>
-      <th class="text-left p-2">Role</th>
-      <th class="text-left p-2">
+      <th scope="col" class="text-left p-2">Role</th>
+      <th scope="col" class="text-left p-2">
         <a hx-get="{{ url_for('admin.list_users', sort='created_at', direction='desc' if direction=='asc' and sort=='created_at' else 'asc', q=q) }}" hx-target="#user-table-body" hx-push-url="true" class="hover:underline">Created</a>
       </th>
     </tr>

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -5,11 +5,11 @@
 <table class="bp-table w-full">
   <thead>
     <tr>
-      <th>Amendment</th>
-      <th>For</th>
-      <th>Against</th>
-      <th>Abstain</th>
-      <th>Outcome</th>
+      <th scope="col">Amendment</th>
+      <th scope="col">For</th>
+      <th scope="col">Against</th>
+      <th scope="col">Abstain</th>
+      <th scope="col">Outcome</th>
     </tr>
   </thead>
   <tbody>

--- a/app/templates/meetings_list.html
+++ b/app/templates/meetings_list.html
@@ -15,15 +15,15 @@
   <table class="bp-table">
     <thead class="bg-bp-grey-50">
       <tr>
-        <th class="text-left p-2">
+        <th scope="col" class="text-left p-2">
           <a hx-get="{{ url_for('meetings.list_meetings', sort='title', direction='desc' if direction=='asc' and sort=='title' else 'asc', q=q) }}"
              hx-target="#meeting-table-body" hx-push-url="true" class="hover:underline">Title</a>
         </th>
-        <th class="text-left p-2">
+        <th scope="col" class="text-left p-2">
           <a hx-get="{{ url_for('meetings.list_meetings', sort='type', direction='desc' if direction=='asc' and sort=='type' else 'asc', q=q) }}"
              hx-target="#meeting-table-body" hx-push-url="true" class="hover:underline">Type</a>
         </th>
-        <th class="text-left p-2">
+        <th scope="col" class="text-left p-2">
           <a hx-get="{{ url_for('meetings.list_meetings', sort='status', direction='desc' if direction=='asc' and sort=='status' else 'asc', q=q) }}"
              hx-target="#meeting-table-body" hx-push-url="true" class="hover:underline">Status</a>
         </th>

--- a/app/templates/public_results.html
+++ b/app/templates/public_results.html
@@ -7,7 +7,7 @@
     <h3 class="font-semibold mb-2">Stage 1 Amendments</h3>
     <table class="bp-table w-full">
       <thead>
-        <tr><th>Amendment</th><th>For</th><th>Against</th><th>Abstain</th></tr>
+        <tr><th scope="col">Amendment</th><th scope="col">For</th><th scope="col">Against</th><th scope="col">Abstain</th></tr>
       </thead>
       <tbody>
         {% for amend, counts in stage1 %}
@@ -27,7 +27,7 @@
     <h3 class="font-semibold mb-2">Stage 2 Motions</h3>
     <table class="bp-table w-full">
       <thead>
-        <tr><th>Motion</th><th>For</th><th>Against</th><th>Abstain</th><th>Outcome</th></tr>
+        <tr><th scope="col">Motion</th><th scope="col">For</th><th scope="col">Against</th><th scope="col">Abstain</th><th scope="col">Outcome</th></tr>
       </thead>
       <tbody>
         {% for motion, counts in stage2 %}

--- a/app/templates/ro/dashboard.html
+++ b/app/templates/ro/dashboard.html
@@ -5,15 +5,15 @@
   <table class="bp-table">
     <thead class="bg-bp-grey-50">
       <tr>
-        <th class="p-2 text-left">Meeting</th>
-        <th class="p-2 text-left">Notice Date</th>
-        <th class="p-2 text-left">Stage 1 Votes</th>
-        <th class="p-2 text-left">Next Reminder</th>
-        <th class="p-2 text-left">Quorum %</th>
-        <th class="p-2 text-left">Time Remaining</th>
-        <th class="p-2 text-left">Stage 1 Locked</th>
-        <th class="p-2 text-left">Stage 2 Locked</th>
-        <th class="p-2 text-left">Actions</th>
+        <th scope="col" class="p-2 text-left">Meeting</th>
+        <th scope="col" class="p-2 text-left">Notice Date</th>
+        <th scope="col" class="p-2 text-left">Stage 1 Votes</th>
+        <th scope="col" class="p-2 text-left">Next Reminder</th>
+        <th scope="col" class="p-2 text-left">Quorum %</th>
+        <th scope="col" class="p-2 text-left">Time Remaining</th>
+        <th scope="col" class="p-2 text-left">Stage 1 Locked</th>
+        <th scope="col" class="p-2 text-left">Stage 2 Locked</th>
+        <th scope="col" class="p-2 text-left">Actions</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Summary
- improve accessibility by adding `scope="col"` to table header cells across templates
- ensure sorting links and other attributes remain intact

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850627ccc40832bb0b1d75b1cf42ad1