### PR TITLE
Show amendment snippets on runoff ballot

### DIFF
--- a/app/templates/voting/runoff_ballot.html
+++ b/app/templates/voting/runoff_ballot.html
@@ -20,7 +20,17 @@
     </div>
     <div class="space-x-4 mb-4">
       {% for sub in form['runoff_' ~ runoff.id] %}
-        <label class="inline-flex items-center mr-4">{{ sub() }}<span>{{ sub.label.text }}</span></label>
+        <label class="inline-flex items-center mr-4">{{ sub() }}
+          <span>
+            {% if sub._value() == 'a' %}
+              {{ sub.label.text }} – {{ snippet(amend_a) }}
+            {% elif sub._value() == 'b' %}
+              {{ sub.label.text }} – {{ snippet(amend_b) }}
+            {% else %}
+              {{ sub.label.text }}
+            {% endif %}
+          </span>
+        </label>
       {% endfor %}
     </div>
   {% endfor %}

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -91,6 +91,14 @@ def compile_motion_text(motion: Motion) -> str:
     return "\n\n".join(parts)
 
 
+def amendment_snippet(amendment: Amendment, char_limit: int = 40) -> str:
+    """Return the first ``char_limit`` characters of an amendment."""
+    text = (amendment.text_md or "").strip()
+    if len(text) > char_limit:
+        return text[:char_limit].rstrip() + "..."
+    return text
+
+
 @bp.route("/<token>", methods=["GET", "POST"])
 @limiter.limit("10 per minute")
 def ballot_token(token: str):
@@ -480,6 +488,7 @@ def runoff_ballot(token: str):
         runoffs=pairs,
         meeting=meeting,
         proxy_for=proxy_member,
+        snippet=amendment_snippet,
     )
 
 


### PR DESCRIPTION
## Summary
- display amendment text snippets next to radio options on runoff ballots
- add `amendment_snippet` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68563d431694832ba14163e34f489a22