### PR TITLE
Add help link to ballot pages

### DIFF
--- a/app/templates/voting/combined_ballot.html
+++ b/app/templates/voting/combined_ballot.html
@@ -7,6 +7,7 @@
 {% set combined = True %}
 {% set combined_label = 'Combined Ballot' %}
 {% include '_stepper.html' %}
+<p class="text-sm mb-4">Need help? <a href="{{ url_for('help.show_help') }}" class="bp-link">Voting Help</a></p>
 {% if preview %}
 <div class="bp-alert-info text-center mb-4">Preview mode – votes will not be saved.</div>
 {% endif %}

--- a/app/templates/voting/stage1_ballot.html
+++ b/app/templates/voting/stage1_ballot.html
@@ -5,6 +5,7 @@
 <h1 class="font-bold text-bp-blue mb-4">Stage 1 – Amendment Votes</h1>
 {% set current_stage = 1 %}
 {% include '_stepper.html' %}
+<p class="text-sm mb-4">Need help? <a href="{{ url_for('help.show_help') }}" class="bp-link">Voting Help</a></p>
 {% if preview %}
 <div class="bp-alert-info text-center mb-4">Preview mode – votes will not be saved.</div>
 {% endif %}

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -5,6 +5,7 @@
 <h1 class="font-bold text-bp-blue mb-4">Stage 2 – Vote on Motion</h1>
 {% set current_stage = 2 %}
 {% include '_stepper.html' %}
+<p class="text-sm mb-4">Need help? <a href="{{ url_for('help.show_help') }}" class="bp-link">Voting Help</a></p>
 {% if carried_summary %}
 <div class="bp-card mb-4">{{ carried_summary|markdown_to_html|safe }}</div>
 {% elif results_link %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -414,6 +414,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-26 – Added stage extension form and reason display on results page.
 * 2025-06-30 – Run-off tie breaks recorded with chair/board/order option and service respects setting.
 * 2025-06-28 – Objection submissions now require email confirmation via token link.
+* 2025-07-01 – Added "Need help?" links on ballot pages pointing to the help screen.
 
 
 

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -757,6 +757,8 @@ def test_stepper_shows_stage1_current():
             assert 'bp-stepper-current" aria-current="step" data-step="1"' in html
             assert 'data-step="2"' in html
             assert 'bp-stepper-complete' not in html
+            assert 'Need help?' in html
+            assert 'href="/help"' in html
 
 
 def test_stepper_shows_stage2_current_and_stage1_complete():
@@ -785,6 +787,8 @@ def test_stepper_shows_stage2_current_and_stage1_complete():
             html = voting.ballot_token(plain)
             assert 'bp-stepper-complete" data-step="1"' in html
             assert 'bp-stepper-current" aria-current="step" data-step="2"' in html
+            assert 'Need help?' in html
+            assert 'href="/help"' in html
 
 
 def test_stepper_combined_ballot_single_label():
@@ -817,6 +821,8 @@ def test_stepper_combined_ballot_single_label():
             assert 'bp-stepper-current' in html
             assert 'data-step="1"' in html
             assert 'Stage 2' not in html
+            assert 'Need help?' in html
+            assert 'href="/help"' in html
 
 
 def test_verify_receipt_found():


### PR DESCRIPTION
## Summary
- link to the help page at the top of each ballot template
- check for help links in ballot rendering tests
- document change in PRD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68564ec54c14832b958186faabc0435c