### PR TITLE
Implement public meetings list with resend feature

### DIFF
--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -9,7 +9,7 @@ from wtforms import (
     IntegerField,
     TextAreaField,
 )
-from wtforms.validators import DataRequired, Email, Optional
+from wtforms.validators import DataRequired, Email, Optional, URL
 
 
 class UserForm(FlaskForm):
@@ -47,4 +47,5 @@ class SettingsForm(FlaskForm):
     clerical_text = TextAreaField("Clerical Amendment Text", validators=[Optional()])
     move_text = TextAreaField("Articles/Bylaws Placement Text", validators=[Optional()])
     manual_email_mode = BooleanField("Disable Automatic Emails")
+    contact_url = StringField("Contact URL", validators=[Optional(), URL()])
     submit = SubmitField("Save")

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -314,6 +314,10 @@ def manage_settings():
         form.move_text.data = AppSetting.get(
             "move_text", current_app.config.get("MOVE_TEXT")
         )
+        form.contact_url.data = AppSetting.get(
+            "contact_url",
+            "https://www.britishpowerlifting.org/contactus",
+        )
         form.manual_email_mode.data = AppSetting.get("manual_email_mode", "0") == "1"
     if form.validate_on_submit():
         AppSetting.set("site_title", form.site_title.data)
@@ -332,6 +336,10 @@ def manage_settings():
         AppSetting.set("tie_break_decisions", form.tie_break_decisions.data)
         AppSetting.set("clerical_text", form.clerical_text.data)
         AppSetting.set("move_text", form.move_text.data)
