### PR TITLE
Add Stage-1 summary to Stage 2 invites and ballot

### DIFF
--- a/app/templates/email/stage2_invite.html
+++ b/app/templates/email/stage2_invite.html
@@ -8,6 +8,13 @@
     <td style="padding:24px;background-color:#FFFFFF;">
       <p>Hello {{ member.name }},</p>
       <p>Stage 2 voting for <strong>{{ meeting.title }}</strong> is now open.</p>
+      {% if summary %}
+      <div style="border:1px solid #F7F7F9;border-radius:16px;padding:12px;margin:16px 0;">
+        {{ summary|markdown_to_html|safe }}
+      </div>
+      {% elif results_link %}
+      <p>See Stage&nbsp;1 results: <a href="{{ results_link }}">{{ results_link }}</a></p>
+      {% endif %}
       {% if test_mode %}
       <p style="color:#DC0714;"><strong>TEST MODE:</strong> votes cast using this link will be recorded as test data.</p>
       {% endif %}

--- a/app/templates/email/stage2_invite.txt
+++ b/app/templates/email/stage2_invite.txt
@@ -4,6 +4,15 @@ Hello {{ member.name }},
 {% endif %}
 
 Stage 2 voting for {{ meeting.title }} is now open.
+{% if summary %}
+
+{{ summary }}
+
+{% elif results_link %}
+
+See Stage 1 results: {{ results_link }}
+
+{% endif %}
 Use the link below to cast your ballot:
 
 {{ link }}

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -5,6 +5,11 @@
 <h1 class="font-bold text-bp-blue mb-4">Stage 2 – Vote on Motion</h1>
 {% set current_stage = 2 %}
 {% include '_stepper.html' %}
+{% if carried_summary %}
+<div class="bp-card mb-4">{{ carried_summary|markdown_to_html|safe }}</div>
+{% elif results_link %}
+<div class="bp-card mb-4"><a href="{{ results_link }}" class="bp-link">View Stage 1 results summary</a></div>
+{% endif %}
 {% if preview %}
 <div class="bp-alert-info text-center mb-4">Preview mode – votes will not be saved.</div>
 {% endif %}

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from flask import Blueprint, render_template, current_app, abort
+from flask import Blueprint, render_template, current_app, abort, url_for
 
 from ..extensions import db
 from ..models import (
@@ -17,6 +17,7 @@ from flask_wtf import FlaskForm
 from wtforms import RadioField, SubmitField, StringField
 from wtforms.validators import DataRequired
 from app.services.email import send_vote_receipt
+from ..utils import carried_amendment_summary
 from ..extensions import limiter
 
 bp = Blueprint("voting", __name__, url_prefix="/vote")
@@ -318,6 +319,8 @@ def ballot_token(token: str):
             m.id: Comment.query.filter_by(motion_id=m.id, hidden=False).count()
             for m in motions
         }
+        carried_summary = carried_amendment_summary(meeting)
+        results_link = None if carried_summary else url_for('main.public_results', meeting_id=meeting.id)
         return render_template(
             "voting/stage2_ballot.html",
             form=form,
@@ -326,6 +329,8 @@ def ballot_token(token: str):
             proxy_for=proxy_member,
             token=token,
             motion_counts=motion_counts,
+            carried_summary=carried_summary,
+            results_link=results_link,
         )
 
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -102,6 +102,7 @@ def test_send_stage2_invite_has_calendar_attachment():
                 mock_send.assert_called_once()
                 sent_msg = mock_send.call_args[0][0]
                 assert any(a.filename == 'stage2.ics' for a in sent_msg.attachments)
+                assert '/results/' in sent_msg.body
 
 
 def test_send_vote_receipt_includes_hash():

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -453,6 +453,69 @@ def test_stage2_ballot_uses_final_text():
             assert "Merged" in html
 
 
+def test_stage2_ballot_includes_carried_summary():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM")
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(
+            meeting_id=meeting.id,
+            title="M1",
+            text_md="Text",
+            category="motion",
+            threshold="normal",
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+        db.session.add(
+            Amendment(
+                meeting_id=meeting.id,
+                motion_id=motion.id,
+                text_md="Add something important",
+                order=1,
+                status="carried",
+            )
+        )
+        member = Member(meeting_id=meeting.id, name="A", email="a@e.co")
+        db.session.add(member)
+        db.session.flush()
+        token_obj, plain = VoteToken.create(member_id=member.id, stage=2, salt=app.config["TOKEN_SALT"])
+        db.session.commit()
+        with app.test_request_context(f"/vote/{plain}"):
+            html = voting.ballot_token(plain)
+            assert "Add something important" in html
+
+
+def test_stage2_ballot_links_results_when_no_summary():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM", public_results=True)
+        db.session.add(meeting)
+        db.session.flush()
+        motion = Motion(
+            meeting_id=meeting.id,
+            title="M1",
+            text_md="Text",
+            category="motion",
+            threshold="normal",
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name="A", email="a@e.co")
+        db.session.add(member)
+        db.session.flush()
+        token_obj, plain = VoteToken.create(member_id=member.id, stage=2, salt=app.config["TOKEN_SALT"])
+        db.session.commit()
+        with app.test_request_context(f"/vote/{plain}"):
+            html = voting.ballot_token(plain)
+            assert "/results/" in html
+
+
 def test_multiple_choice_motion_vote_and_receipt():
     app = _setup_app()
     with app.app_context():


### PR DESCRIPTION
## Summary
- show carried amendment summary via new `carried_amendment_summary` util
- include summary or results link in Stage‑2 invite emails
- display carried amendments or results link at the top of Stage‑2 ballot
- test new functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855b7a94980832ba1787ac6b3c43bfc