### PR TITLE
Add final stage volunteer message setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ STAGE2_REMINDER_TEMPLATE=email/stage2_reminder
 # TIE_BREAK_DECISIONS={}
 CLERICAL_TEXT=The Board may correct typographical or numbering errors with no change to meaning.
 MOVE_TEXT=The Board may place this change in the Articles or Bylaws as most appropriate.
+FINAL_STAGE_MESSAGE=**Thanks for voting!** Getting involved is important to the sport. If you don't already volunteer some time, maybe consider it—even a small commitment helps. Volunteering isn't just about refereeing or coaching; it's also about helping in other ways that help grow the sport. Let British Powerlifting know where you shine by [getting in touch](https://www.britishpowerlifting.org/contactus).
 
 NOTICE_PERIOD_DAYS=14
 STAGE1_LENGTH_DAYS=7

--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -48,6 +48,7 @@ class SettingsForm(FlaskForm):
     tie_break_decisions = TextAreaField("Tie Break Decisions", validators=[Optional()])
     clerical_text = TextAreaField("Clerical Amendment Text", validators=[Optional()])
     move_text = TextAreaField("Articles/Bylaws Placement Text", validators=[Optional()])
+    final_message = TextAreaField("Final Stage Message", validators=[Optional()])
     manual_email_mode = BooleanField("Disable Automatic Emails")
     contact_url = StringField("Contact URL", validators=[Optional(), URL()])
     submit = SubmitField("Save")

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -378,6 +378,10 @@ def manage_settings():
         form.move_text.data = AppSetting.get(
             "move_text", current_app.config.get("MOVE_TEXT")
         )
