### PR TITLE
Add link to manual email page

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1147,11 +1147,15 @@ def results_summary(meeting_id: int):
             and principal.meeting_id == meeting.id
         ):
             unused_proxy_tokens.append((t, proxy, principal))
+
+    manual_email_mode = AppSetting.get("manual_email_mode") == "1"
+
     return render_template(
         "meetings/results_summary.html",
         meeting=meeting,
         results=results,
         unused_proxy_tokens=unused_proxy_tokens,
+        manual_email_mode=manual_email_mode,
     )
 
 

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -68,6 +68,9 @@
 {% endif %}
 <a href="{{ url_for('meetings.results_docx', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block">Download DOCX</a>
 <a href="{{ url_for('meetings.results_stage2_docx', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block ml-2">Download Final DOCX</a>
+{% if manual_email_mode and current_user.has_permission('manage_meetings') %}
+<a href="{{ url_for('meetings.manual_send_emails', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block ml-2">Send Emails</a>
+{% endif %}
 {% if meeting.status == 'Pending Stage 2' %}
 <a href="{{ url_for('meetings.prepare_stage2', meeting_id=meeting.id) }}" class="bp-btn-primary mt-4 inline-block ml-2">Prepare Stage 2 Motion</a>
 {% elif meeting.status == 'Completed' %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -469,6 +469,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-16 – Expanded help docs with motion and amendment submission steps.
 * 2025-07-17 – Fake data generator now assigns member numbers, uses `.invalid` emails and marks demo records as test-only.
 * 2025-07-17 – Added .dockerignore to reduce Docker build context.
+* 2025-07-18 – Linked manual email sending page from results summary.
 
 
 


### PR DESCRIPTION
## Summary
- expose manual email sending page from results summary
- show link only when automatic emails are disabled
- document change in PRD

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68570a18bd84832b93c17c9a2c42f803