### PR TITLE
Add confirmation before publishing results doc

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -132,7 +132,10 @@
           </form>
           <form action="{{ url_for('admin.toggle_results_doc', meeting_id=meeting.id) }}" method="post" class="flex-1">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            <button type="submit" class="bp-btn-secondary text-sm w-full">
+            <button type="submit" class="bp-btn-secondary text-sm w-full"
+              {% if not meeting.results_doc_published %}
+                onclick="return confirm('Publishing the results document will email members and make it public. Continue?')"
+              {% endif %}>
               {{ 'Unpublish Doc' if meeting.results_doc_published else 'Publish Doc' }}
             </button>
           </form>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -305,6 +305,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-14 – Enhanced meetings list with htmx search and sort.
 * 2025-07-01 – Added publishable Stage 2 results document with custom intro text.
 * 2025-07-02 – Enabled voters to edit their comments for 15 minutes with audit history.
+* 2025-07-03 – Added confirmation prompt before publishing results document from admin dashboard.
 * 2025-06-20 – Added comment count badges and modal viewer on ballots; improved thank-you screen.
 * 2025-06-30 – Added motion withdrawal/edit request workflow with chair and board approvals.
 * 2025-06-14 – Added meeting create/edit form with CSRF protection.


### PR DESCRIPTION
## Summary
- add confirm prompt for publishing results document on admin dashboard
- document the new behaviour in the PRD changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857fabb56cc832ba36b3be67573c05b