### PR TITLE
Add ICS generation tests

### DIFF
--- a/tests/test_footer_template.py
+++ b/tests/test_footer_template.py
@@ -58,5 +58,5 @@ def test_theme_toggle_button_present():
                 assert '<button id="theme-toggle"' in html
                 assert 'class="bp-nav-toggle"' in html
                 assert 'aria-label="Switch to dark mode"' in html
-                assert '<span aria-hidden="true">🌙</span>' in html
+                assert 'id="theme-icon"' in html
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,3 +11,47 @@ def test_markdown_to_html_sanitizes_and_marks_safe():
     assert '<script>' not in html
     assert '<h1>' in html
     assert isinstance(html, Markup)
+from dataclasses import dataclass
+from datetime import datetime
+import pytest
+from app.utils import generate_stage_ics
+
+
+@dataclass
+class DummyMeeting:
+    title: str
+    opens_at_stage1: datetime | None = None
+    closes_at_stage1: datetime | None = None
+    opens_at_stage2: datetime | None = None
+    closes_at_stage2: datetime | None = None
+
+
+def test_generate_stage1_ics_contains_calendar_and_title():
+    meeting = DummyMeeting(
+        title="Test Meeting",
+        opens_at_stage1=datetime(2030, 1, 1, 9),
+        closes_at_stage1=datetime(2030, 1, 1, 10),
+    )
+    ics = generate_stage_ics(meeting, 1)
+    text = ics.decode()
+    assert "BEGIN:VCALENDAR" in text
+    assert "Test Meeting" in text
+
+
+def test_generate_stage2_ics_contains_calendar_and_title():
+    meeting = DummyMeeting(
+        title="Test Meeting",
+        opens_at_stage2=datetime(2030, 1, 2, 9),
+        closes_at_stage2=datetime(2030, 1, 2, 10),
+    )
+    ics = generate_stage_ics(meeting, 2)
+    text = ics.decode()
+    assert "BEGIN:VCALENDAR" in text
+    assert "Test Meeting" in text
+
+
+def test_generate_stage_ics_missing_timestamps_raises_error():
+    meeting = DummyMeeting(title="Broken")
+    with pytest.raises(ValueError):
+        generate_stage_ics(meeting, 2)
+


### PR DESCRIPTION
## Summary
- cover ICS utils with stage1 and stage2 tests
- update theme toggle test to match SVG-based markup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68506bd1ec48832b9e57353b07a9c440