### PR TITLE
Add run‑off tie break logic

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -314,6 +314,7 @@ class Runoff(db.Model):
     meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
     amendment_a_id = db.Column(db.Integer, db.ForeignKey("amendments.id"))
     amendment_b_id = db.Column(db.Integer, db.ForeignKey("amendments.id"))
+    tie_break_method = db.Column(db.String(20))
 
 
 class AmendmentConflict(db.Model):

--- a/app/services/runoff.py
+++ b/app/services/runoff.py
@@ -124,7 +124,13 @@ def close_runoff_stage(meeting: Meeting) -> None:
         elif b_for > a_for:
             winner, loser = b, a
         else:
-            winner, loser = (a, b) if a.order <= b.order else (b, a)
+            method = rof.tie_break_method or "order"
+            if method == "chair":
+                winner, loser = a, b
+            elif method == "board":
+                winner, loser = b, a
+            else:
+                winner, loser = (a, b) if a.order <= b.order else (b, a)
         winner.status = "carried"
         loser.status = "failed"
 

--- a/app/templates/ro/runoff_tie_break_form.html
+++ b/app/templates/ro/runoff_tie_break_form.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Run-off Tie Breaks</h1>
+<form method="post" class="space-y-6">
+  {{ form.hidden_tag() }}
+  {% for r, a, b in runoffs %}
+  <div class="bp-card p-4 space-y-2">
+    <p class="font-semibold">Amendments {{ a.order }} vs {{ b.order }}</p>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div class="border p-2 whitespace-pre-wrap">{{ a.text_md }}</div>
+      <div class="border p-2 whitespace-pre-wrap">{{ b.text_md }}</div>
+    </div>
+    <div>
+      {{ form['method_' ~ r.id].label(class='block font-semibold mt-2') }}
+      {{ form['method_' ~ r.id](class='border p-2 rounded w-full') }}
+    </div>
+  </div>
+  {% else %}
+  <p>No run-offs.</p>
+  {% endfor %}
+  <button type="submit" class="bp-btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/docs/full-database-structure.md
+++ b/docs/full-database-structure.md
@@ -131,6 +131,7 @@ This document summarises all tables and columns created by the Alembic migration
 | meeting_id | Integer | FK `meetings.id` |
 | amendment_a_id | Integer | FK `amendments.id` |
 | amendment_b_id | Integer | FK `amendments.id` |
+| tie_break_method | String(20) | |
 
 ### vote_tokens
 | Column | Type | Notes |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -330,6 +330,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-15 – Voting route rejects ballots when a stage is locked.
 * 2025-06-15 – Run-off and reminder emails now link to `/vote/<token>`.
 * 2025-06-17 – Stage 1 closing now voids the vote when quorum is not met.
+* 2025-06-30 – Run-off tie break method recorded per run-off with RO form and service logic.
 * 2025-06-16 – Run-off invite emails now use `/vote/runoff/<token>` links.
 * 2025-06-15 – Added `aria-describedby` error hints on admin and meeting forms.
 * 2025-06-15 – Dashboard shows countdown to next reminder using badge design.

