### PR TITLE
Add stage2 progress indicator

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -174,6 +174,17 @@ class Meeting(db.Model):
         percent = max(0.0, min(100.0, (elapsed / total) * 100))
         return int(percent)
 
+    def stage2_progress_percent(self) -> int:
+        """Return percentage of Stage-2 voting period elapsed."""
+        if not self.opens_at_stage2 or not self.closes_at_stage2:
+            return 0
+        total = (self.closes_at_stage2 - self.opens_at_stage2).total_seconds()
+        if total <= 0:
+            return 0
+        elapsed = (datetime.utcnow() - self.opens_at_stage2).total_seconds()
+        percent = max(0.0, min(100.0, (elapsed / total) * 100))
+        return int(percent)
+
 
 class Member(db.Model):
     __tablename__ = "members"

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -51,9 +51,19 @@
         <div class="mb-4">
           <div class="bp-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ meeting.stage1_progress_percent() }}">
             <div class="bp-progress-bar" style="width: {{ meeting.stage1_progress_percent() }}%"></div>
+            <span class="sr-only">{{ meeting.stage1_progress_percent() }}% complete</span>
           </div>
           <span class="text-xs text-bp-grey-600 mt-1">{{ meeting.stage1_progress_percent() }}% voting window elapsed</span>
         </div>
+        {% if meeting.opens_at_stage2 and meeting.closes_at_stage2 %}
+        <div class="mb-4">
+          <div class="bp-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ meeting.stage2_progress_percent() }}">
+            <div class="bp-progress-bar" style="width: {{ meeting.stage2_progress_percent() }}%"></div>
+            <span class="sr-only">{{ meeting.stage2_progress_percent() }}% complete</span>
+          </div>
+          <span class="text-xs text-bp-grey-600 mt-1">{{ meeting.stage2_progress_percent() }}% Stage 2 elapsed</span>
+        </div>
+        {% endif %}
         {% endif %}
         
         <!-- Meeting Info -->

--- a/app/templates/public_meeting.html
+++ b/app/templates/public_meeting.html
@@ -25,6 +25,13 @@
   {{ meeting.closes_at_stage2.strftime('%Y-%m-%d %H:%M') }}
   <a href="{{ stage2_ics_url }}" class="text-bp-blue hover:underline ml-2">Add to calendar</a>
 </p>
+<div class="mb-6">
+  <div class="bp-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ meeting.stage2_progress_percent() }}">
+    <div class="bp-progress-bar" style="width: {{ meeting.stage2_progress_percent() }}%"></div>
+    <span class="sr-only">{{ meeting.stage2_progress_percent() }}% complete</span>
+  </div>
+  <span class="text-xs text-bp-grey-600 mt-1">{{ meeting.stage2_progress_percent() }}% of Stage 2 voting window elapsed</span>
+</div>
 {% endif %}
 <button class="bp-btn-secondary mb-4" data-modal-target="resend-modal">Resend Voting Email</button>
 <dialog id="resend-modal" class="bp-card w-full max-w-md" role="dialog" aria-labelledby="resend-title">

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -431,6 +431,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-21 – Added "Need help?" link to ballot pages.
 * 2025-07-06 – AGM date field auto-completes stage times based on configured notice and duration settings.
 * 2025-07-07 – Added meeting cloning option to duplicate motions and amendments.
+* 2025-07-08 – Added Stage 2 progress bars and calculation method.
 * 2025-06-21 – Added admin audit logging of key actions.
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -72,3 +72,38 @@ def test_hours_until_next_reminder_after_first():
         db.session.add(meeting)
         db.session.commit()
         assert meeting.hours_until_next_reminder(now=now) == 24
+
+
+def test_stage_progress_percentages():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        now = datetime.utcnow()
+        meeting = Meeting(
+            title='AGM',
+            opens_at_stage1=now - timedelta(hours=1),
+            closes_at_stage1=now + timedelta(hours=1),
+            opens_at_stage2=now - timedelta(hours=2),
+            closes_at_stage2=now + timedelta(hours=2)
+        )
+        db.session.add(meeting)
+        db.session.commit()
+        assert meeting.stage1_progress_percent() == 50
+        assert meeting.stage2_progress_percent() == 50
+
+
+def test_stage2_progress_percent_future():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        now = datetime.utcnow()
+        meeting = Meeting(
+            title='AGM',
+            opens_at_stage2=now + timedelta(hours=1),
+            closes_at_stage2=now + timedelta(hours=2)
+        )
+        db.session.add(meeting)
+        db.session.commit()
+        assert meeting.stage2_progress_percent() == 0


### PR DESCRIPTION
## Summary
- compute `stage2_progress_percent` on Meeting
- show Stage 2 progress bars on admin dashboard and public meeting page
- add tests for progress percentage calculations
- document Stage 2 progress feature in PRD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856a45f1e54832b854a2898b0c46c28