### PR TITLE
Fix admin dropdown z-index

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -501,7 +501,7 @@ nav {
   visibility: hidden;
   transform: translateY(-10px);
   transition: all var(--transition-fast);
-  z-index: 50;
+  z-index: 90;
 }
 
 .bp-dropdown:hover .bp-dropdown-menu,

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2123,7 +2123,7 @@ nav {
   visibility: hidden;
   transform: translateY(-10px);
   transition: all var(--transition-fast);
-  z-index: 50;
+  z-index: 90;
 }
 
 .bp-dropdown:hover .bp-dropdown-menu,

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -383,6 +383,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-20 – Fixed motion view page when amendment seconder is null.
 * 2025-06-20 – Motion creation form hides options unless "Multiple Choice" is selected and shows note about auto-added abstain.
 * 2025-06-20 – Added "Site Settings" to the user dropdown and linked the RO Dashboard in navigation.
+* 2025-06-21 – Increased z-index of admin dropdown so menu overlays main content.
 
 
 ---

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -30,7 +30,7 @@ def test_nav_shows_user_email_and_role():
             with patch('flask_login.utils._get_user', return_value=user):
                 html = render_template('base.html')
                 assert 'alice@example.com' in html
-                assert '<span class="bp-badge bp-badge-secondary">Admin</span>' in html
+                assert '<span class="bp-badge bp-badge-secondary text-xs">Admin</span>' in html
                 assert 'Dashboard' in html
                 assert 'Logout' in html
 


### PR DESCRIPTION
## Summary
- raise z-index for admin dropdown menu
- update changelog
- adjust navigation test for badge class

## Testing
- `npm run build:css`
- `pytest -q`
- `flask --app app run --port 5001`

------
https://chatgpt.com/codex/tasks/task_b_68556225c8ec832bbd9b9fe81516e08c