### PR TITLE
Add timezone display for public meeting timestamps

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime
 from flask import Flask, render_template
-from .utils import markdown_to_html
+from .utils import markdown_to_html, format_dt
 
 from .extensions import (
     db,
@@ -75,6 +75,7 @@ def register_extensions(app):
 
     # register template filters
     app.jinja_env.filters['markdown_to_html'] = markdown_to_html
+    app.jinja_env.filters['format_dt'] = format_dt
 
     from .models import User, AppSetting, Meeting
 

--- a/app/templates/public_meeting.html
+++ b/app/templates/public_meeting.html
@@ -5,24 +5,24 @@
 {% if meeting.opens_at_stage1 and meeting.closes_at_stage1 %}
 <p class="mb-2">
   Stage 1:
-  {{ meeting.opens_at_stage1.strftime('%Y-%m-%d %H:%M') }} –
-  {{ meeting.closes_at_stage1.strftime('%Y-%m-%d %H:%M') }}
+  {{ meeting.opens_at_stage1|format_dt }} –
+  {{ meeting.closes_at_stage1|format_dt }}
   <a href="{{ stage1_ics_url }}" class="text-bp-blue hover:underline ml-2">Add to calendar</a>
 </p>
 {% endif %}
 {% if meeting.runoff_opens_at and meeting.runoff_closes_at %}
 <p class="mb-2">
   Run-off:
-  {{ meeting.runoff_opens_at.strftime('%Y-%m-%d %H:%M') }} –
-  {{ meeting.runoff_closes_at.strftime('%Y-%m-%d %H:%M') }}
+  {{ meeting.runoff_opens_at|format_dt }} –
+  {{ meeting.runoff_closes_at|format_dt }}
   <a href="{{ runoff_ics_url }}" class="text-bp-blue hover:underline ml-2">Add to calendar</a>
 </p>
 {% endif %}
 {% if meeting.opens_at_stage2 and meeting.closes_at_stage2 %}
 <p class="mb-4">
   Stage 2:
-  {{ meeting.opens_at_stage2.strftime('%Y-%m-%d %H:%M') }} –
-  {{ meeting.closes_at_stage2.strftime('%Y-%m-%d %H:%M') }}
+  {{ meeting.opens_at_stage2|format_dt }} –
+  {{ meeting.closes_at_stage2|format_dt }}
   <a href="{{ stage2_ics_url }}" class="text-bp-blue hover:underline ml-2">Add to calendar</a>
 </p>
 {% endif %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -19,6 +19,9 @@ ALLOWED_TAGS = (
 from flask import current_app
 from .models import AppSetting, Amendment
 import json
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+from uuid import uuid4
 
 
 def config_or_setting(
@@ -60,8 +63,26 @@ def markdown_to_html(text: str) -> Markup:
     cleaned = bleach.clean(raw_html, tags=ALLOWED_TAGS, strip=True)
     return Markup(cleaned)
 
-from uuid import uuid4
-from datetime import datetime
+
+def format_dt(dt: datetime, tz_name: str | None = None) -> str:
+    """Return formatted datetime with timezone abbreviation.
+
+    Parameters
+    ----------
+    dt: datetime
+        Naive or aware datetime object.
+    tz_name: str | None
+        Optional timezone name; defaults to ``app.config['TIMEZONE']`` or ``UTC``.
+    """
+
+    if dt is None:
+        return ""
+    tz_name = tz_name or current_app.config.get("TIMEZONE", "UTC")
+    tz = ZoneInfo(tz_name)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(tz).strftime("%Y-%m-%d %H:%M %Z")
+
 
 
 def generate_stage_ics(meeting, stage: int) -> bytes:

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -432,6 +432,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-06 – AGM date field auto-completes stage times based on configured notice and duration settings.
 * 2025-07-07 – Added meeting cloning option to duplicate motions and amendments.
 * 2025-06-21 – Added admin audit logging of key actions.
+* 2025-07-08 – Public meeting times now show timezone abbreviation.
 
 
 

--- a/tests/test_public_meetings.py
+++ b/tests/test_public_meetings.py
@@ -4,6 +4,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from unittest.mock import patch
 from flask import render_template, url_for
 from flask_login import AnonymousUserMixin
+from datetime import datetime
 from app import create_app
 from app.extensions import db
 from app.models import Meeting, Member
@@ -40,3 +41,24 @@ def test_nav_uses_public_link_when_anonymous():
                 html = render_template('base.html')
                 href = url_for('main.public_meetings')
                 assert href in html
+
+
+def test_public_meeting_detail_includes_timezone():
+    app = _setup_app()
+    with app.app_context():
+        app.config['TIMEZONE'] = 'UTC'
+        db.create_all()
+        meeting = Meeting(
+            title='AGM',
+            opens_at_stage1=datetime(2030, 1, 1, 9),
+            closes_at_stage1=datetime(2030, 1, 1, 10),
+            runoff_opens_at=datetime(2030, 1, 1, 11),
+            runoff_closes_at=datetime(2030, 1, 1, 12),
+            opens_at_stage2=datetime(2030, 1, 2, 9),
+            closes_at_stage2=datetime(2030, 1, 2, 10),
+        )
+        db.session.add(meeting)
+        db.session.commit()
+        with app.test_request_context(f'/public/meetings/{meeting.id}'):
+            html = main.public_meeting_detail(meeting.id)
+            assert html.count('UTC') >= 3


### PR DESCRIPTION
## Summary
- format datetimes with timezone via new `format_dt` helper and Jinja filter
- show timezone on public meeting page
- test timezone output on meeting detail page
- document timezone change in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6856a42276d8832ba4d95a3c78301688