### PR TITLE
Add DB indexes for better performance

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -200,7 +200,7 @@ class Meeting(db.Model):
 class Member(db.Model):
     __tablename__ = "members"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
     member_number = db.Column(db.String(50))
     name = db.Column(db.String(255))
     email = db.Column(db.String(255))
@@ -214,7 +214,7 @@ class Member(db.Model):
 class Motion(db.Model):
     __tablename__ = "motions"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
     title = db.Column(db.String(255))
     text_md = db.Column(db.Text)
     final_text_md = db.Column(db.Text)
@@ -234,16 +234,16 @@ class Motion(db.Model):
 class MotionOption(db.Model):
     __tablename__ = "motion_options"
     id = db.Column(db.Integer, primary_key=True)
-    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"))
+    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"), index=True)
     text = db.Column(db.String(255))
 
 
 class VoteToken(db.Model):
     __tablename__ = "vote_tokens"
     token = db.Column(db.String(64), primary_key=True)
-    member_id = db.Column(db.Integer, db.ForeignKey("members.id"))
+    member_id = db.Column(db.Integer, db.ForeignKey("members.id"), index=True)
     proxy_holder_id = db.Column(db.Integer, db.ForeignKey("members.id"))
-    stage = db.Column(db.Integer)
+    stage = db.Column(db.Integer, index=True)
     used_at = db.Column(db.DateTime)
     is_test = db.Column(db.Boolean, default=False)
 
@@ -284,8 +284,8 @@ class SubmissionToken(db.Model):
     __tablename__ = "submission_tokens"
 
     token = db.Column(db.String(64), primary_key=True)
-    member_id = db.Column(db.Integer, db.ForeignKey("members.id"))
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
+    member_id = db.Column(db.Integer, db.ForeignKey("members.id"), index=True)
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
     used_at = db.Column(db.DateTime)
 
     @staticmethod
@@ -310,7 +310,7 @@ class SubmissionToken(db.Model):
 class UnsubscribeToken(db.Model):
     __tablename__ = "unsubscribe_tokens"
     token = db.Column(db.String(36), primary_key=True)
-    member_id = db.Column(db.Integer, db.ForeignKey("members.id"))
+    member_id = db.Column(db.Integer, db.ForeignKey("members.id"), index=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
@@ -347,7 +347,7 @@ class PasswordResetToken(db.Model):
     __tablename__ = "password_reset_tokens"
 
     token = db.Column(db.String(36), primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), index=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     used_at = db.Column(db.DateTime)
 
@@ -357,8 +357,8 @@ class PasswordResetToken(db.Model):
 class Amendment(db.Model):
     __tablename__ = "amendments"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
-    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"))
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
+    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"), index=True)
     text_md = db.Column(db.Text)
     order = db.Column(db.Integer)
     status = db.Column(db.String(50))
@@ -386,9 +386,9 @@ class Amendment(db.Model):
 class Vote(db.Model):
     __tablename__ = "votes"
     id = db.Column(db.Integer, primary_key=True)
-    member_id = db.Column(db.Integer, db.ForeignKey("members.id"))
-    amendment_id = db.Column(db.Integer, db.ForeignKey("amendments.id"), nullable=True)
-    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"), nullable=True)
+    member_id = db.Column(db.Integer, db.ForeignKey("members.id"), index=True)
+    amendment_id = db.Column(db.Integer, db.ForeignKey("amendments.id"), nullable=True, index=True)
+    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"), nullable=True, index=True)
     choice = db.Column(db.String(10))
     hash = db.Column(db.String(128))
     is_test = db.Column(db.Boolean, default=False)
@@ -447,7 +447,7 @@ class User(db.Model, UserMixin):
 class Runoff(db.Model):
     __tablename__ = "runoffs"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
     amendment_a_id = db.Column(db.Integer, db.ForeignKey("amendments.id"))
     amendment_b_id = db.Column(db.Integer, db.ForeignKey("amendments.id"))
     tie_break_method = db.Column(db.String(20), nullable=True)
@@ -456,7 +456,7 @@ class Runoff(db.Model):
 class AmendmentConflict(db.Model):
     __tablename__ = "amendment_conflicts"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
     amendment_a_id = db.Column(db.Integer, db.ForeignKey("amendments.id"))
     amendment_b_id = db.Column(db.Integer, db.ForeignKey("amendments.id"))
 
@@ -491,14 +491,14 @@ class AmendmentObjection(db.Model):
 class Comment(db.Model):
     __tablename__ = "comments"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
-    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"), nullable=True)
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
+    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"), nullable=True, index=True)
     amendment_id = db.Column(
-        db.Integer, db.ForeignKey("amendments.id"), nullable=True
+        db.Integer, db.ForeignKey("amendments.id"), nullable=True, index=True
     )
-    member_id = db.Column(db.Integer, db.ForeignKey("members.id"))
+    member_id = db.Column(db.Integer, db.ForeignKey("members.id"), index=True)
     text_md = db.Column(db.Text)
-    hidden = db.Column(db.Boolean, default=False)
+    hidden = db.Column(db.Boolean, default=False, index=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     edited_at = db.Column(db.DateTime)
     revisions = db.relationship("CommentRevision", backref="comment")
@@ -522,8 +522,8 @@ class CommentRevision(db.Model):
 class EmailLog(db.Model):
     __tablename__ = "email_logs"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
-    member_id = db.Column(db.Integer, db.ForeignKey("members.id"))
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
+    member_id = db.Column(db.Integer, db.ForeignKey("members.id"), index=True)
     type = db.Column(db.String(50))
     is_test = db.Column(db.Boolean, default=False)
     sent_at = db.Column(db.DateTime, default=datetime.utcnow)
@@ -535,7 +535,7 @@ class AdminLog(db.Model):
     __tablename__ = "admin_logs"
 
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), index=True)
     user = db.relationship("User")
     action = db.Column(db.String(50))
     details = db.Column(db.Text)
