### PR TITLE
Add auto-populated meeting dates from AGM input

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -105,6 +105,12 @@ def register_extensions(app):
             'cache_bust': int(datetime.now().timestamp()) if app.debug else '1'
         }
 
+    @app.context_processor
+    def inject_notice_days():
+        return {
+            'notice_days': app.config.get('NOTICE_PERIOD_DAYS', 14)
+        }
+
 
     @login_manager.user_loader
     def load_user(user_id: str) -> User | None:

--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -17,11 +17,31 @@ from wtforms.validators import DataRequired, Optional
 class MeetingForm(FlaskForm):
     title = StringField("Title", validators=[DataRequired()])
     type = SelectField("Type", choices=[("AGM", "AGM"), ("EGM", "EGM")])
-    notice_date = DateTimeLocalField("Notice Date", format="%Y-%m-%dT%H:%M")
-    opens_at_stage1 = DateTimeLocalField("Stage 1 Opens", format="%Y-%m-%dT%H:%M")
-    closes_at_stage1 = DateTimeLocalField("Stage 1 Closes", format="%Y-%m-%dT%H:%M")
-    opens_at_stage2 = DateTimeLocalField("Stage 2 Opens", format="%Y-%m-%dT%H:%M")
-    closes_at_stage2 = DateTimeLocalField("Stage 2 Closes", format="%Y-%m-%dT%H:%M")
+    notice_date = DateTimeLocalField(
+        "Notice Date",
+        format="%Y-%m-%dT%H:%M",
+        description="Must be at least 14 days before Stage 1 opens.",
+    )
+    opens_at_stage1 = DateTimeLocalField(
+        "Stage 1 Opens",
+        format="%Y-%m-%dT%H:%M",
+        description="At least 14 days after notice date.",
+    )
+    closes_at_stage1 = DateTimeLocalField(
+        "Stage 1 Closes",
+        format="%Y-%m-%dT%H:%M",
+        description="Must remain open for at least 7 days.",
+    )
+    opens_at_stage2 = DateTimeLocalField(
+        "Stage 2 Opens",
+        format="%Y-%m-%dT%H:%M",
+        description="At least 1 day after Stage 1 closes.",
+    )
+    closes_at_stage2 = DateTimeLocalField(
+        "AGM Date",
+        format="%Y-%m-%dT%H:%M",
+        description="Final voting deadline; at least 5 days after Stage 2 opens.",
+    )
     ballot_mode = SelectField(
         "Ballot Mode",
         choices=[

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -165,6 +165,18 @@ def _save_meeting(form: MeetingForm, meeting: Meeting | None = None) -> Meeting:
 @permission_required("manage_meetings")
 def create_meeting():
     form = MeetingForm()
+    notice_days = current_app.config.get("NOTICE_PERIOD_DAYS", 14)
+    form.notice_date.description = (
+        f"Must be at least {notice_days} days before Stage 1 opens."
+    )
+    form.opens_at_stage1.description = (
+        f"At least {notice_days} days after notice date."
+    )
+    form.closes_at_stage1.description = "Must remain open for at least 7 days."
+    form.opens_at_stage2.description = "At least 1 day after Stage 1 closes."
+    form.closes_at_stage2.description = (
+        "Final voting deadline; at least 5 days after Stage 2 opens."
+    )
     if form.validate_on_submit():
         _save_meeting(form)
         return redirect(url_for("meetings.list_meetings"))
@@ -179,6 +191,18 @@ def edit_meeting(meeting_id):
     if meeting is None:
         abort(404)
     form = MeetingForm(obj=meeting)
+    notice_days = current_app.config.get("NOTICE_PERIOD_DAYS", 14)
+    form.notice_date.description = (
+        f"Must be at least {notice_days} days before Stage 1 opens."
+    )
+    form.opens_at_stage1.description = (
+        f"At least {notice_days} days after notice date."
+    )
+    form.closes_at_stage1.description = "Must remain open for at least 7 days."
+    form.opens_at_stage2.description = "At least 1 day after Stage 1 closes."
+    form.closes_at_stage2.description = (
+        "Final voting deadline; at least 5 days after Stage 2 opens."
+    )
     if form.validate_on_submit():
         _save_meeting(form, meeting)
         return redirect(url_for("meetings.list_meetings"))

--- a/app/static/js/meeting_form.js
+++ b/app/static/js/meeting_form.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const noticeDays = parseInt(document.body.dataset.noticeDays || '14', 10);
+  const agmField = document.getElementById('closes_at_stage2');
+  if (!agmField) return;
+
+  const toLocal = (date) => {
+    const tz = date.getTimezoneOffset() * 60000;
+    return new Date(date.getTime() - tz).toISOString().slice(0, 16);
+  };
+
+  agmField.addEventListener('change', () => {
+    const base = new Date(agmField.value);
+    if (isNaN(base)) return;
+
+    const opens2 = document.getElementById('opens_at_stage2');
+    const closes1 = document.getElementById('closes_at_stage1');
+    const opens1 = document.getElementById('opens_at_stage1');
+    const notice = document.getElementById('notice_date');
+
+    if (opens2 && !opens2.value) {
+      const d = new Date(base);
+      d.setDate(d.getDate() - 5);
+      opens2.value = toLocal(d);
+    }
+
+    if (opens2 && closes1 && !closes1.value && opens2.value) {
+      const d = new Date(opens2.value);
+      d.setDate(d.getDate() - 1);
+      closes1.value = toLocal(d);
+    }
+
+    if (closes1 && opens1 && !opens1.value && closes1.value) {
+      const d = new Date(closes1.value);
+      d.setDate(d.getDate() - 7);
+      opens1.value = toLocal(d);
+    }
+
+    if (opens1 && notice && !notice.value && opens1.value) {
+      const d = new Date(opens1.value);
+      d.setDate(d.getDate() - noticeDays);
+      notice.value = toLocal(d);
+    }
+  });
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}?v={{ cache_bust }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/dark.css') }}?v={{ cache_bust }}">
   </head>
-  <body hx-boost="true" class="flex flex-col min-h-screen bg-gradient-to-b from-bp-grey-50 to-white font-sans">
+  <body hx-boost="true" class="flex flex-col min-h-screen bg-gradient-to-b from-bp-grey-50 to-white font-sans" data-notice-days="{{ notice_days }}">
     <a href="#main" class="bp-skip-link sr-only focus:not-sr-only">Skip to main content</a>
     <header>
       <nav class="bg-bp-blue text-white shadow-lg">

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -16,29 +16,34 @@
     <p id="{{ form.type.id }}-error" class="bp-error-text">{{ form.type.errors[0] if form.type.errors else '' }}</p>
   </div>
   <div>
+    {{ form.closes_at_stage2.label(class_='block font-semibold') }}
+    {{ form.closes_at_stage2(class_='border p-3 rounded w-full', **{'aria-describedby': form.closes_at_stage2.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.closes_at_stage2.description }}</p>
+    <p id="{{ form.closes_at_stage2.id }}-error" class="bp-error-text">{{ form.closes_at_stage2.errors[0] if form.closes_at_stage2.errors else '' }}</p>
+  </div>
+  <div>
     {{ form.notice_date.label(class_='block font-semibold') }}
     {{ form.notice_date(class_='border p-3 rounded w-full', **{'aria-describedby': form.notice_date.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.notice_date.description }}</p>
     <p id="{{ form.notice_date.id }}-error" class="bp-error-text">{{ form.notice_date.errors[0] if form.notice_date.errors else '' }}</p>
   </div>
   <div>
     {{ form.opens_at_stage1.label(class_='block font-semibold') }}
     {{ form.opens_at_stage1(class_='border p-3 rounded w-full', **{'aria-describedby': form.opens_at_stage1.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.opens_at_stage1.description }}</p>
     <p id="{{ form.opens_at_stage1.id }}-error" class="bp-error-text">{{ form.opens_at_stage1.errors[0] if form.opens_at_stage1.errors else '' }}</p>
   </div>
   <div>
     {{ form.closes_at_stage1.label(class_='block font-semibold') }}
     {{ form.closes_at_stage1(class_='border p-3 rounded w-full', **{'aria-describedby': form.closes_at_stage1.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.closes_at_stage1.description }}</p>
     <p id="{{ form.closes_at_stage1.id }}-error" class="bp-error-text">{{ form.closes_at_stage1.errors[0] if form.closes_at_stage1.errors else '' }}</p>
   </div>
   <div>
     {{ form.opens_at_stage2.label(class_='block font-semibold') }}
     {{ form.opens_at_stage2(class_='border p-3 rounded w-full', **{'aria-describedby': form.opens_at_stage2.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.opens_at_stage2.description }}</p>
     <p id="{{ form.opens_at_stage2.id }}-error" class="bp-error-text">{{ form.opens_at_stage2.errors[0] if form.opens_at_stage2.errors else '' }}</p>
-  </div>
-  <div>
-    {{ form.closes_at_stage2.label(class_='block font-semibold') }}
-    {{ form.closes_at_stage2(class_='border p-3 rounded w-full', **{'aria-describedby': form.closes_at_stage2.id + '-error'}) }}
-    <p id="{{ form.closes_at_stage2.id }}-error" class="bp-error-text">{{ form.closes_at_stage2.errors[0] if form.closes_at_stage2.errors else '' }}</p>
   </div>
   <div>
     {{ form.ballot_mode.label(class_='block font-semibold') }}
@@ -83,4 +88,5 @@
   </div>
   {% endif %}
 </form>
+<script src="{{ url_for('static', filename='js/meeting_form.js') }}"></script>
 {% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -375,6 +375,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-19 – Added public vote charts with JSON tallies endpoint.
 * 2025-06-19 – Implemented tooltip styles for `[data-tooltip]` elements and dark mode.
 * 2025-06-19 – Added discussion comments for motions and amendments with admin moderation.
+* 2025-06-20 – Meeting form auto-populates dates from AGM date with timing notes.
 
 
 ---


### PR DESCRIPTION
## Summary
- auto-fill meeting stage dates based on AGM date
- expose notice_days to templates via context processor
- show timing hints under date fields
- update UI scripts and docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 11 failed, 95 passed)*
- `timeout 5 flask --app app run -p 5155`

------
https://chatgpt.com/codex/tasks/task_b_6855549eb9ec832b8937d42e0792d742