### PR TITLE
Move login link from header to footer

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -28,6 +28,7 @@ from ..models import (
     MotionOption,
     Vote,
     Runoff,
+    AppSetting,
 )
 from ..services.email import (
     send_vote_invite,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -86,23 +86,18 @@
               </li>
               {% endif %}
             </ul>
-            {% if current_user.is_authenticated %}
-            <div class="flex items-center gap-2 ml-4">
-              <span class="text-white/80 text-sm">{{ current_user.email.split('@')[0] }}</span>
-              {% if current_user.role %}
-              <span class="bp-badge bp-badge-secondary">{{ current_user.role.name }}</span>
+              {% if current_user.is_authenticated %}
+              <div class="flex items-center gap-2 ml-4">
+                <span class="text-white/80 text-sm">{{ current_user.email.split('@')[0] }}</span>
+                {% if current_user.role %}
+                <span class="bp-badge bp-badge-secondary">{{ current_user.role.name }}</span>
+                {% endif %}
+                <a href="{{ url_for('auth.logout') }}" class="bp-btn-secondary text-sm py-1 px-3">
+                  <img src="{{ url_for('static', filename='icons/logout_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-1 w-4 h-4">
+                  Logout
+                </a>
+              </div>
               {% endif %}
-              <a href="{{ url_for('auth.logout') }}" class="bp-btn-secondary text-sm py-1 px-3">
-                <img src="{{ url_for('static', filename='icons/logout_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-1 w-4 h-4">
-                Logout
-              </a>
-            </div>
-            {% else %}
-            <a href="{{ url_for('auth.login') }}" class="bp-btn-secondary ml-4">
-              <img src="{{ url_for('static', filename='icons/input_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
-              Login
-            </a>
-            {% endif %}
           </div>
 
           <!-- Mobile Menu Toggle and Theme Toggle -->
@@ -194,13 +189,6 @@
               Logout
             </a>
           </li>
-          {% else %}
-          <li class="mt-4">
-            <a href="{{ url_for('auth.login') }}" class="bp-btn-secondary w-full">
-              <img src="{{ url_for('static', filename='icons/input_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
-              Login
-            </a>
-          </li>
           {% endif %}
         </ul>
       </div>
@@ -264,9 +252,12 @@
             <ul class="space-y-2 text-sm">
               <li><a href="{{ url_for('meetings.list_meetings') }}" class="hover:underline opacity-90 hover:opacity-100">View Meetings</a></li>
               <li><a href="{{ url_for('help.show_help') }}" class="hover:underline opacity-90 hover:opacity-100">Help & Documentation</a></li>
-              <li><a href="{{ url_for('main.results_index') }}" class="hover:underline opacity-90 hover:opacity-100">Results Archive</a></li>
-            </ul>
-          </div>
+                <li><a href="{{ url_for('main.results_index') }}" class="hover:underline opacity-90 hover:opacity-100">Results Archive</a></li>
+                {% if not current_user.is_authenticated %}
+                <li><a href="{{ url_for('auth.login') }}" class="hover:underline opacity-90 hover:opacity-100">Admin Login</a></li>
+                {% endif %}
+              </ul>
+            </div>
           <div>
             <h3 class="font-bold text-lg mb-3">Built with ❤️</h3>
             <p class="text-sm opacity-90">

--- a/tests/test_footer_template.py
+++ b/tests/test_footer_template.py
@@ -59,3 +59,33 @@ def test_theme_toggle_button_present():
                 assert 'aria-label="Switch to dark mode"' in html
                 assert 'id="theme-icon"' in html
 
+
+def test_footer_admin_login_link_for_anonymous():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        anon = AnonymousUserMixin()
+        with app.test_request_context('/'):
+            with patch('flask_login.utils._get_user', return_value=anon):
+                html = render_template('base.html')
+                assert 'Admin Login' in html
+                assert 'Logout' not in html
+
+
+def test_footer_no_admin_login_when_authenticated():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        from app.models import User, Role
+        role = Role(name='Admin')
+        db.session.add(role)
+        user = User(email='test@example.com', role=role)
+        user.is_active = True
+        db.session.add(user)
+        db.session.commit()
+        with app.test_request_context('/'):
+            with patch('flask_login.utils._get_user', return_value=user):
+                html = render_template('base.html')
+                assert 'Admin Login' not in html
+                assert 'Logout' in html
+


### PR DESCRIPTION
## Summary
- hide guest login buttons from the navigation bar
- provide admin login link in the footer
- import `AppSetting` in meetings routes
- test footer login link behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855b05aecc4832bb30d981ec0c7ce74