### PR TITLE
Improve Flask CLI instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ This guide directs AI and human contributors for all folders in this repository.
 | Task | Command |
 |------|--------|
 | Start containers | `docker-compose up --build` |
-| Run dev server | `flask --app app run` |
+| Install dependencies | `pip install -r requirements.txt` |
+| Run dev server | `FLASK_APP=app flask run --port 5555` |
 | Apply migrations | `flask db upgrade` |
 
 ## Documentation Rules
@@ -55,13 +56,16 @@ Docker-compose commands dont work in OpenAI Codex, you'll get this error so dont
 docker-compose up --build -d (failed to run: docker-compose: command not found
 ```
 
-When running flask for testing try a non standard port as sometimes we get this error:
+When running Flask for testing, use a non-standard port as sometimes we get this error:
 ```
 flask --app app run (failed: port already in use in second attempt)
 ```
+Always install dependencies first with `pip install -r requirements.txt` so the `flask` command is available.
+If `flask` still isn't found, invoke commands via `python -m flask --app app`.
 
 ## Change Log
 | Date | Author | Reason |
 |------|--------|-------|
 | 2025-06-13 | Initial draft | Repository documentation for agents |
+| 2025-06-21 | Docs update | Added Flask troubleshooting and install step |
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The following images show the main dashboard and help section in action.
 ```bash
 pip install -r requirements.txt
 ```
+If the `flask` command isn't found after installation, run commands using
+`python -m flask --app app` instead of `flask`.
+
 3. Build and start the containers:
 
 ```bash
@@ -103,10 +106,15 @@ flask --app app create-admin
 
 The `web` service runs migrations on start and exposes the app at `http://localhost:8000`.
 
-To run the development server directly on your machine, install the requirements and execute:
+To run the development server directly on your machine, first install the requirements and then execute:
 
 ```bash
-python -m flask --app app run
+FLASK_APP=app flask run --port 5555
+```
+If the `flask` command is unavailable, use:
+
+```bash
+python -m flask --app app run --port 5555
 ```
 
 ### Generating demo data


### PR DESCRIPTION
## Summary
- document installing deps and new dev server command
- explain how to run Flask when the CLI isn't found

## Testing
- `pip install -r requirements.txt`
- `FLASK_APP=app flask run --port 5555` *(terminated after launch)*
- `flask db upgrade` *(fails: SyntaxError: leading zeros in decimal integer literals are not permitted)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685704f20f48832bab8fe822c2a534b0