### PR TITLE
Add manual email action to results summary

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1147,11 +1147,13 @@ def results_summary(meeting_id: int):
             and principal.meeting_id == meeting.id
         ):
             unused_proxy_tokens.append((t, proxy, principal))
+    manual_email_mode = AppSetting.get("manual_email_mode") == "1"
     return render_template(
         "meetings/results_summary.html",
         meeting=meeting,
         results=results,
         unused_proxy_tokens=unused_proxy_tokens,
+        manual_email_mode=manual_email_mode,
     )
 
 

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -68,6 +68,9 @@
 {% endif %}
 <a href="{{ url_for('meetings.results_docx', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block">Download DOCX</a>
 <a href="{{ url_for('meetings.results_stage2_docx', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block ml-2">Download Final DOCX</a>
+{% if manual_email_mode %}
+<a href="{{ url_for('meetings.manual_send_emails', meeting_id=meeting.id) }}" class="bp-btn-primary mt-4 inline-block ml-2">Send Emails</a>
+{% endif %}
 {% if meeting.status == 'Pending Stage 2' %}
 <a href="{{ url_for('meetings.prepare_stage2', meeting_id=meeting.id) }}" class="bp-btn-primary mt-4 inline-block ml-2">Prepare Stage 2 Motion</a>
 {% elif meeting.status == 'Completed' %}


### PR DESCRIPTION
## Summary
- allow results summary template to show manual send button
- expose manual_email_mode flag in `results_summary` route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68570a3133ec832bb06f81a1183f97ac