### PR TITLE
Validate proxy references on member import

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -414,6 +414,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-26 – Added stage extension form and reason display on results page.
 * 2025-06-30 – Run-off tie breaks recorded with chair/board/order option and service respects setting.
 * 2025-06-28 – Objection submissions now require email confirmation via token link.
+* 2025-07-01 – Member import validates proxy references against uploaded or existing IDs.
 
 
 


### PR DESCRIPTION
## Summary
- ensure `proxy_for` values match existing members or other rows when importing
- test invalid `proxy_for` handling in `import_members`
- document proxy reference validation

## Testing
- `pip install -r requirements.txt`
- `pip install email_validator`
- `pytest -q`
- `flask db upgrade` *(fails: multiple head revisions)*
- `timeout 5 flask --app app run`
- `docker-compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68564e6ae4cc832b99a944566738114c