### PR TITLE
Remove unused helper in tasks

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -158,15 +158,6 @@ def cleanup_vote_tokens() -> None:
     db.session.commit()
 
 
-def _time_remaining(dt: datetime) -> str:
-    delta = dt - datetime.utcnow()
-    if delta.total_seconds() <= 0:
-        return "0d 0h"
-    days = delta.days
-    hours = delta.seconds // 3600
-    return f"{days}d {hours}h"
-
-
 def check_objection_deadlines() -> None:
     now = datetime.utcnow()
     objs_first = AmendmentObjection.query.filter(


### PR DESCRIPTION
## Summary
- delete `_time_remaining` helper from `app/tasks.py`
- `pytest -q` passes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68570a72bccc832b852683f5944a9599