### PR TITLE
Add rate limit test for resend form

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -398,6 +398,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-21 – Tie-break decisions from settings now apply automatically when Stage 1 closes.
 * 2025-06-22 – Added Markdown preview for clerical and move text settings.
 * 2025-06-22 – Added public meetings pages with resend link modal and contact URL setting.
+* 2025-06-23 – Rate limited public resend link form to prevent abuse.
 
 ---
 

--- a/tests/test_resend_rate_limit.py
+++ b/tests/test_resend_rate_limit.py
@@ -1,0 +1,43 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+from app.extensions import db
+from app.models import Meeting, Member
+
+
+def _setup_app():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['MAIL_SUPPRESS_SEND'] = True
+    app.config['MAIL_DEFAULT_SENDER'] = 'noreply@example.com'
+    app.config['TOKEN_SALT'] = 's'
+    app.extensions['mail'].suppress = True
+    app.extensions['mail'].default_sender = 'noreply@example.com'
+    return app
+
+
+def test_public_resend_is_rate_limited():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM', status='Stage 1')
+        db.session.add(meeting)
+        db.session.flush()
+        member = Member(
+            meeting_id=meeting.id,
+            name='Alice',
+            email='alice@example.com',
+            member_number='123',
+        )
+        db.session.add(member)
+        db.session.commit()
+
+        client = app.test_client()
+        data = {'email': member.email, 'member_number': '123'}
+        for _ in range(5):
+            resp = client.post(f'/public/meetings/{meeting.id}/resend', data=data)
+            assert resp.status_code == 200
+        resp = client.post(f'/public/meetings/{meeting.id}/resend', data=data)
+        assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- test rate limiting for public resend link form
- document rate limiting in PRD

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6855b5b62424832b91b9c0c857011a9c