### PR TITLE
Add runoff invite calendar attachment

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -21,6 +21,7 @@ from docx.oxml import parse_xml
 from docx.oxml.ns import nsdecls
 import io
 import os
+from types import SimpleNamespace
 
 
 def _log_email(member: Member, meeting: Meeting, kind: str, test_mode: bool) -> None:
@@ -126,6 +127,17 @@ def send_runoff_invite(member: Member, token: str, meeting: Meeting, *, test_mod
     )
     msg.body = render_template('email/runoff_invite.txt', member=member, meeting=meeting, link=link, unsubscribe_url=unsubscribe, test_mode=test_mode)
     msg.html = render_template('email/runoff_invite.html', member=member, meeting=meeting, link=link, unsubscribe_url=unsubscribe, test_mode=test_mode)
+    try:
+        dummy = SimpleNamespace(
+            title=meeting.title,
+            opens_at_stage1=meeting.runoff_opens_at,
+            closes_at_stage1=meeting.runoff_closes_at,
+        )
+        ics = generate_stage_ics(dummy, 1)
+    except Exception:
+        ics = None
+    if ics:
+        msg.attach('runoff.ics', 'text/calendar', ics)
     mail.send(msg)
     _log_email(member, meeting, 'runoff_invite', test_mode)
 

--- a/app/templates/email/runoff_invite.html
+++ b/app/templates/email/runoff_invite.html
@@ -16,6 +16,7 @@
       </p>
       <p>If the button does not work, copy this link into your browser:</p>
       <p>{{ link }}</p>
+      <p>A calendar file showing the run-off voting window is attached.</p>
     </td>
   </tr>
   <tr>

--- a/app/templates/email/runoff_invite.txt
+++ b/app/templates/email/runoff_invite.txt
@@ -8,5 +8,7 @@ Use the link below to cast your ballot:
 
 {{ link }}
 
+An iCalendar file with the run-off voting window is attached for your diary.
+
 If you did not expect this email you can ignore it.
 To stop these emails, visit {{ unsubscribe_url }}

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -68,6 +68,28 @@ def test_send_runoff_invite_uses_token_url():
                 assert '/vote/runoff/abc123' in sent_msg.body
 
 
+def test_send_runoff_invite_has_calendar_attachment():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        now = datetime.utcnow()
+        meeting = Meeting(
+            title='AGM',
+            runoff_opens_at=now,
+            runoff_closes_at=now + timedelta(hours=1),
+        )
+        db.session.add(meeting)
+        member = Member(name='Ben', email='ben@example.com', meeting_id=1)
+        db.session.add(member)
+        db.session.commit()
+        with app.test_request_context('/'):
+            with patch.object(mail, 'send') as mock_send:
+                send_runoff_invite(member, 'abc123', meeting, test_mode=False)
+                mock_send.assert_called_once()
+                sent_msg = mock_send.call_args[0][0]
+                assert any(a.filename == 'runoff.ics' for a in sent_msg.attachments)
+
+
 def test_send_stage1_reminder_uses_token_url():
     app = _setup_app()
     with app.app_context():


### PR DESCRIPTION
## Summary
- generate a calendar file for runoff invites
- mention attachment in runoff invite templates
- test runoff invite calendar attachment

## Testing
- `pytest tests/test_email_service.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68564e72e490832b9f43129401418fd0