### PR TITLE
Add SVG icons for theme toggle

### DIFF
--- a/app/static/img/moon.svg
+++ b/app/static/img/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
+</svg>

--- a/app/static/img/sun.svg
+++ b/app/static/img/sun.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/>
+</svg>

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -31,18 +31,34 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const themeBtn = document.getElementById('theme-toggle');
+  const themeIcon = document.getElementById('theme-icon');
   const root = document.documentElement;
+
+  function updateThemeUI(theme) {
+    if (themeIcon) {
+      themeIcon.src =
+        theme === 'dark' ? themeIcon.dataset.sun : themeIcon.dataset.moon;
+    }
+    themeBtn.setAttribute(
+      'aria-label',
+      theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+    );
+  }
+
   if (themeBtn) {
     const saved = localStorage.getItem('theme');
-    if (saved) root.dataset.theme = saved;
+    if (saved) {
+      root.dataset.theme = saved;
+      updateThemeUI(saved);
+    } else {
+      updateThemeUI(root.dataset.theme || 'light');
+    }
+
     themeBtn.addEventListener('click', () => {
       const newTheme = root.dataset.theme === 'dark' ? 'light' : 'dark';
       root.dataset.theme = newTheme;
       localStorage.setItem('theme', newTheme);
-      themeBtn.setAttribute(
-        'aria-label',
-        newTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
-      );
+      updateThemeUI(newTheme);
     });
   }
 });

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -24,7 +24,15 @@
             &#9776;
           </button>
           <button id="theme-toggle" class="bp-nav-toggle" aria-label="Switch to dark mode">
-            <span aria-hidden="true">🌙</span>
+            <img
+              id="theme-icon"
+              src="{{ url_for('static', filename='img/moon.svg') }}"
+              data-moon="{{ url_for('static', filename='img/moon.svg') }}"
+              data-sun="{{ url_for('static', filename='img/sun.svg') }}"
+              class="h-5 w-5"
+              alt=""
+              aria-hidden="true"
+            >
           </button>
           <div id="nav-drawer" class="bp-nav-drawer" hidden>
             <ul class="bp-nav-items">

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -368,6 +368,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-16 – Added skip link for keyboard users and assigned id="main" to content container.
 * 2025-06-16 – Navigation drawer closes via Escape key for keyboard users.
 * 2025-06-16 – Increased default rate limit to 1000 per day.
+* 2025-06-18 – Added SVG icons for the theme toggle and updated navigation script.
 
 
 


### PR DESCRIPTION
## Summary
- replace emoji with sun/moon SVG icons
- swap icon and ARIA label depending on current theme
- log the update in the PRD changelog

## Testing
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_685069ce90dc832bbcacd67e8ae71bcb