### PR TITLE
Fix tests by adding email validator dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ gunicorn==21.2.0
 Flask-Login==0.6.3
 Flask-Bcrypt==1.0.1
 Flask-WTF==1.2.2
+email-validator==2.1.0.post1
 python-dotenv==1.0.1
 uuid6==2025.0.0
 Flask-Mail==0.10.0


### PR DESCRIPTION
## Summary
- add `email-validator` to requirements to satisfy WTForms Email validator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68567b545650832bacb78f83577afb6a