### PR TITLE
Fix token verification

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -264,7 +264,7 @@ class VoteToken(db.Model):
     @classmethod
     def verify(cls, token: str, salt: str) -> "VoteToken | None":
         hashed = cls._hash(token, salt)
-        return cls.query.filter(db.or_(cls.token == hashed, cls.token == token)).first()
+        return cls.query.filter_by(token=hashed).first()
 
 
 class UnsubscribeToken(db.Model):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -36,8 +36,9 @@ def test_send_stage1_reminders_sends_emails():
         member = Member(meeting_id=meeting.id, name='Ann', email='a@example.com')
         db.session.add(member)
         db.session.flush()
-        token_hash = VoteToken._hash('tok', app.config['TOKEN_SALT'])
-        token = VoteToken(token=token_hash, member_id=member.id, stage=1)
+        token, _ = VoteToken.create(
+            member_id=member.id, stage=1, salt=app.config['TOKEN_SALT']
+        )
         db.session.add(token)
         db.session.commit()
         with patch('app.tasks.send_stage1_reminder') as mock_send:
@@ -66,10 +67,11 @@ def test_cleanup_vote_tokens_removes_expired_and_used():
         db.session.add_all([member1, member2])
         db.session.flush()
 
-        t_used = VoteToken(token=VoteToken._hash('used', app.config['TOKEN_SALT']), member_id=member1.id, stage=1, used_at=now)
-        t_expired1 = VoteToken(token=VoteToken._hash('exp1', app.config['TOKEN_SALT']), member_id=member1.id, stage=1)
-        t_expired2 = VoteToken(token=VoteToken._hash('exp2', app.config['TOKEN_SALT']), member_id=member1.id, stage=2)
-        t_valid = VoteToken(token=VoteToken._hash('valid', app.config['TOKEN_SALT']), member_id=member2.id, stage=1)
+        t_used, _ = VoteToken.create(member_id=member1.id, stage=1, salt=app.config['TOKEN_SALT'])
+        t_used.used_at = now
+        t_expired1, _ = VoteToken.create(member_id=member1.id, stage=1, salt=app.config['TOKEN_SALT'])
+        t_expired2, _ = VoteToken.create(member_id=member1.id, stage=2, salt=app.config['TOKEN_SALT'])
+        t_valid, _ = VoteToken.create(member_id=member2.id, stage=1, salt=app.config['TOKEN_SALT'])
         db.session.add_all([t_used, t_expired1, t_expired2, t_valid])
         db.session.commit()
 

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -199,9 +199,10 @@ def test_receipt_email_sent_after_vote():
         member = Member(meeting_id=meeting.id, name="Alice", email="a@example.com")
         db.session.add(member)
         db.session.commit()
-        token = VoteToken(token=VoteToken._hash("tok-receipt", app.config["TOKEN_SALT"]), member_id=member.id, stage=2)
-        db.session.add(token)
-        token_obj, plain = VoteToken.create(member_id=member.id, stage=2, salt=app.config["TOKEN_SALT"])
+        token_obj, plain = VoteToken.create(
+            member_id=member.id, stage=2, salt=app.config["TOKEN_SALT"]
+        )
+        db.session.add(token_obj)
         db.session.commit()
         
         with patch("app.voting.routes.send_vote_receipt") as mock_receipt:


### PR DESCRIPTION
## Summary
- verify vote tokens only by their hashed form
- update tests for scheduler and voting to use plaintext tokens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856abf2f518832bb1bb0a06f34871e8