### PR TITLE
Add secure tokens for motion and amendment submissions

### DIFF
--- a/app/submissions/forms.py
+++ b/app/submissions/forms.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, SubmitField
+from wtforms import StringField, TextAreaField, SubmitField, SelectField
 from wtforms.validators import DataRequired, Email
 
 
@@ -8,6 +8,7 @@ class MotionSubmissionForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
     title = StringField('Motion Title', validators=[DataRequired()])
     text_md = TextAreaField('Motion Text', validators=[DataRequired()])
+    seconder_id = SelectField('Seconder', coerce=int)
     submit = SubmitField('Submit Motion')
 
 
@@ -15,4 +16,5 @@ class AmendmentSubmissionForm(FlaskForm):
     name = StringField('Your Name', validators=[DataRequired()])
     email = StringField('Email', validators=[DataRequired(), Email()])
     text_md = TextAreaField('Amendment Text', validators=[DataRequired()])
+    seconder_id = SelectField('Seconder', coerce=int)
     submit = SubmitField('Submit Amendment')

--- a/app/submissions/routes.py
+++ b/app/submissions/routes.py
@@ -1,53 +1,91 @@
-from flask import render_template, redirect, url_for, flash, abort
+from flask import render_template, redirect, url_for, flash, abort, current_app
+from datetime import datetime
 from ..extensions import db
-from ..models import Meeting, Motion, MotionSubmission, AmendmentSubmission
+from ..models import (
+    Meeting,
+    Motion,
+    Member,
+    MotionSubmission,
+    AmendmentSubmission,
+    SubmissionToken,
+)
 from ..services.email import (
     send_motion_submission_alert,
     send_amendment_submission_alert,
+    notify_seconder_motion,
+    notify_seconder_amendment,
 )
 from . import bp
 from .forms import MotionSubmissionForm, AmendmentSubmissionForm
 
 
-@bp.route('/motion/<int:meeting_id>', methods=['GET', 'POST'])
-def submit_motion(meeting_id: int):
+@bp.route('/<token>/motion/<int:meeting_id>', methods=['GET', 'POST'])
+def submit_motion(token: str, meeting_id: int):
+    token_obj = SubmissionToken.verify(token, current_app.config["TOKEN_SALT"])
+    if not token_obj or token_obj.meeting_id != meeting_id:
+        abort(404)
     meeting = db.session.get(Meeting, meeting_id)
     if meeting is None:
         abort(404)
-    form = MotionSubmissionForm()
+    member = db.session.get(Member, token_obj.member_id)
+    if member is None or member.meeting_id != meeting_id:
+        abort(404)
+    form = MotionSubmissionForm(name=member.name, email=member.email)
+    members = Member.query.filter_by(meeting_id=meeting.id).order_by(Member.name).all()
+    form.seconder_id.choices = [(m.id, m.name) for m in members if m.id != member.id]
     if form.validate_on_submit():
         sub = MotionSubmission(
             meeting_id=meeting.id,
+            member_id=member.id,
             name=form.name.data,
             email=form.email.data,
+            seconder_id=form.seconder_id.data,
             title=form.title.data,
             text_md=form.text_md.data,
         )
         db.session.add(sub)
+        token_obj.used_at = datetime.utcnow()
         db.session.commit()
         send_motion_submission_alert(sub, meeting)
+        seconder = db.session.get(Member, form.seconder_id.data)
+        if seconder:
+            notify_seconder_motion(seconder, meeting)
         flash('Motion submitted for review', 'success')
         return redirect(url_for('main.public_meeting_detail', meeting_id=meeting.id))
     return render_template('submissions/motion_form.html', form=form, meeting=meeting)
 
 
-@bp.route('/amendment/<int:motion_id>', methods=['GET', 'POST'])
-def submit_amendment(motion_id: int):
+@bp.route('/<token>/amendment/<int:motion_id>', methods=['GET', 'POST'])
+def submit_amendment(token: str, motion_id: int):
     motion = db.session.get(Motion, motion_id)
     if motion is None:
         abort(404)
+    token_obj = SubmissionToken.verify(token, current_app.config["TOKEN_SALT"])
+    if not token_obj or token_obj.meeting_id != motion.meeting_id:
+        abort(404)
     meeting = db.session.get(Meeting, motion.meeting_id)
-    form = AmendmentSubmissionForm()
+    member = db.session.get(Member, token_obj.member_id)
+    if member is None or member.meeting_id != meeting.id:
+        abort(404)
+    form = AmendmentSubmissionForm(name=member.name, email=member.email)
+    members = Member.query.filter_by(meeting_id=meeting.id).order_by(Member.name).all()
+    form.seconder_id.choices = [(m.id, m.name) for m in members if m.id != member.id]
     if form.validate_on_submit():
         sub = AmendmentSubmission(
             motion_id=motion.id,
+            member_id=member.id,
             name=form.name.data,
             email=form.email.data,
+            seconder_id=form.seconder_id.data,
             text_md=form.text_md.data,
         )
         db.session.add(sub)
+        token_obj.used_at = datetime.utcnow()
         db.session.commit()
         send_amendment_submission_alert(sub, motion, meeting)
+        seconder = db.session.get(Member, form.seconder_id.data)
+        if seconder:
+            notify_seconder_amendment(seconder, meeting, motion)
         flash('Amendment submitted for review', 'success')
         return redirect(url_for('meetings.view_motion', motion_id=motion.id))
     return render_template('submissions/amendment_form.html', form=form, motion=motion)

--- a/app/templates/email/seconder_notice.html
+++ b/app/templates/email/seconder_notice.html
@@ -1,0 +1,1 @@
+<p>You have been listed as the seconder for a submission in {{ meeting.title }}.</p>

