### PR TITLE
Replace deprecated get_or_404

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -67,7 +67,9 @@ def list_meetings():
 @token_required
 @limiter.limit("60 per minute", key_func=token_key_func)
 def meeting_results(meeting_id: int):
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if not meeting:
+        abort(404)
     if not meeting.public_results:
         abort(404)
 
@@ -112,7 +114,9 @@ def meeting_results(meeting_id: int):
 @limiter.limit("60 per minute", key_func=token_key_func)
 def meeting_stage1_results(meeting_id: int):
     """Return amendment tallies if stage results are public."""
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if not meeting:
+        abort(404)
     if not (meeting.early_public_results or meeting.public_results):
         abort(404)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -284,7 +284,9 @@ def public_results(meeting_id: int):
 
 @bp.route('/results/<int:meeting_id>/charts')
 def public_results_charts(meeting_id: int):
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if not meeting:
+        abort(404)
     if not meeting.public_results:
         abort(404)
     return render_template('results_chart.html', meeting=meeting)
@@ -293,7 +295,9 @@ def public_results_charts(meeting_id: int):
 @bp.route('/results/<int:meeting_id>/tallies.json')
 def public_results_json(meeting_id: int):
     """Return tallies for amendments and motions as JSON."""
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if not meeting:
+        abort(404)
     if not meeting.public_results:
         abort(404)
 
@@ -336,7 +340,9 @@ def public_results_json(meeting_id: int):
 @bp.route('/results/<int:meeting_id>/final.pdf')
 def public_results_pdf(meeting_id: int):
     """Download PDF summary of Stage 1 and Stage 2 results."""
-    meeting = Meeting.query.get_or_404(meeting_id)
+    meeting = db.session.get(Meeting, meeting_id)
+    if not meeting:
+        abort(404)
     if not meeting.public_results:
         abort(404)
 


### PR DESCRIPTION
## Summary
- avoid Flask-SQLAlchemy `query.get_or_404`
- use `db.session.get` and manual 404s

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68571353e598832ba6ae53383b13395a