### PR TITLE
Add per-member resend links

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1130,6 +1130,11 @@ def results_summary(meeting_id: int):
         abort(404)
     results = _amendment_results(meeting)
     stage = 2 if meeting.status in {"Stage 2", "Pending Stage 2"} else 1
+    members = (
+        Member.query.filter_by(meeting_id=meeting.id, is_test=False)
+        .order_by(Member.name)
+        .all()
+    )
     tokens = (
         VoteToken.query
         .filter_by(stage=stage, used_at=None, is_test=False)
@@ -1151,6 +1156,7 @@ def results_summary(meeting_id: int):
         "meetings/results_summary.html",
         meeting=meeting,
         results=results,
+        members=members,
         unused_proxy_tokens=unused_proxy_tokens,
     )
 

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -38,6 +38,30 @@
   {% endfor %}
   </tbody>
 </table>
+<h2 class="font-bold text-bp-blue mt-6">Members</h2>
+<table class="bp-table w-full mt-2">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Email</th>
+      <th scope="col">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for m in members %}
+    <tr class="border-t">
+      <td class="p-2">{{ m.name }}</td>
+      <td class="p-2">{{ m.email }}</td>
+      <td class="p-2">
+        <form method="post" action="{{ url_for('meetings.resend_member_link', meeting_id=meeting.id, member_id=m.id) }}" class="inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="bp-btn-secondary">Resend link</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 {% if unused_proxy_tokens %}
 <h2 class="font-bold text-bp-blue mt-6">Unused Proxy Tokens</h2>
 <table class="bp-table w-full mt-2">

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -477,3 +477,4 @@ SES/SMTP  ─── Outbound mail
 
 
 
+* 2025-07-19 – Added per-member resend link on results summary.


### PR DESCRIPTION
## Summary
- let admins resend member tokens from results summary
- show members table with Resend link actions
- document the new capability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68570a2cb71c832b983bd6a986698cbe