### PR TITLE
Replace Query.get usage

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -6,6 +6,7 @@ from flask import (
     url_for,
     flash,
     current_app,
+    abort,
 )
 import json
 from flask_login import login_required
@@ -39,7 +40,9 @@ def dashboard():
 @login_required
 @permission_required("manage_meetings")
 def toggle_public_results(meeting_id: int):
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     meeting.public_results = not meeting.public_results
     db.session.commit()
     return redirect(url_for("admin.dashboard"))
@@ -63,7 +66,9 @@ def list_objections():
 @login_required
 @permission_required("manage_meetings")
 def reinstate_amendment(amendment_id: int):
-    amendment = Amendment.query.get_or_404(amendment_id)
+    amendment = db.session.get(Amendment, amendment_id)
+    if amendment is None:
+        abort(404)
     count = AmendmentObjection.query.filter_by(amendment_id=amendment_id).count()
     total = Member.query.filter_by(meeting_id=amendment.meeting_id).count()
     threshold = max(25, int(total * 0.05))
@@ -145,7 +150,9 @@ def create_user():
 @login_required
 @permission_required("manage_users")
 def edit_user(user_id):
-    user = User.query.get_or_404(user_id)
+    user = db.session.get(User, user_id)
+    if user is None:
+        abort(404)
     form = UserForm(obj=user)
     form.role_id.choices = [(r.id, r.name) for r in Role.query.order_by(Role.name)]
     if form.validate_on_submit():
@@ -195,7 +202,9 @@ def create_role():
 @login_required
 @permission_required("manage_users")
 def edit_role(role_id):
-    role = Role.query.get_or_404(role_id)
+    role = db.session.get(Role, role_id)
+    if role is None:
+        abort(404)
     form = RoleForm(obj=role)
     form.permission_ids.choices = [
         (p.id, p.name) for p in Permission.query.order_by(Permission.name)

--- a/app/notifications/routes.py
+++ b/app/notifications/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, abort
 from ..models import UnsubscribeToken, Member
 from ..extensions import db
 
@@ -7,7 +7,9 @@ bp = Blueprint('notifications', __name__)
 @bp.route('/unsubscribe/<token>')
 def unsubscribe(token: str):
     token_obj = UnsubscribeToken.query.filter_by(token=token).first_or_404()
-    member = Member.query.get_or_404(token_obj.member_id)
+    member = db.session.get(Member, token_obj.member_id)
+    if member is None:
+        abort(404)
     member.email_opt_out = True
     db.session.commit()
     return render_template('notifications/unsubscribed.html', member=member)

--- a/app/ro/routes.py
+++ b/app/ro/routes.py
@@ -10,6 +10,7 @@ from flask import (
     Response,
     jsonify,
     flash,
+    abort,
 )
 from flask_login import login_required
 from flask_wtf import FlaskForm
@@ -49,7 +50,9 @@ def dashboard():
 @login_required
 @permission_required('manage_meetings')
 def lock_stage(meeting_id: int, stage: int):
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     if stage == 1:
         meeting.stage1_locked = True
     else:
@@ -62,7 +65,9 @@ def lock_stage(meeting_id: int, stage: int):
 @login_required
 @permission_required('manage_meetings')
 def unlock_stage(meeting_id: int, stage: int):
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     if stage == 1:
         meeting.stage1_locked = False
     else:
@@ -75,7 +80,9 @@ def unlock_stage(meeting_id: int, stage: int):
 @login_required
 @permission_required('manage_meetings')
 def download_tallies(meeting_id: int):
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     output = StringIO()
     writer = csv.writer(output)
     writer.writerow([
@@ -120,7 +127,9 @@ def download_tallies(meeting_id: int):
 @permission_required('manage_meetings')
 def download_tallies_json(meeting_id: int):
     """Return tallies for amendments and motions as JSON."""
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     rows: list[dict[str, int | str]] = []
     for amend in Amendment.query.filter_by(meeting_id=meeting.id).all():
         rows.append(
@@ -170,7 +179,9 @@ def _tie_break_form(amendments: list[Amendment]) -> FlaskForm:
 @login_required
 @permission_required('manage_meetings')
 def tie_breaks(meeting_id: int):
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     amends = []
     for a in Amendment.query.filter_by(meeting_id=meeting.id).order_by(Amendment.order).all():
         for_count = Vote.query.filter_by(amendment_id=a.id, choice='for').count()
@@ -196,7 +207,9 @@ def tie_breaks(meeting_id: int):
 @permission_required('manage_meetings')
 def download_stage2_tallies(meeting_id: int):
     """Return a CSV of Stage 2 motion tallies including outcome."""
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     output = StringIO()
     writer = csv.writer(output)
     writer.writerow(['id', 'title', 'for', 'against', 'abstain', 'outcome'])
@@ -226,7 +239,9 @@ def download_stage2_tallies(meeting_id: int):
 @permission_required('manage_meetings')
 def download_audit_log(meeting_id: int):
     """Return a CSV audit log of all votes for a meeting."""
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     output = StringIO()
     writer = csv.writer(output)
     writer.writerow(['member_id', 'amendment_id', 'motion_id', 'choice', 'hash'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -36,7 +36,9 @@ def _vote_counts(query):
 
 @bp.route('/results/<int:meeting_id>')
 def public_results(meeting_id: int):
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
     if not meeting.public_results:
         abort(404)
 

--- a/tests/test_meetings_routes.py
+++ b/tests/test_meetings_routes.py
@@ -713,7 +713,7 @@ def test_edit_and_delete_amendment():
             with patch("flask_login.utils._get_user", return_value=user):
                 meetings.edit_amendment(amend.id)
 
-        assert Amendment.query.get(amend.id).text_md == "changed"
+        assert db.session.get(Amendment, amend.id).text_md == "changed"
 
         with app.test_request_context(
             f"/meetings/amendments/{amend.id}/delete", method="POST"

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -47,7 +47,7 @@ def test_unsubscribe_route_marks_opt_out():
         client = app.test_client()
         resp = client.get(f'/unsubscribe/{token.token}')
         assert resp.status_code == 200
-        assert Member.query.get(1).email_opt_out is True
+        assert db.session.get(Member, 1).email_opt_out is True
 
 
 def test_email_not_sent_when_opted_out():

--- a/tests/test_ro_dashboard.py
+++ b/tests/test_ro_dashboard.py
@@ -254,9 +254,9 @@ def test_lock_and_unlock_stage_post():
         with app.test_request_context(f'/ro/{meeting.id}/lock/1', method='POST'):
             with patch('flask_login.utils._get_user', return_value=user):
                 ro.lock_stage(meeting.id, 1)
-        assert Meeting.query.get(meeting.id).stage1_locked is True
+        assert db.session.get(Meeting, meeting.id).stage1_locked is True
 
         with app.test_request_context(f'/ro/{meeting.id}/unlock/1', method='POST'):
             with patch('flask_login.utils._get_user', return_value=user):
                 ro.unlock_stage(meeting.id, 1)
-        assert Meeting.query.get(meeting.id).stage1_locked is False
+        assert db.session.get(Meeting, meeting.id).stage1_locked is False


### PR DESCRIPTION
## Summary
- update routes and tests to use `db.session.get`
- adjust failing queries to abort if no row exists

## Testing
- `pytest -q` *(fails: test_theme_toggle_button_present)*

------
https://chatgpt.com/codex/tasks/task_b_68506c00ba44832b90163fc8afd74baa