### PR TITLE
Add tooltip styles with dark mode support

### DIFF
--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -106,3 +106,15 @@
   background-color: #334155;
   color: #F7F7F9;
 }
+
+/* Tooltip dark mode */
+@media (prefers-color-scheme: dark) {
+  [data-tooltip]::after {
+    background-color: #334155;
+    color: #F7F7F9;
+  }
+}
+[data-theme="dark"] [data-tooltip]::after {
+  background-color: #334155;
+  color: #F7F7F9;
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1128,7 +1128,6 @@ a:focus-visible {
   top: 0;
 }
 
-<<<<<<< codex/implement-pagination-for-meetings-list
 /* Pagination component */
 .bp-pagination {
   display: flex;
@@ -1160,7 +1159,8 @@ a:focus-visible {
 .bp-pagination .bp-disabled {
   opacity: 0.5;
   pointer-events: none;
-=======
+}
+
 /* Progress bar component */
 .bp-progress {
   width: 100%;
@@ -1179,5 +1179,34 @@ a:focus-visible {
   .bp-progress {
     height: 0.25rem;
   }
->>>>>>> main
+}
+
+/* Tooltip styling */
+[data-tooltip] {
+  position: relative;
+  cursor: help;
+}
+
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 0.25rem);
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #002D59; /* bp-blue */
+  color: #FFFFFF;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem; /* 12px */
+  line-height: 1rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease-in-out;
+  z-index: 10;
+}
+
+[data-tooltip]:hover::after,
+[data-tooltip]:focus::after {
+  opacity: 1;
 }

--- a/app/templates/meetings_list.html
+++ b/app/templates/meetings_list.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="font-bold text-bp-blue mb-4">Meetings</h1>
+<h1 class="font-bold text-bp-blue mb-4">
+  Meetings
+  <span class="ml-1" tabindex="0" data-tooltip="List of active and past meetings">?</span>
+</h1>
 
 <form class="mb-4 bp-card bp-form"
       hx-get="{{ url_for('meetings.list_meetings') }}"

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -370,6 +370,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-16 – Increased default rate limit to 1000 per day.
 * 2025-06-18 – Added bp-pagination component and meeting list pagination.
 * 2025-06-18 – Added SVG icons for the theme toggle and updated navigation script.
+* 2025-06-19 – Implemented tooltip styles for `[data-tooltip]` elements and dark mode.
 
 
 

--- a/docs/ui-ux-design-guidance.md
+++ b/docs/ui-ux-design-guidance.md
@@ -266,7 +266,9 @@ IPF meet results portals – table designs for big numeric data.
 - **Progress bars** – `.bp-progress` uses ARIA roles and includes a `<span class="sr-only">% complete</span>` label.
 - **Tabs** – `.bp-tab` underlines the active tab; keep touch targets ≥ 44 px.
 - **Collapsible sections** – use `<details>` and `<summary>` styled with a bp-blue disclosure arrow.
-- **Tooltip** – `data-tooltip` attribute triggers a CSS-only bubble for short hints.
+- **Tooltip** – `[data-tooltip]` reveals a CSS-only bubble on hover **or focus**.
+  The element should be `position: relative`; the bubble text is generated with a
+  `::after` pseudo-element.
 - **Utility gaps** – `.bp-gap-xs` (4 px) to `.bp-gap-lg` (24 px) standardise spacing across components.
 
 


### PR DESCRIPTION
## Summary
- style `[data-tooltip]` elements with a pseudo-element bubble
- provide dark mode colours
- include tooltip example on meetings list page
- document tooltip usage in UI guidance
- note addition in PRD changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68506f96e458832baf8f5e64784fec33