### PR TITLE
docs: link previously orphaned docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ The `docs` directory contains background and design material:
 - **original-british-powerlifting-voting-process-motion.md** – The full text of the motion modernising British Powerlifting's voting procedure which this app implements.
 - **template-motion.md** - A more readily adoptable motion template that membership organisations can revise and adopt to make their Articles support the VoteBuddy process.
 - **full-database-structure.md** – Quick reference describing all database tables and columns.
+- **app-settings-guidance.md** – When to store global values in the `app_settings` table.
+- **member-import.md** – Steps and CSV format for uploading members and issuing tokens.
+- **unit-test-strategy.md** – Fixtures and patterns for the tests under `tests/`.
 
 Refer to these files for detail on features, design and governance context.
 

--- a/assets/assets.md
+++ b/assets/assets.md
@@ -1,1 +1,0 @@
-for storing files


### PR DESCRIPTION
## Summary
- link additional docs from the README
- remove unused `assets/assets.md`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test_import_members_sends_invites_and_tokens, test_close_stage1_runoff_triggers_emails_and_tokens)*

------
https://chatgpt.com/codex/tasks/task_b_6855b0873dc4832b97b81aedd8a56324