+        form.final_message.data = AppSetting.get(
+            "final_message",
+            current_app.config.get("FINAL_STAGE_MESSAGE"),
+        )
         form.contact_url.data = AppSetting.get(
             "contact_url",
             "https://www.britishpowerlifting.org/contactus",
@@ -408,6 +412,7 @@ def manage_settings():
         AppSetting.set("tie_break_decisions", form.tie_break_decisions.data)
         AppSetting.set("clerical_text", form.clerical_text.data)
         AppSetting.set("move_text", form.move_text.data)
+        AppSetting.set("final_message", form.final_message.data)
         if form.contact_url.data:
             AppSetting.set("contact_url", form.contact_url.data)
         else:

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1337,7 +1337,12 @@ def preview_voting(meeting_id: int, stage: int):
         form = _combined_form(motions, amendments)
         if form.validate_on_submit():
             flash("Preview submission complete – votes were not saved", "info")
-            return render_template("voting/confirmation.html", preview=True)
+            return render_template(
+                "voting/confirmation.html",
+                preview=True,
+                stage=stage,
+                final_message_default=current_app.config.get("FINAL_STAGE_MESSAGE"),
+            )
         motions_grouped = []
         for motion in motions:
             ams = [a for a in amendments if a.motion_id == motion.id]
@@ -1366,7 +1371,12 @@ def preview_voting(meeting_id: int, stage: int):
         form = _amendment_form(amendments)
         if form.validate_on_submit():
             flash("Preview submission complete – votes were not saved", "info")
-            return render_template("voting/confirmation.html", preview=True)
+            return render_template(
+                "voting/confirmation.html",
+                preview=True,
+                stage=stage,
+                final_message_default=current_app.config.get("FINAL_STAGE_MESSAGE"),
+            )
         motions_grouped = []
         for motion in motions:
             ams = [a for a in amendments if a.motion_id == motion.id]
@@ -1389,7 +1399,12 @@ def preview_voting(meeting_id: int, stage: int):
     form = _motion_form(motions)
     if form.validate_on_submit():
         flash("Preview submission complete – votes were not saved", "info")
-        return render_template("voting/confirmation.html", preview=True)
+        return render_template(
+            "voting/confirmation.html",
+            preview=True,
+            stage=stage,
+            final_message_default=current_app.config.get("FINAL_STAGE_MESSAGE"),
+        )
     compiled = [
         (m, m.final_text_md or compile_motion_text(m)) for m in motions
     ]

--- a/app/templates/admin/settings_form.html
+++ b/app/templates/admin/settings_form.html
@@ -115,6 +115,16 @@
       </div>
     </div>
     <div class="mb-4">
+      {{ form.final_message.label(class='block mb-1') }}
+      <div class="flex gap-2">
+        {{ form.final_message(class='bp-input w-full h-32', **{'data-markdown-editor': '1'}) }}
+        <form action="{{ url_for('admin.reset_setting', key='final_message') }}" method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="text-sm underline">Reset default</button>
+        </form>
+      </div>
+    </div>
+    <div class="mb-4">
       {{ form.contact_url.label(class='block mb-1') }}
       {{ form.contact_url(class='bp-input w-full') }}
     </div>

--- a/app/templates/voting/confirmation.html
+++ b/app/templates/voting/confirmation.html
@@ -18,4 +18,7 @@
     {% endif %}
     <a href="{{ url_for('help.show_help') }}" class="bp-btn-secondary">Voting Help</a>
 </div>
+{% if stage == 2 and not preview %}
+<div class="bp-card mt-4">{{ setting('final_message', final_message_default)|markdown_to_html|safe }}</div>
+{% endif %}
 {% endblock %}

--- a/app/voting/routes.py
+++ b/app/voting/routes.py
@@ -227,6 +227,8 @@ def ballot_token(token: str):
                 choice="recorded",
                 meeting=meeting,
                 token=token,
+                stage=vote_token.stage,
+                final_message_default=current_app.config.get("FINAL_STAGE_MESSAGE"),
             )
 
         motion_counts = {
@@ -293,6 +295,8 @@ def ballot_token(token: str):
                 choice="recorded",
                 meeting=meeting,
                 token=token,
+                stage=vote_token.stage,
+                final_message_default=current_app.config.get("FINAL_STAGE_MESSAGE"),
             )
 
         motion_counts = {
@@ -351,6 +355,8 @@ def ballot_token(token: str):
                 choice="recorded",
                 meeting=meeting,
                 token=token,
+                stage=vote_token.stage,
+                final_message_default=current_app.config.get("FINAL_STAGE_MESSAGE"),
             )
 
         compiled = [
@@ -465,7 +471,12 @@ def runoff_ballot(token: str):
         VoteToken.query.filter_by(member_id=member.id, stage=vote_token.stage).update({"used_at": now})
         db.session.commit()
         send_vote_receipt(acting_member, meeting, hashes)
-        return render_template("voting/confirmation.html", choice="recorded")
+        return render_template(
+            "voting/confirmation.html",
+            choice="recorded",
+            stage=vote_token.stage,
+            final_message_default=current_app.config.get("FINAL_STAGE_MESSAGE"),
+        )
 
     pairs = [
         (

--- a/config.py
+++ b/config.py
@@ -38,6 +38,13 @@ class Config:
         "MOVE_TEXT",
         "The Board may place this change in the Articles or Bylaws as most appropriate.",
     )
+    FINAL_STAGE_MESSAGE = (
+        "**Thanks for voting!**\n\n"
+        "Getting involved is important to the sport. "
+        "If you don't already volunteer some time, maybe consider it—even a small commitment helps. "
+        "Volunteering isn't just about refereeing or coaching; it's also about helping in other ways that help grow the sport. "
+        "Let British Powerlifting know where you shine by [getting in touch](https://www.britishpowerlifting.org/contactus)."
+    )
     RATELIMIT_DEFAULT = os.getenv("RATELIMIT_DEFAULT", "1000 per day")
     RATELIMIT_STORAGE_URL = os.getenv("RATELIMIT_STORAGE_URL", "memory://")
     COMMENTS_PER_PAGE = int(os.getenv("COMMENTS_PER_PAGE", "10"))

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -458,6 +458,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-21 – Linked manual email sending page from results summary.
 * 2025-06-21 – Added per-member resend link on results summary.
 * 2025-06-21 – Default calendar timezone now Europe/London.
+* 2025-06-22 – Added configurable final-stage volunteer message on confirmation screen.
 
 
 ---


### PR DESCRIPTION
## Summary
- add `FINAL_STAGE_MESSAGE` config default
- store and edit new field via admin settings form
- display volunteer message after submitting Stage 2 vote
- document new setting in env example and changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685760053e44832ba2fa4e70bf339f0c