### PR TITLE
Remove unused Inches import

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -21,7 +21,7 @@ from ..models import (
 from uuid6 import uuid7
 from sqlalchemy import func
 from docx import Document
-from docx.shared import RGBColor, Inches, Pt
+from docx.shared import RGBColor, Pt
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import parse_xml
 from docx.oxml.ns import nsdecls


### PR DESCRIPTION
## Summary
- clean up unused import in email service

## Testing
- `pip install -r requirements.txt`
- `FLASK_APP=app flask run --port 5555` *(fails: we terminated after start)*
- `flask db upgrade` *(fails: SyntaxError in migrations)*
- `pytest -k email_service -q`
- `ruff check app/services/email.py`

------
https://chatgpt.com/codex/tasks/task_b_6857078712d0832b87edfc1a37d00254