### PR TITLE
Fix login heading style

### DIFF
--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Admin Login</h1>
+<h2 class="text-2xl font-bold text-bp-blue">Admin Login</h2>
 
 <form method="post" class="bp-form bp-card">
   <div>


### PR DESCRIPTION
## Summary
- use consistent heading class on the login page

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685062adabfc832b8dc380d013c7e45f