### PR TITLE
Add AGM stage defaults

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -425,6 +425,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-05 – Comment posting now shows a confirmation flash message.
 * 2025-07-01 – Added manual tally entry for in-person meetings with Stage 1 and Stage 2 forms.
 * 2025-07-01 – Added resubscribe links alongside unsubscribe and a route to opt back in.
+* 2025-07-06 – AGM date field auto-completes stage times based on configured notice and duration settings.
 
 
 

--- a/tests/test_meetings_routes.py
+++ b/tests/test_meetings_routes.py
@@ -1055,3 +1055,18 @@ def test_default_stage_time_calculation():
             defaults["opens_at_stage2"] - defaults["closes_at_stage1"]
             >= timedelta(days=app.config["STAGE_GAP_DAYS"])
         )
+
+
+def test_prefill_form_defaults():
+    app = create_app()
+    with app.app_context():
+        app.config["WTF_CSRF_ENABLED"] = False
+        agm = (datetime.utcnow() + timedelta(days=30)).replace(second=0, microsecond=0)
+        data = MultiDict({"closes_at_stage2": agm.strftime("%Y-%m-%dT%H:%M")})
+        form = MeetingForm(formdata=data)
+        meetings._prefill_form_defaults(form)
+        assert form.notice_date.data is not None
+        assert form.opens_at_stage1.data is not None
+        assert form.closes_at_stage1.data is not None
+        assert form.opens_at_stage2.data is not None
+        assert form.closes_at_stage2.data == agm


### PR DESCRIPTION
## Summary
- auto-fill stage dates from the AGM date
- test prefill logic
- document AGM-based defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68567b982170832b9295a5c420625382