@@ -545,8 +545,8 @@ class AdminLog(db.Model):
 class MotionSubmission(db.Model):
     __tablename__ = "motion_submissions"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
-    member_id = db.Column(db.Integer, db.ForeignKey("members.id"))
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
+    member_id = db.Column(db.Integer, db.ForeignKey("members.id"), index=True)
     name = db.Column(db.String(255))
     email = db.Column(db.String(255))
     seconder_id = db.Column(db.Integer, db.ForeignKey("members.id"))
@@ -557,8 +557,8 @@ class MotionSubmission(db.Model):
 class AmendmentSubmission(db.Model):
     __tablename__ = "amendment_submissions"
     id = db.Column(db.Integer, primary_key=True)
-    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"))
-    member_id = db.Column(db.Integer, db.ForeignKey("members.id"))
+    motion_id = db.Column(db.Integer, db.ForeignKey("motions.id"), index=True)
+    member_id = db.Column(db.Integer, db.ForeignKey("members.id"), index=True)
     name = db.Column(db.String(255))
     email = db.Column(db.String(255))
     seconder_id = db.Column(db.Integer, db.ForeignKey("members.id"))
@@ -569,7 +569,7 @@ class AmendmentSubmission(db.Model):
 class MeetingFile(db.Model):
     __tablename__ = "meeting_files"
     id = db.Column(db.Integer, primary_key=True)
-    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"))
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
     filename = db.Column(db.String(255))
     title = db.Column(db.String(255))
     description = db.Column(db.Text)

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -298,6 +298,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-14 – Added secondary button, table, badge and card styles.
 * 2025-06-14 – Added dotenv loading with SQLite fallback when `DATABASE_URL` is unset.
 * 2025-06-14 – Added focus-visible outlines for buttons and links.
+* 2025-06-22 – Added indexes on frequently filtered columns for better performance.
 * 2025-06-15 – Implemented dark mode with optional theme toggle.
 * 2025-06-14 – Expanded UI/UX design guidance with extended design patterns.
 * 2025-06-14 – Implemented meetings list view with table layout.

