### PR TITLE
Add stage extension with reason logging

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -193,3 +193,12 @@ class MotionForm(FlaskForm):
         default=True,
     )
     submit = SubmitField("Save")
+
+
+class ExtendStageForm(FlaskForm):
+    """Admin form to extend a stage voting window."""
+
+    opens_at = DateTimeLocalField("New Opens At", format="%Y-%m-%dT%H:%M")
+    closes_at = DateTimeLocalField("New Closes At", format="%Y-%m-%dT%H:%M")
+    reason = TextAreaField("Reason", validators=[DataRequired()])
+    submit = SubmitField("Extend")

--- a/app/models.py
+++ b/app/models.py
@@ -94,6 +94,7 @@ class Meeting(db.Model):
     stage1_reminder_sent_at = db.Column(db.DateTime)
     public_results = db.Column(db.Boolean, default=False)
     comments_enabled = db.Column(db.Boolean, default=False)
+    extension_reason = db.Column(db.Text)
 
     def stage1_votes_count(self) -> int:
         """Return number of verified Stage-1 votes."""

--- a/app/templates/meetings/extend_stage.html
+++ b/app/templates/meetings/extend_stage.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
+{% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Extend Stage', None)]) }}
+<h1 class="font-bold text-bp-blue mb-4">Extend Stage {{ stage }}</h1>
+<form method="post" class="bp-form bp-card space-y-4">
+  {{ form.hidden_tag() }}
+  <div>
+    {{ form.opens_at.label(class_='block font-semibold') }}
+    {{ form.opens_at(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.closes_at.label(class_='block font-semibold') }}
+    {{ form.closes_at(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.reason.label(class_='block font-semibold') }}
+    {{ form.reason(class_='border p-3 rounded w-full') }}
+  </div>
+  <button type="submit" class="bp-btn-primary">Extend</button>
+</form>
+{% endblock %}

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -2,6 +2,9 @@
 {% block content %}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Stage 1 Results</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
+{% if meeting.extension_reason %}
+<p class="bp-alert-info mb-4">Extension reason: {{ meeting.extension_reason }}</p>
+{% endif %}
 <table class="bp-table w-full">
   <thead>
     <tr>

--- a/app/templates/public_results.html
+++ b/app/templates/public_results.html
@@ -2,6 +2,9 @@
 {% block content %}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} – Results</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
+{% if meeting.extension_reason %}
+<p class="bp-alert-info mb-4">Extension reason: {{ meeting.extension_reason }}</p>
+{% endif %}
 <p class="mb-4">
   <a href="{{ url_for('main.public_results_charts', meeting_id=meeting.id) }}" class="text-bp-blue underline">View charts</a>
 </p>

--- a/docs/full-database-structure.md
+++ b/docs/full-database-structure.md
@@ -54,6 +54,7 @@ This document summarises all tables and columns created by the Alembic migration
 | stage2_locked | Boolean | Default `False` |
 | stage1_reminder_sent_at | DateTime | |
 | public_results | Boolean | Default `False` |
+| extension_reason | Text | Reason for extending a stage |
 
 ### members
 | Column | Type | Notes |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -406,6 +406,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-24 – Added run-off closing helper and route clearing tokens.
 * 2025-06-20 – Stage 1 is skipped when no amendments exist by the deadline; Stage 2 tokens are generated.
 * 2025-06-25 – Receipt checker warns when a hash matches multiple votes and footer now links to it.
+* 2025-06-26 – Added stage extension form and reason display on results page.
 
 
 

--- a/migrations/versions/j7k8l9m0n1p2_add_extension_reason.py
+++ b/migrations/versions/j7k8l9m0n1p2_add_extension_reason.py
@@ -1,0 +1,23 @@
+"""add extension_reason column
+
+Revision ID: j7k8l9m0n1p2
+Revises: i1j2k3l4m5n6
+Create Date: 2025-06-26 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'j7k8l9m0n1p2'
+down_revision = 'i1j2k3l4m5n6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('meetings', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('extension_reason', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('meetings', schema=None) as batch_op:
+        batch_op.drop_column('extension_reason')

--- a/tests/test_extension_reason.py
+++ b/tests/test_extension_reason.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from types import SimpleNamespace
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import create_app
+from app.extensions import db
+from app.models import Meeting, Permission, Role, User
+from app.meetings import routes as meetings
+
+
+def _make_user():
+    perm = Permission(name="manage_meetings")
+    role = Role(permissions=[perm])
+    user = User(role=role)
+    user.email = "admin@example.com"
+    user.is_active = True
+    return user
+
+
+def test_extend_stage_updates_reason():
+    app = create_app()
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title="AGM")
+        db.session.add(meeting)
+        db.session.commit()
+
+        now = datetime.utcnow()
+        data = {
+            "opens_at": (now + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M"),
+            "closes_at": (now + timedelta(days=2)).strftime("%Y-%m-%dT%H:%M"),
+            "reason": "Storm delay",
+        }
+        form = SimpleNamespace(
+            validate_on_submit=lambda: True,
+            opens_at=SimpleNamespace(data=datetime.strptime(data["opens_at"], "%Y-%m-%dT%H:%M")),
+            closes_at=SimpleNamespace(data=datetime.strptime(data["closes_at"], "%Y-%m-%dT%H:%M")),
+            reason=SimpleNamespace(data=data["reason"]),
+        )
+        with app.test_request_context(f"/meetings/{meeting.id}/extend/2", method="POST"):
+            user = _make_user()
+            with patch("flask_login.utils._get_user", return_value=user):
+                with patch("app.meetings.routes.ExtendStageForm", return_value=form):
+                    meetings.extend_stage(meeting.id, 2)
+        assert meeting.extension_reason == "Storm delay"
+        assert meeting.opens_at_stage2 is not None


### PR DESCRIPTION
## Summary
- add `extension_reason` column to meetings
- implement `ExtendStageForm` for new open/close dates and reason
- create admin route `/meetings/<id>/extend/<stage>`
- show extension reason on results pages
- document schema change and add changelog entry
- test extension reason logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_extension_reason.py::test_extend_stage_updates_reason -q`
- `pytest tests/test_public_results.py::test_public_results_respects_flag_and_renders -q`


------
https://chatgpt.com/codex/tasks/task_b_68563d4dffb8832bab68f5f918770108