### PR TITLE
Add amendment submission button

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -549,11 +549,17 @@ def view_motion(motion_id):
         .filter(Amendment.motion_id == motion.id)
         .all()
     )
+    token = request.args.get("token")
+    if token:
+        token_obj = SubmissionToken.verify(token, current_app.config["TOKEN_SALT"])
+        if not token_obj or token_obj.meeting_id != motion.meeting_id:
+            token = None
     return render_template(
         "meetings/view_motion.html",
         motion=motion,
         amendments=amendments,
         conflicts=conflicts,
+        token=token,
     )
 
 

--- a/app/templates/meetings/view_motion.html
+++ b/app/templates/meetings/view_motion.html
@@ -4,6 +4,9 @@
 <div class="bp-card bp-glow mb-4">{{ (motion.text_md or 'No motion text.')|markdown_to_html|safe }}</div>
 <h3 class="font-bold mb-2">Amendments</h3>
 <a href="{{ url_for('meetings.manage_conflicts', motion_id=motion.id) }}" class="bp-btn-secondary mb-4 inline-block">Manage Conflicts</a>
+{% if token %}
+<a href="{{ url_for('submissions.submit_amendment', token=token, motion_id=motion.id) }}" class="bp-btn-primary mb-4 inline-block">Submit Amendment</a>
+{% endif %}
 {% for amend in amendments %}
   <div class="bp-card mb-2">
     <p class="font-semibold mb-1">

--- a/docs/help-voting.md
+++ b/docs/help-voting.md
@@ -31,13 +31,12 @@ Before the notice deadline you can propose new motions or submit amendments to
 published motions.
 
 1. When the submission window opens you'll receive a special **Submit Motion**
-   link by email. Follow it to fill out a short form with your motion title,
-   text and chosen seconder.
-2. After submitting you'll see a confirmation message while coordinators review
+   link by email. This link includes a personal token authorising submissions.
+2. Keep that email handy&mdash;the same token lets you submit amendments. Open
+   the motion you wish to change and click **Submit Amendment** to access the
+   form.
+3. After submitting you'll see a confirmation message while coordinators review
    your proposal.
-3. To change an existing motion, open it on the meeting page and click
-   **Submit Amendment**. Enter your wording and seconder just like the motion
-   form. You'll get an email once your amendment is accepted or rejected.
 
 ## Manual tally entry
 


### PR DESCRIPTION
## Summary
- show Submit Amendment button on motion page when a submission token is present
- validate token in `view_motion` route and pass it to the template
- explain token emails in the voting help docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68570a49493c832b80de626c359e0339