### PR TITLE
Add docstring for permission decorator

### DIFF
--- a/app/permissions.py
+++ b/app/permissions.py
@@ -4,6 +4,10 @@ from flask_login import current_user
 
 
 def permission_required(permission_name):
+    """Return a decorator enforcing ``permission_name`` for a view.
+
+    Use as ``@permission_required('perm')`` above Flask view functions.
+    """
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
## Summary
- document `permission_required` with a concise docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `flask --app app run -p 5050` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68506bd93620832b85cce4e2d219f9b7