+        if form.contact_url.data:
+            AppSetting.set("contact_url", form.contact_url.data)
+        else:
+            AppSetting.delete("contact_url")
         AppSetting.set("manual_email_mode", "1" if form.manual_email_mode.data else "0")
         flash("Settings updated", "success")
         return redirect(url_for("admin.manage_settings"))

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -28,6 +28,7 @@ from ..models import (
     MotionOption,
     Vote,
     Runoff,
+    AppSetting,
 )
 from ..services.email import (
     send_vote_invite,
@@ -276,6 +277,7 @@ def import_members(meeting_id):
 
             member = Member(
                 meeting_id=meeting.id,
+                member_number=row.get("member_id"),
                 name=name,
                 email=email,
                 proxy_for=(row.get("proxy_for") or "").strip() or None,

--- a/app/models.py
+++ b/app/models.py
@@ -156,6 +156,7 @@ class Member(db.Model):
     __tablename__ = "members"
     id = db.Column(db.Integer, primary_key=True)
     meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
+    member_number = db.Column(db.String(50))
     name = db.Column(db.String(255))
     email = db.Column(db.String(255))
     proxy_for = db.Column(db.String(255))

--- a/app/templates/admin/settings_form.html
+++ b/app/templates/admin/settings_form.html
@@ -95,6 +95,10 @@
       </div>
     </div>
     <div class="mb-4">
+      {{ form.contact_url.label(class='block mb-1') }}
+      {{ form.contact_url(class='bp-input w-full') }}
+    </div>
+    <div class="mb-4">
       {{ form.manual_email_mode() }} {{ form.manual_email_mode.label }}
     </div>
     {{ form.submit(class='bp-btn-primary') }}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,9 +26,9 @@
             <ul class="bp-nav-items">
               <li>
                 <a
-                  href="{{ url_for('meetings.list_meetings') }}"
-                  class="bp-nav-link{% if request.path == url_for('meetings.list_meetings') %} active{% endif %}"
-                  {% if request.path == url_for('meetings.list_meetings') %}aria-current="page"{% endif %}
+                  href="{{ current_user.is_authenticated and current_user.has_permission('manage_meetings') and url_for('meetings.list_meetings') or url_for('main.public_meetings') }}"
+                  class="bp-nav-link{% if request.path == url_for('meetings.list_meetings') or request.path == url_for('main.public_meetings') %} active{% endif %}"
+                  {% if request.path == url_for('meetings.list_meetings') or request.path == url_for('main.public_meetings') %}aria-current="page"{% endif %}
                 >
                   <img src="{{ url_for('static', filename='icons/calendar_today_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
                   Meetings
@@ -135,9 +135,9 @@
         <ul class="bp-nav-items">
           <li>
             <a
-              href="{{ url_for('meetings.list_meetings') }}"
-              class="bp-nav-link text-white{% if request.path == url_for('meetings.list_meetings') %} active{% endif %}"
-              {% if request.path == url_for('meetings.list_meetings') %}aria-current="page"{% endif %}
+              href="{{ current_user.is_authenticated and current_user.has_permission('manage_meetings') and url_for('meetings.list_meetings') or url_for('main.public_meetings') }}"
+              class="bp-nav-link text-white{% if request.path == url_for('meetings.list_meetings') or request.path == url_for('main.public_meetings') %} active{% endif %}"
+              {% if request.path == url_for('meetings.list_meetings') or request.path == url_for('main.public_meetings') %}aria-current="page"{% endif %}
             >
               <img src="{{ url_for('static', filename='icons/calendar_today_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
               Meetings
@@ -262,7 +262,7 @@
           <div>
             <h3 class="font-bold text-lg mb-3">Quick Links</h3>
             <ul class="space-y-2 text-sm">
-              <li><a href="{{ url_for('meetings.list_meetings') }}" class="hover:underline opacity-90 hover:opacity-100">View Meetings</a></li>
+              <li><a href="{{ current_user.is_authenticated and current_user.has_permission('manage_meetings') and url_for('meetings.list_meetings') or url_for('main.public_meetings') }}" class="hover:underline opacity-90 hover:opacity-100">View Meetings</a></li>
               <li><a href="{{ url_for('help.show_help') }}" class="hover:underline opacity-90 hover:opacity-100">Help & Documentation</a></li>
               <li><a href="{{ url_for('main.results_index') }}" class="hover:underline opacity-90 hover:opacity-100">Results Archive</a></li>
             </ul>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,7 +9,7 @@
       <img src="{{ url_for('static', filename='icons/key_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon w-5 h-5">
       <span>Admin Login</span>
     </a>
-    <a href="{{ url_for('meetings.list_meetings') }}" class="bp-btn-secondary bp-btn-icon">
+    <a href="{{ current_user.is_authenticated and current_user.has_permission('manage_meetings') and url_for('meetings.list_meetings') or url_for('main.public_meetings') }}" class="bp-btn-secondary bp-btn-icon">
       <img src="{{ url_for('static', filename='icons/calendar_today_30dp_000000_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon w-5 h-5">
       <span>View Meetings</span>
     </a>

--- a/app/templates/public_meeting.html
+++ b/app/templates/public_meeting.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }}</h1>
+<p class="mb-4">Stage: {{ meeting.status or 'Draft' }} | Members: {{ member_count }}</p>
+<button class="bp-btn-secondary mb-4" data-modal-target="resend-modal">Resend Voting Email</button>
+<dialog id="resend-modal" class="bp-card w-full max-w-md" role="dialog" aria-labelledby="resend-title">
+  <h2 id="resend-title" class="font-bold mb-2">Request Voting Email</h2>
+  <div id="resend-modal-content" hx-target="this" hx-swap="outerHTML">
+    {% include 'resend_modal_content.html' %}
+  </div>
+  <button class="bp-btn-secondary mt-4" data-close-modal>Close</button>
+</dialog>
+{% endblock %}

