### PR TITLE
Improve motion submission guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ VoteBuddy aims to apply principles from UK Parliamentary Proceedure as well as "
 - iCalendar downloads for Stage 1 and Stage 2 voting windows
 - Results exports to CSV and DOCX plus audit logs
 - Clone meetings to duplicate motions and amendments
+- Token-based forms for submitting motions and amendments with coordinator review
 - Optional unsubscribe tokens for members
 - Built in Python (Flask)
 

--- a/app/submissions/routes.py
+++ b/app/submissions/routes.py
@@ -17,7 +17,7 @@ from ..services.email import (
 )
 from . import bp
 from .forms import MotionSubmissionForm, AmendmentSubmissionForm
-from ..auth.routes import permission_required
+from ..permissions import permission_required
 from flask_login import login_required
 
 

--- a/app/templates/help/help.html
+++ b/app/templates/help/help.html
@@ -63,7 +63,8 @@
               Motion
             </h3>
             <p>Members vote on the final motion text after any carried amendments have been applied. A 75% majority is required for special resolutions.</p>
-            <p class="mt-2">To propose a new motion, visit the public meeting page and click <strong>Submit Motion</strong>.</p>
+            <p class="mt-2">To propose a new motion, visit the public meeting page and click <strong>Submit Motion</strong> to open the short form. After you submit it the coordinators will review your text.</p>
+            <p class="mt-2">To suggest changes to an existing motion, open that motion and choose <strong>Submit Amendment</strong>. Enter your wording and seconder and you'll receive an email once it has been reviewed.</p>
           </div>
         </div>
         

--- a/docs/help-voting.md
+++ b/docs/help-voting.md
@@ -27,11 +27,17 @@ download an `.ics` file that you can import into most calendar apps.
 
 ## Submitting motions and amendments
 
-Before the notice deadline you can propose new motions or submit amendments
-to published motions. Visit the public meeting page and click **Submit Motion**
-to file a proposal. Once motions are listed each one has a **Submit Amendment**
-link for changes. After you fill in the form the coordinators are emailed and
-will review your text before voting opens.
+Before the notice deadline you can propose new motions or submit amendments to
+published motions.
+
+1. When the submission window opens you'll receive a special **Submit Motion**
+   link by email. Follow it to fill out a short form with your motion title,
+   text and chosen seconder.
+2. After submitting you'll see a confirmation message while coordinators review
+   your proposal.
+3. To change an existing motion, open it on the meeting page and click
+   **Submit Amendment**. Enter your wording and seconder just like the motion
+   form. You'll get an email once your amendment is accepted or rejected.
 
 ## Manual tally entry
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -466,3 +466,4 @@ SES/SMTP  ─── Outbound mail
 
 *Draft v0.1 – generated 13 Jun 2025.*
 * 2025-07-15 – Added meeting file uploads with public links.
+* 2025-07-16 – Expanded help docs with motion and amendment submission steps.


### PR DESCRIPTION
## Summary
- clarify submission steps in help docs and help page
- list motion/amend submission forms in README features
- fix import path for permission_required
- log docs update in PRD

## Testing
- `pytest -q` *(fails: DetachedInstanceError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_b_6856baf330ac832b8ba254ab11599d00