### PR TITLE
Document generate-fake-data CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ To run the development server directly on your machine, install the requirements
 python -m flask --app app run
 ```
 
+### Generating demo data
+
+You can seed a fresh development database with example meetings and members using the
+`generate-fake-data` CLI command:
+
+```bash
+flask --app app generate-fake-data
+```
+
+This creates demo coordinator and returning officer accounts and inserts a sample meeting with motions,
+amendments and 30 random members. **Run it only on a local database** as it may conflict with real
+data and could trigger emails if your mail settings are active.
+
 ### Running tests
 
 Install the dependencies and execute:

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -377,6 +377,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-19 – Added discussion comments for motions and amendments with admin moderation.
 * 2025-06-20 – Added CLI command `generate-fake-data` to seed demo meetings and members.
 * 2025-06-20 – Meeting form auto-populates dates from AGM date with timing notes.
+* 2025-06-21 – Documented `generate-fake-data` CLI usage and cautions in README.
 
 
 ---


### PR DESCRIPTION
## Summary
- explain how to generate demo data with the CLI and add cautions
- record the documentation update in the PRD changelog

## Testing
- `python -m flask --app app db upgrade` *(fails: Multiple head revisions)*
- `python -m flask --app app run -p 5010` *(runs then terminated)*
- `docker-compose up --build` *(fails: command not found)*
- `pytest -q` *(fails: 11 failed, 95 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6855584f83cc832b93bc465da9566c9e