### PR TITLE
Add admin audit logging

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -30,6 +30,7 @@ from .forms import (
 )
 
 from ..permissions import permission_required
+from ..services.audit import record_action, get_logs
 
 bp = Blueprint("admin", __name__, url_prefix="/admin")
 
@@ -51,6 +52,7 @@ def toggle_public_results(meeting_id: int):
         abort(404)
     meeting.public_results = not meeting.public_results
     db.session.commit()
+    record_action('toggle_public_results', f'meeting_id={meeting.id}')
     return redirect(url_for("admin.dashboard"))
 
 
@@ -63,6 +65,7 @@ def toggle_results_doc(meeting_id: int):
         abort(404)
     meeting.results_doc_published = not meeting.results_doc_published
     db.session.commit()
+    record_action('toggle_results_doc', f'meeting_id={meeting.id}')
     return redirect(url_for("admin.dashboard"))
 
 
@@ -161,7 +164,8 @@ def create_user():
     form = UserCreateForm()
     form.role_id.choices = [(r.id, r.name) for r in Role.query.order_by(Role.name)]
     if form.validate_on_submit():
-        _save_user(form)
+        user = _save_user(form)
+        record_action("create_user", f"user_id={user.id}")
         return redirect(url_for("admin.list_users"))
     return render_template("admin/user_form.html", form=form, user=None)
 
@@ -176,7 +180,8 @@ def edit_user(user_id):
     form = UserForm(obj=user)
     form.role_id.choices = [(r.id, r.name) for r in Role.query.order_by(Role.name)]
     if form.validate_on_submit():
-        _save_user(form, user)
+        updated = _save_user(form, user)
+        record_action("edit_user", f"user_id={updated.id}")
         return redirect(url_for("admin.list_users"))
     return render_template("admin/user_form.html", form=form, user=user)
 
@@ -353,6 +358,7 @@ def manage_settings():
         else:
             AppSetting.delete("contact_url")
         AppSetting.set("manual_email_mode", "1" if form.manual_email_mode.data else "0")
+        record_action("update_settings")
         flash("Settings updated", "success")
         return redirect(url_for("admin.manage_settings"))
     return render_template("admin/settings_form.html", form=form)
@@ -363,5 +369,19 @@ def manage_settings():
 @permission_required("manage_settings")
 def reset_setting(key: str):
     AppSetting.delete(key)
+    record_action("reset_setting", key)
     flash("Setting reset to default", "success")
     return redirect(url_for("admin.manage_settings"))
