### PR TITLE
Limit verify_receipt lookups

### DIFF
--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -476,6 +476,7 @@ class ReceiptLookupForm(FlaskForm):
 
 
 @bp.route("/verify-receipt", methods=["GET", "POST"])
+@limiter.limit("20 per hour")
 def verify_receipt():
     """Allow members to check a vote receipt hash."""
     form = ReceiptLookupForm()


### PR DESCRIPTION
## Summary
- limit `voting.verify_receipt` to 20 lookups an hour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856ac1380dc832bafe52699c6fb5f7f