### PR TITLE
Add tests for run-off ICS features

### DIFF
--- a/tests/test_public_runoff_ics.py
+++ b/tests/test_public_runoff_ics.py
@@ -1,0 +1,48 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from datetime import datetime, timedelta
+import pytest
+from werkzeug.exceptions import NotFound
+
+from app import create_app
+from app.extensions import db
+from app.models import Meeting
+from app import routes as main
+
+
+def _setup_app():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    return app
+
+
+def test_public_runoff_ics_downloads_when_timestamps_set():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        now = datetime.utcnow()
+        meeting = Meeting(
+            title='AGM',
+            runoff_opens_at=now,
+            runoff_closes_at=now + timedelta(hours=1),
+        )
+        db.session.add(meeting)
+        db.session.commit()
+        with app.test_request_context(f'/public/meetings/{meeting.id}/runoff.ics'):
+            resp = main.public_runoff_ics(meeting.id)
+            assert resp.mimetype == 'text/calendar'
+            cd = resp.headers['Content-Disposition']
+            assert 'runoff.ics' in cd
+
+
+def test_public_runoff_ics_missing_timestamps_returns_404():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        db.session.commit()
+        with app.test_request_context(f'/public/meetings/{meeting.id}/runoff.ics'):
+            with pytest.raises(NotFound):
+                main.public_runoff_ics(meeting.id)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ def test_markdown_to_html_sanitizes_and_marks_safe():
 from dataclasses import dataclass
 from datetime import datetime
 import pytest
-from app.utils import generate_stage_ics
+from app.utils import generate_stage_ics, generate_runoff_ics
 
 
 @dataclass
@@ -24,6 +24,13 @@ class DummyMeeting:
     closes_at_stage1: datetime | None = None
     opens_at_stage2: datetime | None = None
     closes_at_stage2: datetime | None = None
+
+
+@dataclass
+class RunoffMeeting:
+    title: str
+    runoff_opens_at: datetime | None = None
+    runoff_closes_at: datetime | None = None
 
 
 def test_generate_stage1_ics_contains_calendar_and_title():
@@ -54,4 +61,22 @@ def test_generate_stage_ics_missing_timestamps_raises_error():
     meeting = DummyMeeting(title="Broken")
     with pytest.raises(ValueError):
         generate_stage_ics(meeting, 2)
+
+
+def test_generate_runoff_ics_contains_calendar_and_title():
+    meeting = RunoffMeeting(
+        title="Test Meeting",
+        runoff_opens_at=datetime(2030, 1, 3, 9),
+        runoff_closes_at=datetime(2030, 1, 3, 10),
+    )
+    ics = generate_runoff_ics(meeting)
+    text = ics.decode()
+    assert "BEGIN:VCALENDAR" in text
+    assert "Test Meeting" in text
+
+
+def test_generate_runoff_ics_missing_timestamps_raises_error():
+    meeting = RunoffMeeting(title="Broken")
+    with pytest.raises(ValueError):
+        generate_runoff_ics(meeting)
 


### PR DESCRIPTION
## Summary
- cover `generate_runoff_ics` with positive and negative cases
- ensure `public_runoff_ics` serves a file when timestamps exist
- verify missing timestamps trigger a 404

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68571313df50832baccd1bae713c88fd