### PR TITLE
Show tie-break method in Stage 1 results

### DIFF
--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -25,6 +25,9 @@
         {% else %}
           <span class="bp-tick bp-tick-fail">&#8211;</span>
         {% endif %}
+        {% if amend.tie_break_method %}
+          <div class="text-xs mt-1">Tie-break: {{ amend.tie_break_method }}</div>
+        {% endif %}
       </td>
     </tr>
   {% else %}

--- a/docs/help-voting.md
+++ b/docs/help-voting.md
@@ -9,6 +9,8 @@ British Powerlifting motions are decided in two parts:
 
 Some ballots may combine these into one form but the sequence stays the same: know what has changed, then cast your vote on the motion.
 
+By default a tied amendment vote is decided by the Chair's casting vote. If the Chair is unable to act, the earlier-submitted amendment prevails.
+
 ## How voting links work
 
 Each eligible member receives an email with a unique link. This link contains a secure token identifying you and the stage. Tokens can only be used once (unless revoting is enabled) and only during the advertised voting window. Do not share your link with others.


### PR DESCRIPTION
## Summary
- show amendment tie-break method in Stage 1 results table
- document default tie-break rule in help docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855b8fea5c8832b9f6ad3ebf35d8af0