--- a/app/templates/email/seconder_notice.txt
+++ b/app/templates/email/seconder_notice.txt
@@ -1,0 +1,1 @@
+You have been listed as the seconder for a submission in {{ meeting.title }}.

--- a/app/templates/submissions/amendment_form.html
+++ b/app/templates/submissions/amendment_form.html
@@ -17,6 +17,10 @@
     {{ form.text_md.label(class_='block font-semibold') }}
     {{ form.text_md(class_='border p-3 rounded w-full') }}
   </div>
+  <div>
+    {{ form.seconder_id.label(class_='block font-semibold') }}
+    {{ form.seconder_id(class_='border p-2 rounded w-full') }}
+  </div>
   <button type="submit" class="bp-btn-primary">Submit Amendment</button>
 </form>
 {% endblock %}

--- a/app/templates/submissions/motion_form.html
+++ b/app/templates/submissions/motion_form.html
@@ -21,6 +21,10 @@
     {{ form.text_md.label(class_='block font-semibold') }}
     {{ form.text_md(class_='border p-3 rounded w-full') }}
   </div>
+  <div>
+    {{ form.seconder_id.label(class_='block font-semibold') }}
+    {{ form.seconder_id(class_='border p-2 rounded w-full') }}
+  </div>
   <button type="submit" class="bp-btn-primary">Submit Motion</button>
 </form>
 {% endblock %}

--- a/docs/full-database-structure.md
+++ b/docs/full-database-structure.md
@@ -153,6 +153,14 @@ This document summarises all tables and columns created by the Alembic migration
 | stage | Integer | |
 | used_at | DateTime | |
 
+### submission_tokens
+| Column | Type | Notes |
+|-------|------|-------|
+| token | String(64) | SHA-256 hash of the emailed token |
+| member_id | Integer | FK `members.id` |
+| meeting_id | Integer | FK `meetings.id` |
+| used_at | DateTime | |
+
 ### unsubscribe_tokens
 | Column | Type | Notes |
 |-------|------|-------|

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -445,6 +445,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-10 – Added PDF export for final results on public results page.
 * 2025-07-10 – Added Stage 2 reminder job and email templates.
 * 2025-07-10 – Added password reset flow with email tokens.
+* 2025-07-11 – Submission links now use member tokens and notify seconders.
 * 2025-06-21 – Rate limited comment posting to 5 per minute.
 * 2025-06-21 – Added public motion/amendment submission forms with email alerts.
 

--- a/migrations/versions/r1s2t3u4_add_submission_tokens_and_seconders.py
+++ b/migrations/versions/r1s2t3u4_add_submission_tokens_and_seconders.py
@@ -1,0 +1,39 @@
+"""add submission tokens and seconder fields"""
+
+Revision ID: r1s2t3u4
+Revises: q1w2e3r4
+Create Date: 2025-07-11 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'r1s2t3u4'
+down_revision = 'q1w2e3r4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'submission_tokens',
+        sa.Column('token', sa.String(length=64), primary_key=True),
+        sa.Column('member_id', sa.Integer(), sa.ForeignKey('members.id')),
+        sa.Column('meeting_id', sa.Integer(), sa.ForeignKey('meetings.id')),
+        sa.Column('used_at', sa.DateTime(), nullable=True),
+    )
+    with op.batch_alter_table('motion_submissions') as batch_op:
+        batch_op.add_column(sa.Column('member_id', sa.Integer(), sa.ForeignKey('members.id')))
+        batch_op.add_column(sa.Column('seconder_id', sa.Integer(), sa.ForeignKey('members.id')))
+    with op.batch_alter_table('amendment_submissions') as batch_op:
+        batch_op.add_column(sa.Column('member_id', sa.Integer(), sa.ForeignKey('members.id')))
+        batch_op.add_column(sa.Column('seconder_id', sa.Integer(), sa.ForeignKey('members.id')))
+
+
+def downgrade():
+    with op.batch_alter_table('amendment_submissions') as batch_op:
+        batch_op.drop_column('seconder_id')
+        batch_op.drop_column('member_id')
+    with op.batch_alter_table('motion_submissions') as batch_op:
+        batch_op.drop_column('seconder_id')
+        batch_op.drop_column('member_id')
+    op.drop_table('submission_tokens')

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -3,7 +3,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app import create_app
 from app.extensions import db
-from app.models import Meeting, Motion
+from app.models import Meeting, Motion, Member, SubmissionToken
 
 
 def setup_app():
@@ -20,11 +20,18 @@ def test_submit_pages_load():
         meeting = Meeting(title='T')
         db.session.add(meeting)
         db.session.flush()
+        member = Member(meeting_id=meeting.id, name='Alice', email='a@example.com')
+        db.session.add(member)
+        db.session.flush()
         motion = Motion(meeting_id=meeting.id, title='M', text_md='t', category='motion', threshold='normal', ordering=1)
         db.session.add(motion)
         db.session.commit()
+        token_obj, plain = SubmissionToken.create(member.id, meeting.id, 's')
+        db.session.commit()
     client = app.test_client()
-    resp = client.get(f'/submit/motion/{meeting.id}')
+    resp = client.get(f'/submit/{plain}/motion/{meeting.id}')
     assert resp.status_code == 200
-    resp = client.get(f'/submit/amendment/{motion.id}')
+    token_obj2, plain2 = SubmissionToken.create(member.id, meeting.id, 's')
+    db.session.commit()
+    resp = client.get(f'/submit/{plain2}/amendment/{motion.id}')
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- secure motion and amendment submission endpoints with new SubmissionToken
- email seconders when they are listed on a submission
- include seconder field on submission forms
- generate submission tokens when sending invites
- document new table and changelog entry
- include tests for tokenised submission pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6856b34b1840832bbffd3863c675ad09