### PR TITLE
Update vote hash to include item and stage

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -139,6 +139,7 @@ def generate_fake_data() -> None:
                 amendment_id=amend.id,
                 choice=random.choice(choices),
                 salt=current_app.config["VOTE_SALT"],
+                stage=1,
             )
         for motion in motions:
             Vote.record(
@@ -146,6 +147,7 @@ def generate_fake_data() -> None:
                 motion_id=motion.id,
                 choice=random.choice(choices),
                 salt=current_app.config["VOTE_SALT"],
+                stage=2,
             )
         t1 = VoteToken.query.filter_by(member_id=member.id, stage=1).first()
         t2 = VoteToken.query.filter_by(member_id=member.id, stage=2).first()

--- a/app/models.py
+++ b/app/models.py
@@ -266,10 +266,14 @@ class Vote(db.Model):
         salt: str,
         amendment_id: int | None = None,
         motion_id: int | None = None,
+        stage: int | None = None,
         is_test: bool = False,
     ) -> "Vote":
         """Create a vote with hashed choice."""
-        digest = hashlib.sha256(f"{member_id}{choice}{salt}".encode()).hexdigest()
+        target_id = amendment_id if amendment_id is not None else motion_id or ""
+        stage_val = stage if stage is not None else ""
+        digest_source = f"{member_id}{target_id}{stage_val}{choice}{salt}"
+        digest = hashlib.sha256(digest_source.encode()).hexdigest()
         vote = cls(
             member_id=member_id,
             amendment_id=amendment_id,

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -170,6 +170,7 @@ def ballot_token(token: str):
                     amendment_id=amend.id,
                     choice=choice,
                     salt=current_app.config["VOTE_SALT"],
+                    stage=vote_token.stage,
                 )
                 hashes.append(vote.hash)
                 if proxy_member:
@@ -178,6 +179,7 @@ def ballot_token(token: str):
                         amendment_id=amend.id,
                         choice=choice,
                         salt=current_app.config["VOTE_SALT"],
+                        stage=vote_token.stage,
                     )
             for motion in motions:
                 choice = form[f"motion_{motion.id}"].data
@@ -186,6 +188,7 @@ def ballot_token(token: str):
                     motion_id=motion.id,
                     choice=choice,
                     salt=current_app.config["VOTE_SALT"],
+                    stage=vote_token.stage,
                 )
                 hashes.append(vote.hash)
                 if proxy_member:
@@ -194,6 +197,7 @@ def ballot_token(token: str):
                         motion_id=motion.id,
                         choice=choice,
                         salt=current_app.config["VOTE_SALT"],
+                        stage=vote_token.stage,
                     )
             vote_token.used_at = datetime.utcnow()
             db.session.commit()
@@ -244,6 +248,7 @@ def ballot_token(token: str):
                     amendment_id=amend.id,
                     choice=choice,
                     salt=current_app.config["VOTE_SALT"],
+                    stage=vote_token.stage,
                 )
                 hashes.append(vote.hash)
                 if proxy_member:
@@ -252,6 +257,7 @@ def ballot_token(token: str):
                         amendment_id=amend.id,
                         choice=choice,
                         salt=current_app.config["VOTE_SALT"],
+                        stage=vote_token.stage,
                     )
             vote_token.used_at = datetime.utcnow()
             db.session.commit()
@@ -297,6 +303,7 @@ def ballot_token(token: str):
                     motion_id=motion.id,
                     choice=choice,
                     salt=current_app.config["VOTE_SALT"],
+                    stage=vote_token.stage,
                 )
                 hashes.append(vote.hash)
                 if proxy_member:
@@ -305,6 +312,7 @@ def ballot_token(token: str):
                         motion_id=motion.id,
                         choice=choice,
                         salt=current_app.config["VOTE_SALT"],
+                        stage=vote_token.stage,
                     )
             vote_token.used_at = datetime.utcnow()
             db.session.commit()
