### PR TITLE
Add License section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,7 @@ Refer to these files for detail on features, design and governance context.
 ## Contributing
 
 Pull requests are welcome. Please include updates to migrations or documentation where relevant.
+
+## License
+
+This project is released under the [Apache 2.0](LICENCE.md) license.


### PR DESCRIPTION
## Summary
- document Apache 2.0 licensing in README

## Testing
- `flask --app app run --port 5555` *(fails: user interrupted)*
- `flask db upgrade` *(fails: SyntaxError in migration script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857014d90b4832b8cc8fca5eb146cf1