### PR TITLE
Implement email-based rate limit

### DIFF
--- a/tests/test_resend_rate_limit.py
+++ b/tests/test_resend_rate_limit.py
@@ -18,7 +18,7 @@ def _setup_app():
     return app
 
 
-def test_public_resend_is_rate_limited():
+def test_public_resend_is_rate_limited_per_email():
     app = _setup_app()
     with app.app_context():
         db.create_all()
@@ -39,5 +39,38 @@ def test_public_resend_is_rate_limited():
         for _ in range(5):
             resp = client.post(f'/public/meetings/{meeting.id}/resend', data=data)
             assert resp.status_code == 200
+
         resp = client.post(f'/public/meetings/{meeting.id}/resend', data=data)
         assert resp.status_code == 429
+
+        other = {'email': 'other@example.com', 'member_number': '123'}
+        resp = client.post(f'/public/meetings/{meeting.id}/resend', data=other)
+        assert resp.status_code == 200
+
+
+def test_public_resend_returns_generic_success():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM', status='Stage 1')
+        db.session.add(meeting)
+        db.session.flush()
+        member = Member(
+            meeting_id=meeting.id,
+            name='Alice',
+            email='alice@example.com',
+            member_number='123',
+        )
+        db.session.add(member)
+        db.session.commit()
+
+        client = app.test_client()
+        data = {'email': member.email, 'member_number': '123'}
+        resp = client.post(f'/public/meetings/{meeting.id}/resend', data=data)
+        assert resp.status_code == 200
+        assert 'If the details are correct' in resp.get_data(as_text=True)
+
+        wrong = {'email': 'bad@example.com', 'member_number': '999'}
+        resp2 = client.post(f'/public/meetings/{meeting.id}/resend', data=wrong)
+        assert resp2.status_code == 200
+        assert resp.get_data(as_text=True) == resp2.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- rate limit public meeting resend link by email rather than IP
- always show a generic success message and log attempts
- cover the new behaviour in resend rate limit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68563f7d8b74832b88cfc621c917af5d