### PR TITLE
Add runoff closing helper and route

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1139,6 +1139,21 @@ def stage2_ics(meeting_id: int):
     )
 
 
+@bp.route("/<int:meeting_id>/close-runoff", methods=["POST"])
+@login_required
+@permission_required("manage_meetings")
+def close_runoff(meeting_id: int):
+    """Finalize run-off results and move meeting to Pending Stage 2."""
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
+    runoff.close_runoff_stage(meeting)
+    meeting.status = "Pending Stage 2"
+    db.session.commit()
+    flash("Run-off votes tallied", "success")
+    return redirect(url_for("meetings.results_summary", meeting_id=meeting.id))
+
+
 @bp.route("/<int:meeting_id>/close-stage2", methods=["POST"])
 @login_required
 @permission_required("manage_meetings")

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -399,6 +399,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-22 – Added Markdown preview for clerical and move text settings.
 * 2025-06-22 – Added public meetings pages with resend link modal and contact URL setting.
 * 2025-06-23 – Rate limited public resend link form to prevent abuse.
+* 2025-06-24 – Added run-off closing helper and route clearing tokens.
 
 ---
 


### PR DESCRIPTION
## Summary
- tally run-off votes with new `close_runoff_stage` service
- expose `/meetings/<id>/close-runoff` route
- test runoff close logic and update docs

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6855b7b693b8832bbd0d899192d7d714