### PR TITLE
Fix CSRF token usage

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -29,7 +29,7 @@
     {% endif %}
     <span class="bp-badge">Next reminder in {{ meeting.hours_until_next_reminder() }}h</span>
     <form action="{{ url_for('admin.toggle_public_results', meeting_id=meeting.id) }}" method="post" class="inline-block mt-2">
-      {{ csrf_token() }}
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <button type="submit" class="bp-btn-secondary text-sm">
         {{ 'Hide Results' if meeting.public_results else 'Show Results' }}
       </button>

--- a/app/templates/admin/objections.html
+++ b/app/templates/admin/objections.html
@@ -15,7 +15,7 @@
       <td class="p-2">{{ obj.created_at.strftime('%Y-%m-%d') }}</td>
       <td class="p-2">
         <form method="post" action="{{ url_for('admin.reinstate_amendment', amendment_id=amend.id) }}">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button class="bp-btn-secondary">Reinstate</button>
         </form>
       </td>

--- a/app/templates/admin/settings_form.html
+++ b/app/templates/admin/settings_form.html
@@ -19,7 +19,7 @@
       <div class="flex gap-2">
         {{ form.from_email(class='bp-input w-full') }}
         <form action="{{ url_for('admin.reset_setting', key='from_email') }}" method="post">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
         </form>
       </div>
@@ -29,7 +29,7 @@
       <div class="flex gap-2">
         {{ form.runoff_extension_minutes(class='bp-input w-full') }}
         <form action="{{ url_for('admin.reset_setting', key='runoff_extension_minutes') }}" method="post">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
         </form>
       </div>
@@ -39,7 +39,7 @@
       <div class="flex gap-2">
         {{ form.reminder_hours_before_close(class='bp-input w-full') }}
         <form action="{{ url_for('admin.reset_setting', key='reminder_hours_before_close') }}" method="post">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
         </form>
       </div>
@@ -49,7 +49,7 @@
       <div class="flex gap-2">
         {{ form.reminder_cooldown_hours(class='bp-input w-full') }}
         <form action="{{ url_for('admin.reset_setting', key='reminder_cooldown_hours') }}" method="post">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
         </form>
       </div>
@@ -59,7 +59,7 @@
       <div class="flex gap-2">
         {{ form.reminder_template(class='bp-input w-full') }}
         <form action="{{ url_for('admin.reset_setting', key='reminder_template') }}" method="post">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
         </form>
       </div>
@@ -69,7 +69,7 @@
       <div class="flex gap-2">
         {{ form.tie_break_decisions(class='bp-input w-full h-32') }}
         <form action="{{ url_for('admin.reset_setting', key='tie_break_decisions') }}" method="post">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
         </form>
       </div>
@@ -79,7 +79,7 @@
       <div class="flex gap-2">
         {{ form.clerical_text(class='bp-input w-full h-32') }}
         <form action="{{ url_for('admin.reset_setting', key='clerical_text') }}" method="post">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
         </form>
       </div>
@@ -89,7 +89,7 @@
       <div class="flex gap-2">
         {{ form.move_text(class='bp-input w-full h-32') }}
         <form action="{{ url_for('admin.reset_setting', key='move_text') }}" method="post">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
         </form>
       </div>

--- a/app/templates/comments/comments.html
+++ b/app/templates/comments/comments.html
@@ -5,7 +5,7 @@
     <div>{{ c.text_md|markdown_to_html|safe }}</div>
     {% if current_user.is_authenticated and current_user.has_permission('manage_meetings') and not c.hidden %}
     <form method="post" action="{{ url_for('comments.hide_comment', comment_id=c.id) }}" class="mt-2">
-      {{ csrf_token() }}
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <button class="bp-btn-secondary">Hide</button>
     </form>
     {% endif %}
@@ -27,7 +27,7 @@
   {% endif %}
 </nav>
 <form method="post" hx-post="{{ url_for('comments.' + ('add_motion_comment' if target[0]=='motion' else 'add_amendment_comment'), token=token, **{target[0]+'_id': target[1]}) }}" hx-target="closest div" hx-swap="outerHTML" class="bp-form space-y-2">
-  {{ csrf_token() }}
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
   <textarea name="text" class="border p-2 rounded w-full" required></textarea>
   {% set show_warn = comments|selectattr('member_id','equalto', g.member_id)|list|length == 0 %}
   {% if show_warn %}

--- a/app/templates/ro/dashboard.html
+++ b/app/templates/ro/dashboard.html
@@ -30,23 +30,23 @@
         <td class="p-2 space-x-2">
           {% if meeting.stage1_locked %}
             <form action="{{ url_for('ro.unlock_stage', meeting_id=meeting.id, stage=1) }}" method="post" class="inline">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <button type="submit" class="bp-btn-primary text-sm">Unlock S1</button>
             </form>
           {% else %}
             <form action="{{ url_for('ro.lock_stage', meeting_id=meeting.id, stage=1) }}" method="post" class="inline">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <button type="submit" class="bp-btn-primary text-sm">Lock S1</button>
             </form>
           {% endif %}
           {% if meeting.stage2_locked %}
             <form action="{{ url_for('ro.unlock_stage', meeting_id=meeting.id, stage=2) }}" method="post" class="inline">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <button type="submit" class="bp-btn-primary text-sm">Unlock S2</button>
             </form>
           {% else %}
             <form action="{{ url_for('ro.lock_stage', meeting_id=meeting.id, stage=2) }}" method="post" class="inline">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <button type="submit" class="bp-btn-primary text-sm">Lock S2</button>
             </form>
           {% endif %}


### PR DESCRIPTION
## Summary
- embed CSRF token as hidden input in various templates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685526556868832b91f3e9fe46830f34