+
+
+@bp.route("/audit")
+@login_required
+@permission_required("manage_users")
+def view_audit():
+    page = request.args.get("page", 1, type=int)
+    pagination = get_logs(page=page, per_page=20)
+    return render_template(
+        "admin/audit.html",
+        logs=pagination.items,
+        pagination=pagination,
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -416,3 +416,16 @@ class EmailLog(db.Model):
     is_test = db.Column(db.Boolean, default=False)
     sent_at = db.Column(db.DateTime, default=datetime.utcnow)
 
+
+class AdminLog(db.Model):
+    """Record an administrative action performed by a user."""
+
+    __tablename__ = "admin_logs"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
+    user = db.relationship("User")
+    action = db.Column(db.String(50))
+    details = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -1,0 +1,21 @@
+from flask_login import current_user
+
+from ..extensions import db
+from ..models import AdminLog
+
+
+def record_action(action: str, details: str | None = None, user_id: int | None = None) -> AdminLog:
+    """Persist an administrative action."""
+    user_id = user_id or getattr(current_user, "id", None)
+    log = AdminLog(user_id=user_id, action=action, details=details)
+    db.session.add(log)
+    db.session.commit()
+    return log
+
+
+def get_logs(page: int = 1, per_page: int = 20):
+    """Return paginated audit log entries ordered by newest first."""
+    return (
+        AdminLog.query.order_by(AdminLog.created_at.desc())
+        .paginate(page=page, per_page=per_page, error_out=False)
+    )

--- a/app/templates/admin/audit.html
+++ b/app/templates/admin/audit.html
@@ -1,0 +1,65 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
+{% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Audit Log', url_for('admin.view_audit'))]) }}
+<h1 class="font-bold text-bp-blue mb-4">Audit Log</h1>
+<div class="bp-card">
+<table class="bp-table">
+  <thead class="bg-bp-grey-50">
+    <tr>
+      <th scope="col" class="text-left p-2">When</th>
+      <th scope="col" class="text-left p-2">User</th>
+      <th scope="col" class="text-left p-2">Action</th>
+      <th scope="col" class="text-left p-2">Details</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for log in logs %}
+    <tr class="border-t">
+      <td class="p-2">{{ log.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+      <td class="p-2">{{ log.user.email if log.user else 'System' }}</td>
+      <td class="p-2">{{ log.action }}</td>
+      <td class="p-2">{{ log.details }}</td>
+    </tr>
+  {% else %}
+    <tr><td colspan="4" class="p-2">No entries.</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+</div>
+{% if pagination.pages > 1 %}
+<nav aria-label="Pagination" class="mt-6 flex justify-center">
+  <ul class="bp-pagination">
+    {% if pagination.has_prev %}
+    <li>
+      <a href="{{ url_for('admin.view_audit', page=pagination.prev_num) }}" aria-label="Previous" class="hover:bg-bp-grey-100 transition-colors">
+        <svg class="bp-icon w-5 h-5" viewBox="0 0 24 24"><path d="M15 19l-7-7 7-7" stroke="currentColor" fill="none"/></svg>
+      </a>
+    </li>
+    {% else %}
+    <li><span class="bp-disabled opacity-50"><svg class="bp-icon w-5 h-5" viewBox="0 0 24 24"><path d="M15 19l-7-7 7-7" stroke="currentColor" fill="none"/></svg></span></li>
+    {% endif %}
+    {% for p in pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+      {% if p %}
+        {% if p == pagination.page %}
+        <li><span class="bp-current-page">{{ p }}</span></li>
+        {% else %}
+        <li><a href="{{ url_for('admin.view_audit', page=p) }}" class="hover:bg-bp-grey-100 transition-colors">{{ p }}</a></li>
+        {% endif %}
+      {% else %}
+        <li><span class="text-bp-grey-400">&hellip;</span></li>
+      {% endif %}
+    {% endfor %}
+    {% if pagination.has_next %}
+    <li>
+      <a href="{{ url_for('admin.view_audit', page=pagination.next_num) }}" aria-label="Next" class="hover:bg-bp-grey-100 transition-colors">
+        <svg class="bp-icon w-5 h-5" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7" stroke="currentColor" fill="none"/></svg>
+      </a>
+    </li>
+    {% else %}
+    <li><span class="bp-disabled opacity-50"><svg class="bp-icon w-5 h-5" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7" stroke="currentColor" fill="none"/></svg></span></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -429,6 +429,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-01 – Added resubscribe links alongside unsubscribe and a route to opt back in.
 * 2025-06-21 – Added "Need help?" link to ballot pages.
 * 2025-07-06 – AGM date field auto-completes stage times based on configured notice and duration settings.
+* 2025-06-21 – Added admin audit logging of key actions.
 
 
 

--- a/migrations/versions/o3p4q5r6_add_admin_logs.py
+++ b/migrations/versions/o3p4q5r6_add_admin_logs.py
@@ -1,0 +1,28 @@
+"""add admin logs table
+
+Revision ID: o3p4q5r6
+Revises: n1o2p3q4
+Create Date: 2025-06-21 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'o3p4q5r6'
+down_revision = 'n1o2p3q4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'admin_logs',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id')),
+        sa.Column('action', sa.String(length=50), nullable=True),
+        sa.Column('details', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table('admin_logs')

--- a/tests/test_admin_audit.py
+++ b/tests/test_admin_audit.py
@@ -1,0 +1,83 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from unittest.mock import patch
+from app import create_app
+from app.extensions import db
+from app.models import Role, Permission, User, Meeting, AdminLog
+from app.admin import routes as admin
+
+
+def _setup_app():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['WTF_CSRF_ENABLED'] = False
+    return app
+
+
+def test_create_user_logged():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        perm = Permission(name='manage_users')
+        role = Role(name='Admin', permissions=[perm])
+        db.session.add_all([perm, role])
+        db.session.commit()
+        admin_user = User(email='root@example.com', role=role, is_active=True)
+        db.session.add(admin_user)
+        db.session.commit()
+        data = {'email': 'new@example.com', 'password': 'pw', 'role_id': role.id, 'is_active': 'y'}
+        with app.test_request_context('/admin/users/create', method='POST', data=data):
+            with patch('flask_login.utils._get_user', return_value=admin_user):
+                admin.create_user()
+        log = AdminLog.query.filter_by(action='create_user').first()
+        assert log is not None
+        assert log.user_id == admin_user.id
+
+
+def test_toggle_public_results_logged():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        perm = Permission(name='manage_meetings')
+        role = Role(name='Coordinator', permissions=[perm])
+        user = User(email='c@example.com', role=role, is_active=True)
+        meeting = Meeting(title='AGM')
+        db.session.add_all([perm, role, user, meeting])
+        db.session.commit()
+        with app.test_request_context(f'/admin/meetings/{meeting.id}/toggle-public', method='POST'):
+            with patch('flask_login.utils._get_user', return_value=user):
+                admin.toggle_public_results(meeting.id)
+        log = AdminLog.query.filter_by(action='toggle_public_results').first()
+        assert log and str(meeting.id) in log.details
+
+
+def test_update_settings_logged():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        perm = Permission(name='manage_settings')
+        role = Role(name='Root', permissions=[perm])
+        user = User(email='root@example.com', role=role, is_active=True)
+        db.session.add_all([perm, role, user])
+        db.session.commit()
+        data = {
+            'site_title': 'VoteBuddy',
+            'site_logo': '',
+            'from_email': 'a@example.com',
+            'runoff_extension_minutes': '10',
+            'reminder_hours_before_close': '1',
+            'reminder_cooldown_hours': '1',
+            'reminder_template': 'email/reminder',
+            'tie_break_decisions': '',
+            'clerical_text': '',
+            'move_text': '',
+            'manual_email_mode': 'y',
+            'contact_url': 'https://example.com',
+        }
+        with app.test_request_context('/admin/settings', method='POST', data=data):
+            with patch('flask_login.utils._get_user', return_value=user):
+                admin.manage_settings()
+        log = AdminLog.query.filter_by(action='update_settings').first()
+        assert log is not None
+


### PR DESCRIPTION
## Summary
- add `AdminLog` model and audit service
- log admin actions for meetings, users and settings
- add audit log page with pagination and permission checks
- document audit logging in product requirements
- include migration and tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68569e9bc6c0832ba558bd2bf5338e0d