--- a/migrations/versions/j7k8l9m0n1_add_runoff_tie_break_method.py
+++ b/migrations/versions/j7k8l9m0n1_add_runoff_tie_break_method.py
@@ -1,0 +1,23 @@
+"""add tie_break_method to runoffs
+
+Revision ID: j7k8l9m0n1
+Revises: i1j2k3l4m5n6
+Create Date: 2025-06-30 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'j7k8l9m0n1'
+down_revision = 'i1j2k3l4m5n6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('runoffs', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('tie_break_method', sa.String(length=20), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('runoffs', schema=None) as batch_op:
+        batch_op.drop_column('tie_break_method')

--- a/tests/test_runoff.py
+++ b/tests/test_runoff.py
@@ -378,3 +378,132 @@ def test_close_runoff_stage_b_wins():
 
         assert a1.status == 'failed'
         assert a2.status == 'carried'
+
+
+def test_close_runoff_stage_tie_order():
+    app = _setup()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        db.session.flush()
+
+        motion = Motion(
+            meeting_id=meeting.id,
+            title='M',
+            text_md='x',
+            category='motion',
+            threshold='normal',
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+
+        a1 = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A1', order=1, status='carried')
+        a2 = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A2', order=2, status='carried')
+        db.session.add_all([a1, a2])
+        db.session.flush()
+
+        Runoff.query.delete()
+        r = Runoff(meeting_id=meeting.id, amendment_a_id=a1.id, amendment_b_id=a2.id, tie_break_method='order')
+        db.session.add(r)
+        m1 = Member(meeting_id=meeting.id, name='Bob', email='b@example.com')
+        m2 = Member(meeting_id=meeting.id, name='Eve', email='e@example.com')
+        db.session.add_all([m1, m2])
+        db.session.flush()
+
+        Vote.record(member_id=m1.id, amendment_id=a1.id, choice='for', salt='s')
+        Vote.record(member_id=m1.id, amendment_id=a2.id, choice='against', salt='s')
+        Vote.record(member_id=m2.id, amendment_id=a1.id, choice='against', salt='s')
+        Vote.record(member_id=m2.id, amendment_id=a2.id, choice='for', salt='s')
+
+        ro.close_runoff_stage(meeting)
+
+        assert a1.status == 'carried'
+        assert a2.status == 'failed'
+
+
+def test_close_runoff_stage_tie_chair():
+    app = _setup()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        db.session.flush()
+
+        motion = Motion(
+            meeting_id=meeting.id,
+            title='M',
+            text_md='x',
+            category='motion',
+            threshold='normal',
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+
+        a1 = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A1', order=1, status='carried')
+        a2 = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A2', order=2, status='carried')
+        db.session.add_all([a1, a2])
+        db.session.flush()
+
+        Runoff.query.delete()
+        r = Runoff(meeting_id=meeting.id, amendment_a_id=a1.id, amendment_b_id=a2.id, tie_break_method='chair')
+        db.session.add(r)
+        m1 = Member(meeting_id=meeting.id, name='Bob', email='b@example.com')
+        m2 = Member(meeting_id=meeting.id, name='Eve', email='e@example.com')
+        db.session.add_all([m1, m2])
+        db.session.flush()
+
+        Vote.record(member_id=m1.id, amendment_id=a1.id, choice='for', salt='s')
+        Vote.record(member_id=m1.id, amendment_id=a2.id, choice='against', salt='s')
+        Vote.record(member_id=m2.id, amendment_id=a1.id, choice='against', salt='s')
+        Vote.record(member_id=m2.id, amendment_id=a2.id, choice='for', salt='s')
+
+        ro.close_runoff_stage(meeting)
+
+        assert a1.status == 'carried'
+        assert a2.status == 'failed'
+
+
+def test_close_runoff_stage_tie_board():
+    app = _setup()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        db.session.flush()
+
+        motion = Motion(
+            meeting_id=meeting.id,
+            title='M',
+            text_md='x',
+            category='motion',
+            threshold='normal',
+            ordering=1,
+        )
+        db.session.add(motion)
+        db.session.flush()
+
+        a1 = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A1', order=1, status='carried')
+        a2 = Amendment(meeting_id=meeting.id, motion_id=motion.id, text_md='A2', order=2, status='carried')
+        db.session.add_all([a1, a2])
+        db.session.flush()
+
+        Runoff.query.delete()
+        r = Runoff(meeting_id=meeting.id, amendment_a_id=a1.id, amendment_b_id=a2.id, tie_break_method='board')
+        db.session.add(r)
+        m1 = Member(meeting_id=meeting.id, name='Bob', email='b@example.com')
+        m2 = Member(meeting_id=meeting.id, name='Eve', email='e@example.com')
+        db.session.add_all([m1, m2])
+        db.session.flush()
+
+        Vote.record(member_id=m1.id, amendment_id=a1.id, choice='for', salt='s')
+        Vote.record(member_id=m1.id, amendment_id=a2.id, choice='against', salt='s')
+        Vote.record(member_id=m2.id, amendment_id=a1.id, choice='against', salt='s')
+        Vote.record(member_id=m2.id, amendment_id=a2.id, choice='for', salt='s')
+
+        ro.close_runoff_stage(meeting)
+
+        assert a1.status == 'failed'
+        assert a2.status == 'carried'


### PR DESCRIPTION
## Summary
- allow recording tie-break methods on `Runoff`
- implement tie-break resolution using chair/board/order logic
- add RO page to set run-off tie breaks
- document run-off tie break column
- extend tests for tie scenarios

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68563da7d754832b8406b06e23bf9a6d