### PR TITLE
Add help link to member emails

### DIFF
--- a/app/templates/email/final_results.html
+++ b/app/templates/email/final_results.html
@@ -24,6 +24,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/final_results.txt
+++ b/app/templates/email/final_results.txt
@@ -9,8 +9,10 @@ Hello {{ member.name }},
 
 {% if results_link %}
 See the full results: {{ results_link }}
+Need help? {{ url_for('help.show_help', _external=True) }}
 {% else %}
 The certified results document is attached.
+Need help? {{ url_for('help.show_help', _external=True) }}
 {% endif %}
 
 If you did not expect this email you can ignore it.

--- a/app/templates/email/invite.html
+++ b/app/templates/email/invite.html
@@ -8,6 +8,7 @@
     <td style="padding:24px;background-color:#FFFFFF;">
       <p>Hello {{ member.name }},</p>
       <p>You are invited to vote in <strong>{{ meeting.title }}</strong>.</p>
+      <p>This link is unique to you. For an overview of how online voting works, see <a href="{{ url_for('help.show_help', _external=True) }}">the voting help page</a>.</p>
       {% if test_mode %}
       <p style="color:#DC0714;"><strong>TEST MODE:</strong> votes cast using this link will be recorded as test data.</p>
       {% endif %}
@@ -23,6 +24,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/invite.txt
+++ b/app/templates/email/invite.txt
@@ -4,6 +4,7 @@ Hello {{ member.name }},
 {% endif %}
 
 You are invited to vote in {{ meeting.title }}.
+This link is unique to you. For an overview see {{ url_for('help.show_help', _external=True) }}
 Use the link below to cast your ballot:
 
 {{ link }}
@@ -12,6 +13,7 @@ An iCalendar file with the voting window is attached for your diary.
 
 Submit an objection to a rejected amendment:
 {{ objection_link }}
+Need help? {{ url_for('help.show_help', _external=True) }}
 
 If you did not expect this email you can ignore it.
 To stop these emails, visit {{ unsubscribe_url }}

--- a/app/templates/email/proxy_invite.html
+++ b/app/templates/email/proxy_invite.html
@@ -21,6 +21,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/proxy_invite.txt
+++ b/app/templates/email/proxy_invite.txt
@@ -7,6 +7,7 @@ You have been nominated as a proxy for {{ principal.name }} in {{ meeting.title 
 Use the link below to cast their ballot:
 
 {{ link }}
+Need help? {{ url_for('help.show_help', _external=True) }}
 
 If you did not expect this email you can ignore it.
 To stop these emails, visit {{ unsubscribe_url }}

--- a/app/templates/email/quorum_failure.html
+++ b/app/templates/email/quorum_failure.html
@@ -14,6 +14,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/quorum_failure.txt
+++ b/app/templates/email/quorum_failure.txt
@@ -3,6 +3,7 @@ Hello {{ member.name }},
 The Stage 1 vote for {{ meeting.title }} did not reach quorum and has been declared void.
 
 The Board will review the options and you will be notified when a new ballot is scheduled.
+Need help? {{ url_for('help.show_help', _external=True) }}
 
 If you did not expect this email you can ignore it.
 To stop these emails, visit {{ unsubscribe_url }}

--- a/app/templates/email/receipt.html
+++ b/app/templates/email/receipt.html
@@ -23,6 +23,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/receipt.txt
+++ b/app/templates/email/receipt.txt
@@ -10,6 +10,7 @@ Receipt hashes:
 {% endfor %}
 
 You can verify a receipt hash at {{ url_for('voting.verify_receipt', _external=True) }}
+Need help? {{ url_for('help.show_help', _external=True) }}
 
 To stop these emails, visit {{ unsubscribe_url }}
 To start them again later, visit {{ resubscribe_url }}

--- a/app/templates/email/reminder.html
+++ b/app/templates/email/reminder.html
@@ -22,6 +22,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/reminder.txt
+++ b/app/templates/email/reminder.txt
@@ -11,5 +11,6 @@ Voting closes soon. Use the link below:
 If you already voted, you can ignore this email.
 Submit an objection:
 {{ objection_link }}
+Need help? {{ url_for('help.show_help', _external=True) }}
 To stop these reminders, visit {{ unsubscribe_url }}
 To start them again later, visit {{ resubscribe_url }}

--- a/app/templates/email/runoff_invite.html
+++ b/app/templates/email/runoff_invite.html
@@ -22,6 +22,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/runoff_invite.txt
+++ b/app/templates/email/runoff_invite.txt
@@ -9,6 +9,7 @@ Use the link below to cast your ballot:
 {{ link }}
 
 An iCalendar file with the run-off voting window is attached for your diary.
+Need help? {{ url_for('help.show_help', _external=True) }}
 
 If you did not expect this email you can ignore it.
 To stop these emails, visit {{ unsubscribe_url }}

--- a/app/templates/email/stage2_invite.html
+++ b/app/templates/email/stage2_invite.html
@@ -29,6 +29,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/stage2_invite.txt
+++ b/app/templates/email/stage2_invite.txt
@@ -18,6 +18,7 @@ Use the link below to cast your ballot:
 {{ link }}
 
 An iCalendar file with the Stage 2 voting window is attached for your diary.
+Need help? {{ url_for('help.show_help', _external=True) }}
 
 If you did not expect this email you can ignore it.
 To stop these emails, visit {{ unsubscribe_url }}

--- a/app/templates/email/stage2_reminder.html
+++ b/app/templates/email/stage2_reminder.html
@@ -28,6 +28,7 @@
   <tr>
     <td style="background-color:#F7F7F9;padding:12px 24px;font-size:14px;color:#3F4854;">
       <p style="margin:0;">Voting assistance: <a href="mailto:support@example.com">support@example.com</a></p>
+      <p style="margin:0;">Voting help: <a href="{{ url_for('help.show_help', _external=True) }}">Help page</a></p>
       <p style="margin:0;">Company No. 12345678 · <a href="{{ unsubscribe_url }}">Unsubscribe</a> · <a href="{{ resubscribe_url }}">Resubscribe</a></p>
     </td>
   </tr>

--- a/app/templates/email/stage2_reminder.txt
+++ b/app/templates/email/stage2_reminder.txt
@@ -16,6 +16,7 @@ See Stage 1 results: {{ results_link }}
 Use the link below to cast your ballot:
 
 {{ link }}
+Need help? {{ url_for('help.show_help', _external=True) }}
 
 If you already voted, you can ignore this email.
 To stop these reminders, visit {{ unsubscribe_url }}

--- a/app/templates/email/submission_invite.html
+++ b/app/templates/email/submission_invite.html
@@ -1,3 +1,4 @@
 <p>Dear {{ member.name }},</p>
 <p>You may submit motions and amendments for {{ meeting.title }} online.</p>
 <p><a href="{{ link }}">Submit your proposal</a></p>
+<p>More about online voting: <a href="{{ url_for('help.show_help', _external=True) }}">Voting Help</a></p>

--- a/app/templates/email/submission_invite.txt
+++ b/app/templates/email/submission_invite.txt
@@ -4,3 +4,4 @@ You may submit motions and amendments for {{ meeting.title }} online.
 Use the link below to send your proposal:
 
 {{ link }}
+Need help? {{ url_for('help.show_help', _external=True) }}


### PR DESCRIPTION
## Summary
- include short explanation and help link in first invite email
- add help page link to other member emails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68575f929374832b8dbcd40fc7f9227b