--- a/app/templates/public_meetings.html
+++ b/app/templates/public_meetings.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="font-bold text-bp-blue mb-4">Meetings</h1>
+<div class="bp-card">
+  <ul class="space-y-2">
+  {% for meeting in meetings %}
+    <li>
+      <a href="{{ url_for('main.public_meeting_detail', meeting_id=meeting.id) }}" class="text-bp-blue hover:underline">{{ meeting.title }}</a>
+      <span class="ml-2 text-sm">{{ meeting.status or 'Draft' }}</span>
+      <span class="ml-2 text-sm">{{ member_counts[meeting.id] }} members</span>
+    </li>
+  {% else %}
+    <li>No meetings available.</li>
+  {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/app/templates/resend_modal_content.html
+++ b/app/templates/resend_modal_content.html
@@ -1,0 +1,18 @@
+{% if message %}
+  <p class="mb-2">{{ message }}</p>
+  {% if not success %}
+  <p class="text-sm">Need help? <a href="{{ contact_url }}" class="bp-link">Contact BP</a></p>
+  {% endif %}
+{% else %}
+  <form hx-post="{{ url_for('main.resend_meeting_link_public', meeting_id=meeting.id) }}" class="bp-form space-y-4">
+    <div class="bp-form-group">
+      <input id="member_number" name="member_number" class="bp-input" required>
+      <label for="member_number" class="bp-form-label">Member Number</label>
+    </div>
+    <div class="bp-form-group">
+      <input id="email" name="email" type="email" class="bp-input" required>
+      <label for="email" class="bp-form-label">Email</label>
+    </div>
+    <button type="submit" class="bp-btn-primary">Send Email</button>
+  </form>
+{% endif %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -396,6 +396,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-20 – Added moderator control to toggle member commenting rights.
 * 2025-06-21 – Removed unused `VoteForm` class and cleaned up voting routes.
 * 2025-06-21 – Tie-break decisions from settings now apply automatically when Stage 1 closes.
+* 2025-06-22 – Added public meetings pages with resend link modal and contact URL setting.
 
 ---
 

--- a/migrations/versions/ghijkl_add_member_number.py
+++ b/migrations/versions/ghijkl_add_member_number.py
@@ -1,0 +1,23 @@
+"""add member number to members
+
+Revision ID: ghijkl
+Revises: fed1234
+Create Date: 2025-06-22 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'ghijkl'
+down_revision = 'fed1234'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('members', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('member_number', sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('members', schema=None) as batch_op:
+        batch_op.drop_column('member_number')

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -52,10 +52,10 @@ def test_nav_highlights_current_page():
     with app.app_context():
         db.create_all()
         anon = AnonymousUserMixin()
-        with app.test_request_context('/meetings/'):
+        with app.test_request_context('/public/meetings'):
             with patch('flask_login.utils._get_user', return_value=anon):
                 html = render_template('base.html')
-                assert re.search(r'<a[^>]*href="/meetings/"[^>]*aria-current="page"', html)
+                assert re.search(r'<a[^>]*href="/public/meetings"[^>]*aria-current="page"', html)
 
 
 def test_nav_includes_site_settings_when_authorized():

--- a/tests/test_public_meetings.py
+++ b/tests/test_public_meetings.py
@@ -1,0 +1,42 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from unittest.mock import patch
+from flask import render_template, url_for
+from flask_login import AnonymousUserMixin
+from app import create_app
+from app.extensions import db
+from app.models import Meeting, Member
+from app import routes as main
+
+
+def _setup_app():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['TOKEN_SALT'] = 's'
+    return app
+
+
+def test_public_meetings_list_renders():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        m = Meeting(title='AGM', status='Stage 1')
+        db.session.add(m)
+        db.session.commit()
+        with app.test_request_context('/public/meetings'):
+            html = main.public_meetings()
+            assert 'AGM' in html
+
+
+def test_nav_uses_public_link_when_anonymous():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        anon = AnonymousUserMixin()
+        with app.test_request_context('/'):
+            with patch('flask_login.utils._get_user', return_value=anon):
+                html = render_template('base.html')
+                href = url_for('main.public_meetings')
+                assert href in html


### PR DESCRIPTION
## Summary
- add `member_number` field to Member model
- include `member_number` on CSV import
- create public meetings list and detail views
- allow members to request voting links via modal form
- link to new public pages from navigation and footer
- add contact URL setting to admin settings
- document changes in PRD
- new tests for navigation and public meetings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855afddf554832b965ebcf05c839220