### PR TITLE
Fix checkmark SVG accessibility

### DIFF
--- a/app/templates/voting/confirmation.html
+++ b/app/templates/voting/confirmation.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="bp-card text-center space-y-4">
-    <svg class="w-16 h-16 mx-auto text-bp-red" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+    <svg class="w-16 h-16 mx-auto text-bp-red" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
     </svg>
     <p class="text-lg font-semibold">Vote recorded! You’ll get an e‑mail receipt shortly.</p>


### PR DESCRIPTION
## Summary
- ensure the checkmark icon in the voting confirmation page is hidden from screen readers

## Testing
- `pytest -q`
- `flask --app app run --port 5678` (started then stopped)

------
https://chatgpt.com/codex/tasks/task_b_685062d7a118832b9db67b2c520c8ac6