### PR TITLE
Implement tie-break decisions logic

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -386,6 +386,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-20 – Added "Site Settings" to the user dropdown and linked the RO Dashboard in navigation.
 * 2025-06-20 – Updated navigation test for role badge markup.
 * 2025-06-20 – Added clearer member import button with downloadable sample CSV.
+* 2025-06-21 – Tie-break decisions from settings now apply automatically when Stage 1 closes.
 
 
 ---


### PR DESCRIPTION
## Summary
- use `tie_break_decisions` setting when closing Stage 1
- test tie-break decisions via new unit test
- document automatic tie-break handling in PRD

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_runoff.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685573111d10832b913529f31d29ce09