### PR TITLE
Add meeting progress bars

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -138,6 +138,17 @@ class Meeting(db.Model):
         minutes = rem // 60
         return f"{hours}h {minutes}m"
 
+    def stage1_progress_percent(self) -> int:
+        """Return percentage of Stage-1 voting period elapsed."""
+        if not self.opens_at_stage1 or not self.closes_at_stage1:
+            return 0
+        total = (self.closes_at_stage1 - self.opens_at_stage1).total_seconds()
+        if total <= 0:
+            return 0
+        elapsed = (datetime.utcnow() - self.opens_at_stage1).total_seconds()
+        percent = max(0.0, min(100.0, (elapsed / total) * 100))
+        return int(percent)
+
 
 class Member(db.Model):
     __tablename__ = "members"
@@ -307,8 +318,8 @@ class AmendmentConflict(db.Model):
 class AmendmentMerge(db.Model):
     __tablename__ = "amendment_merges"
     id = db.Column(db.Integer, primary_key=True)
-    combined_id = db.Column(db.Integer, db.ForeignKey('amendments.id'))
-    source_id = db.Column(db.Integer, db.ForeignKey('amendments.id'))
+    combined_id = db.Column(db.Integer, db.ForeignKey("amendments.id"))
+    source_id = db.Column(db.Integer, db.ForeignKey("amendments.id"))
 
 
 class AmendmentObjection(db.Model):

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1114,3 +1114,23 @@ a:focus-visible {
 .bp-skip-link:focus {
   top: 0;
 }
+
+/* Progress bar component */
+.bp-progress {
+  width: 100%;
+  height: 0.5rem;
+  background-color: #F7F7F9; /* bp-grey-50 */
+  border-radius: 0.25rem;
+  overflow: hidden;
+}
+
+.bp-progress-bar {
+  height: 100%;
+  background-color: #002D59; /* bp-blue */
+}
+
+@media (max-width: 400px) {
+  .bp-progress {
+    height: 0.25rem;
+  }
+}

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -16,6 +16,10 @@
       Quorum: {{ '%.1f'|format(meeting.quorum_percentage()) }}% –
       Stage 1 closes in {{ meeting.stage1_time_remaining() }}
     </div>
+    <div class="bp-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ meeting.stage1_progress_percent() }}">
+      <div class="bp-progress-bar" style="width: {{ meeting.stage1_progress_percent() }}%"></div>
+      <span class="sr-only">{{ meeting.stage1_progress_percent() }}% complete</span>
+    </div>
     <h3 class="font-semibold mb-1">{{ meeting.title }}</h3>
     <p class="text-sm mb-1">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
     {% if meeting.status == 'Completed' %}

--- a/app/templates/ro/dashboard.html
+++ b/app/templates/ro/dashboard.html
@@ -55,6 +55,14 @@
           <a href="{{ url_for('ro.download_audit_log', meeting_id=meeting.id) }}" class="bp-btn-secondary text-sm">Audit</a>
         </td>
       </tr>
+      <tr>
+        <td colspan="9" class="p-2">
+          <div class="bp-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ meeting.stage1_progress_percent() }}">
+            <div class="bp-progress-bar" style="width: {{ meeting.stage1_progress_percent() }}%"></div>
+            <span class="sr-only">{{ meeting.stage1_progress_percent() }}% complete</span>
+          </div>
+        </td>
+      </tr>
       {% else %}
       <tr><td colspan="7" class="p-2">No meetings.</td></tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- show time remaining for Stage 1 with a progress bar on admin and RO dashboards
- implement `stage1_progress_percent` model helper
- style `.bp-progress` component

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850692e60d8832babd3da45b131cb7c