### PR TITLE
Add support contact link to receipt verification

### DIFF
--- a/app/templates/voting/verify_receipt.html
+++ b/app/templates/voting/verify_receipt.html
@@ -23,6 +23,9 @@
     </ul>
   </div>
 {% elif message %}
-  <div class="bp-alert-error mt-4">{{ message }}</div>
+  <div class="bp-alert-error mt-4">
+    <p>{{ message }}</p>
+    <p class="text-sm">Need help? <a href="{{ contact_url }}" class="bp-link">Contact support</a></p>
+  </div>
 {% endif %}
 {% endblock %}

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -12,6 +12,7 @@ from ..models import (
     MotionOption,
     Runoff,
     Comment,
+    AppSetting,
 )
 from flask_wtf import FlaskForm
 from wtforms import RadioField, SubmitField, StringField
@@ -495,6 +496,13 @@ def verify_receipt():
             message = "Multiple votes share this hash. Check your email receipt or contact support."
         else:
             message = "No vote found for that hash."
+    contact_url = AppSetting.get(
+        "contact_url", "https://www.britishpowerlifting.org/contactus"
+    )
     return render_template(
-        "voting/verify_receipt.html", form=form, votes=votes, message=message
+        "voting/verify_receipt.html",
+        form=form,
+        votes=votes,
+        message=message,
+        contact_url=contact_url,
     )

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -859,6 +859,7 @@ def test_verify_receipt_not_found():
     resp = client.post("/vote/verify-receipt", data={"hash": "bad"})
     assert resp.status_code == 200
     assert b"No vote found" in resp.data
+    assert b"Contact support" in resp.data
 
 
 def test_verify_receipt_multiple_matches():
@@ -900,6 +901,7 @@ def test_verify_receipt_multiple_matches():
     resp = client.post("/vote/verify-receipt", data={"hash": vote_hash})
     assert resp.status_code == 200
     assert b"Multiple votes share this hash" in resp.data
+    assert b"Contact support" in resp.data
 
 
 def test_confirmation_shows_change_vote_link_when_revoting_enabled():


### PR DESCRIPTION
## Summary
- show contact link on verify receipt errors
- fetch support URL from AppSetting with a default
- ensure tests expect link text

## Testing
- `pytest tests/test_voting.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6856a42aedd0832bbff7e496055ec04c