@@ -386,26 +394,26 @@ def runoff_ballot(token: str):
             a_id = r.amendment_a_id
             b_id = r.amendment_b_id
             if choice == "a":
-                v1 = Vote.record(member_id=member.id, amendment_id=a_id, choice="for", salt=current_app.config["VOTE_SALT"])
-                v2 = Vote.record(member_id=member.id, amendment_id=b_id, choice="against", salt=current_app.config["VOTE_SALT"])
+                v1 = Vote.record(member_id=member.id, amendment_id=a_id, choice="for", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
+                v2 = Vote.record(member_id=member.id, amendment_id=b_id, choice="against", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
                 hashes.extend([v1.hash, v2.hash])
                 if proxy_member:
-                    Vote.record(member_id=proxy_member.id, amendment_id=a_id, choice="for", salt=current_app.config["VOTE_SALT"])
-                    Vote.record(member_id=proxy_member.id, amendment_id=b_id, choice="against", salt=current_app.config["VOTE_SALT"])
+                    Vote.record(member_id=proxy_member.id, amendment_id=a_id, choice="for", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
+                    Vote.record(member_id=proxy_member.id, amendment_id=b_id, choice="against", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
             elif choice == "b":
-                v1 = Vote.record(member_id=member.id, amendment_id=a_id, choice="against", salt=current_app.config["VOTE_SALT"])
-                v2 = Vote.record(member_id=member.id, amendment_id=b_id, choice="for", salt=current_app.config["VOTE_SALT"])
+                v1 = Vote.record(member_id=member.id, amendment_id=a_id, choice="against", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
+                v2 = Vote.record(member_id=member.id, amendment_id=b_id, choice="for", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
                 hashes.extend([v1.hash, v2.hash])
                 if proxy_member:
-                    Vote.record(member_id=proxy_member.id, amendment_id=a_id, choice="against", salt=current_app.config["VOTE_SALT"])
-                    Vote.record(member_id=proxy_member.id, amendment_id=b_id, choice="for", salt=current_app.config["VOTE_SALT"])
+                    Vote.record(member_id=proxy_member.id, amendment_id=a_id, choice="against", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
+                    Vote.record(member_id=proxy_member.id, amendment_id=b_id, choice="for", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
             else:
-                v1 = Vote.record(member_id=member.id, amendment_id=a_id, choice="abstain", salt=current_app.config["VOTE_SALT"])
-                v2 = Vote.record(member_id=member.id, amendment_id=b_id, choice="abstain", salt=current_app.config["VOTE_SALT"])
+                v1 = Vote.record(member_id=member.id, amendment_id=a_id, choice="abstain", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
+                v2 = Vote.record(member_id=member.id, amendment_id=b_id, choice="abstain", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
                 hashes.extend([v1.hash, v2.hash])
                 if proxy_member:
-                    Vote.record(member_id=proxy_member.id, amendment_id=a_id, choice="abstain", salt=current_app.config["VOTE_SALT"])
-                    Vote.record(member_id=proxy_member.id, amendment_id=b_id, choice="abstain", salt=current_app.config["VOTE_SALT"])
+                    Vote.record(member_id=proxy_member.id, amendment_id=a_id, choice="abstain", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
+                    Vote.record(member_id=proxy_member.id, amendment_id=b_id, choice="abstain", salt=current_app.config["VOTE_SALT"], stage=vote_token.stage)
         vote_token.used_at = datetime.utcnow()
         db.session.commit()
         send_vote_receipt(member, meeting, hashes)

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -84,7 +84,9 @@ def test_cast_vote_records_hash_and_marks_used():
 
         vote = Vote.query.first()
         token_db = VoteToken.query.filter_by(token=token_obj.token).first()
-        expected = hashlib.sha256(f"{member_id}forsalty".encode()).hexdigest()
+        expected = hashlib.sha256(
+            f"{member_id}{amendment.id}1for{app.config['VOTE_SALT']}".encode()
+        ).hexdigest()
     assert vote.hash == expected
     assert token_db.used_at is not None
 
@@ -119,10 +121,62 @@ def test_stage2_motion_vote():
             voting.ballot_token(plain)
 
         vote = Vote.query.first()
-        expected = hashlib.sha256(f"{member_id}againstsalty".encode()).hexdigest()
+        expected = hashlib.sha256(
+            f"{member_id}{motion.id}2against{app.config['VOTE_SALT']}".encode()
+        ).hexdigest()
         assert vote.motion_id == motion.id
         assert vote.hash == expected
         assert token_obj.used_at is not None
+
+
+def test_vote_hash_unique_per_motion():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM")
+        db.session.add(meeting)
+        db.session.flush()
+        m1 = Motion(
+            meeting_id=meeting.id,
+            title="M1",
+            text_md="Motion text",
+            category="motion",
+            threshold="normal",
+            ordering=1,
+        )
+        m2 = Motion(
+            meeting_id=meeting.id,
+            title="M2",
+            text_md="Motion text",
+            category="motion",
+            threshold="normal",
+            ordering=2,
+        )
+        db.session.add_all([m1, m2])
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name="Alice", email="a@example.com")
+        db.session.add(member)
+        db.session.commit()
+        token_obj, plain = VoteToken.create(member_id=member.id, stage=2, salt=app.config["TOKEN_SALT"])
+        db.session.commit()
+
+        with app.test_request_context(
+            f"/vote/{plain}",
+            method="POST",
+            data={f"motion_{m1.id}": "for", f"motion_{m2.id}": "for"},
+        ):
+            voting.ballot_token(plain)
+
+        votes = Vote.query.order_by(Vote.motion_id).all()
+        assert len(votes) == 2
+        h1 = hashlib.sha256(
+            f"{member.id}{m1.id}2for{app.config['VOTE_SALT']}".encode()
+        ).hexdigest()
+        h2 = hashlib.sha256(
+            f"{member.id}{m2.id}2for{app.config['VOTE_SALT']}".encode()
+        ).hexdigest()
+        hashes = {votes[0].hash, votes[1].hash}
+        assert hashes == {h1, h2}
 
 
 def test_receipt_email_sent_after_vote():
@@ -339,8 +393,12 @@ def test_proxy_vote_creates_two_records():
         votes = Vote.query.order_by(Vote.member_id).all()
         assert len(votes) == 2
         assert {v.member_id for v in votes} == {member.id, proxied.id}
-        expected_alice = hashlib.sha256(f"{member.id}forsalty".encode()).hexdigest()
-        expected_bob = hashlib.sha256(f"{proxied.id}forsalty".encode()).hexdigest()
+        expected_alice = hashlib.sha256(
+            f"{member.id}{amend.id}1for{app.config['VOTE_SALT']}".encode()
+        ).hexdigest()
+        expected_bob = hashlib.sha256(
+            f"{proxied.id}{amend.id}1for{app.config['VOTE_SALT']}".encode()
+        ).hexdigest()
         assert {votes[0].hash, votes[1].hash} == {expected_alice, expected_bob}
 
 
@@ -496,7 +554,7 @@ def test_multiple_choice_motion_vote_and_receipt():
             vote_hashes = mock_receipt.call_args[0][2]
             vote = Vote.query.first()
             expected = hashlib.sha256(
-                f"{member.id}{opt2.text}{app.config['VOTE_SALT']}".encode()
+                f"{member.id}{motion.id}2{opt2.text}{app.config['VOTE_SALT']}".encode()
             ).hexdigest()
             assert vote.choice == opt2.text
             assert vote.hash == expected


### PR DESCRIPTION
## Summary
- include amendment/motion id and voting stage when hashing votes
- pass stage into vote recording routes and CLI
- update vote hash expectations in voting tests
- ensure hashes are unique for each motion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855b8b2dff0832bb9dab66bc5db2da4