### PR TITLE
Fix migrations and doc guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This guide directs AI and human contributors for all folders in this repository.
 | Start containers | `docker-compose up --build` |
 | Install dependencies | `pip install -r requirements.txt` |
 | Run dev server | `FLASK_APP=app flask run --port 5555` |
-| Apply migrations | `flask db upgrade` |
+| Apply migrations | `FLASK_APP=app flask db upgrade` |
 
 ## Documentation Rules
 - When merging a feature PR, append a date + summary to `docs/prd.md` under **Changelog**.

--- a/migrations/versions/p2q3r4s5_add_submission_tables.py
+++ b/migrations/versions/p2q3r4s5_add_submission_tables.py
@@ -1,4 +1,4 @@
-"""add submission tables"""
+"""add submission tables
 
 Revision ID: p2q3r4s5
 Revises: p1q2r3s4

--- a/migrations/versions/r1s2t3u4_add_submission_tokens_and_seconders.py
+++ b/migrations/versions/r1s2t3u4_add_submission_tokens_and_seconders.py
@@ -1,4 +1,4 @@
-"""add submission tokens and seconder fields"""
+"""add submission tokens and seconder fields
 
 Revision ID: r1s2t3u4
 Revises: q1w2e3r4


### PR DESCRIPTION
## Summary
- fix syntax errors in old migration files
- clarify how to run migrations in AGENTS guide

## Testing
- `pip install -r requirements.txt`
- `FLASK_APP=app flask run --port 5555` *(terminated after launch)*
- `FLASK_APP=app flask db upgrade 22043ac5e6e1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685707209198832b9f13c7999a347498