--- a/migrations/versions/i20240701_add_performance_indexes.py
+++ b/migrations/versions/i20240701_add_performance_indexes.py
@@ -1,0 +1,74 @@
+"""add performance indexes
+
+Revision ID: i20240701
+Revises: s1t2u3v4
+Create Date: 2025-06-22 01:04:57.974821
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'i20240701'
+down_revision = 's1t2u3v4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index("ix_members_meeting_id", "members", ["meeting_id"])
+    op.create_index("ix_motions_meeting_id", "motions", ["meeting_id"])
+    op.create_index("ix_amendments_meeting_id", "amendments", ["meeting_id"])
+    op.create_index("ix_amendments_motion_id", "amendments", ["motion_id"])
+    op.create_index("ix_vote_tokens_member_id", "vote_tokens", ["member_id"])
+    op.create_index("ix_vote_tokens_stage", "vote_tokens", ["stage"])
+    op.create_index("ix_submission_tokens_member_id", "submission_tokens", ["member_id"])
+    op.create_index("ix_submission_tokens_meeting_id", "submission_tokens", ["meeting_id"])
+    op.create_index("ix_unsubscribe_tokens_member_id", "unsubscribe_tokens", ["member_id"])
+    op.create_index("ix_votes_member_id", "votes", ["member_id"])
+    op.create_index("ix_votes_amendment_id", "votes", ["amendment_id"])
+    op.create_index("ix_votes_motion_id", "votes", ["motion_id"])
+    op.create_index("ix_comments_meeting_id", "comments", ["meeting_id"])
+    op.create_index("ix_comments_motion_id", "comments", ["motion_id"])
+    op.create_index("ix_comments_amendment_id", "comments", ["amendment_id"])
+    op.create_index("ix_comments_member_id", "comments", ["member_id"])
+    op.create_index("ix_comments_hidden", "comments", ["hidden"])
+    op.create_index("ix_email_logs_meeting_id", "email_logs", ["meeting_id"])
+    op.create_index("ix_email_logs_member_id", "email_logs", ["member_id"])
+    op.create_index("ix_admin_logs_user_id", "admin_logs", ["user_id"])
+    op.create_index("ix_password_reset_tokens_user_id", "password_reset_tokens", ["user_id"])
+    op.create_index("ix_motion_submissions_meeting_id", "motion_submissions", ["meeting_id"])
+    op.create_index("ix_motion_submissions_member_id", "motion_submissions", ["member_id"])
+    op.create_index("ix_amendment_submissions_motion_id", "amendment_submissions", ["motion_id"])
+    op.create_index("ix_amendment_submissions_member_id", "amendment_submissions", ["member_id"])
+    op.create_index("ix_meeting_files_meeting_id", "meeting_files", ["meeting_id"])
+
+
+def downgrade():
+    op.drop_index("ix_meeting_files_meeting_id", table_name="meeting_files")
+    op.drop_index("ix_amendment_submissions_member_id", table_name="amendment_submissions")
+    op.drop_index("ix_amendment_submissions_motion_id", table_name="amendment_submissions")
+    op.drop_index("ix_motion_submissions_member_id", table_name="motion_submissions")
+    op.drop_index("ix_motion_submissions_meeting_id", table_name="motion_submissions")
+    op.drop_index("ix_password_reset_tokens_user_id", table_name="password_reset_tokens")
+    op.drop_index("ix_admin_logs_user_id", table_name="admin_logs")
+    op.drop_index("ix_email_logs_member_id", table_name="email_logs")
+    op.drop_index("ix_email_logs_meeting_id", table_name="email_logs")
+    op.drop_index("ix_comments_hidden", table_name="comments")
+    op.drop_index("ix_comments_member_id", table_name="comments")
+    op.drop_index("ix_comments_amendment_id", table_name="comments")
+    op.drop_index("ix_comments_motion_id", table_name="comments")
+    op.drop_index("ix_comments_meeting_id", table_name="comments")
+    op.drop_index("ix_votes_motion_id", table_name="votes")
+    op.drop_index("ix_votes_amendment_id", table_name="votes")
+    op.drop_index("ix_votes_member_id", table_name="votes")
+    op.drop_index("ix_unsubscribe_tokens_member_id", table_name="unsubscribe_tokens")
+    op.drop_index("ix_submission_tokens_meeting_id", table_name="submission_tokens")
+    op.drop_index("ix_submission_tokens_member_id", table_name="submission_tokens")
+    op.drop_index("ix_vote_tokens_stage", table_name="vote_tokens")
+    op.drop_index("ix_vote_tokens_member_id", table_name="vote_tokens")
+    op.drop_index("ix_amendments_motion_id", table_name="amendments")
+    op.drop_index("ix_amendments_meeting_id", table_name="amendments")
+    op.drop_index("ix_motions_meeting_id", table_name="motions")
+    op.drop_index("ix_members_meeting_id", table_name="members")


### PR DESCRIPTION
## Summary
- add indexes to models for common query fields
- create migration to add/drop these indexes
- log change in docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685755de3d48832ba458945ec61e9888