### PR TITLE
Ensure breadcrumbs present across pages

### DIFF
--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Home', url_for('main.index')), ('Admin Login', None)]) }}
 <div class="max-w-md mx-auto">
   <h2 class="text-2xl font-bold text-bp-blue mb-6">Admin Login</h2>
 

--- a/app/templates/auth/request_reset.html
+++ b/app/templates/auth/request_reset.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Admin Login', url_for('auth.login')), ('Reset Password', None)]) }}
 <div class="max-w-md mx-auto">
   <h2 class="text-2xl font-bold text-bp-blue mb-6">Reset Password</h2>
   <form method="post" class="bp-card space-y-6">

--- a/app/templates/auth/reset_form.html
+++ b/app/templates/auth/reset_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Admin Login', url_for('auth.login')), ('Reset Password', None)]) }}
 <div class="max-w-md mx-auto">
   <h2 class="text-2xl font-bold text-bp-blue mb-6">Set New Password</h2>
   <form method="post" class="bp-card space-y-6">

--- a/app/templates/comments/edit_comment.html
+++ b/app/templates/comments/edit_comment.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
-{{ breadcrumbs([]) }}
+{% if target[0] == 'motion' %}
+{{ breadcrumbs([('Comments', url_for('comments.motion_comments', token=token, motion_id=target[1])), ('Edit Comment', None)]) }}
+{% else %}
+{{ breadcrumbs([('Comments', url_for('comments.amendment_comments', token=token, amendment_id=target[1])), ('Edit Comment', None)]) }}
+{% endif %}
 <h1 class="font-bold text-bp-blue mb-4">Edit Comment</h1>
 <form method="post" class="bp-form space-y-4 bp-card">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/help/help.html
+++ b/app/templates/help/help.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Home', url_for('main.index')), ('Help', None)]) }}
 <div class="max-w-4xl mx-auto">
   <!-- Header -->
   <div class="text-center mb-8">

--- a/app/templates/meetings/import_members.html
+++ b/app/templates/meetings/import_members.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Import Members', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Import Members</h1>
 <p class="mb-4">
   <a href="{{ url_for('meetings.download_sample_csv') }}" class="bp-link" download>Download sample CSV</a>

--- a/app/templates/meetings/manage_conflicts.html
+++ b/app/templates/meetings/manage_conflicts.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (motion.meeting.title if motion.meeting else 'Meeting', url_for('meetings.edit_meeting', meeting_id=motion.meeting_id)), ('Manage Conflicts', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ motion.title }} - Manage Conflicts</h1>
 <form method="post" class="bp-form bp-card space-y-4 mb-6">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/manual_email.html
+++ b/app/templates/meetings/manual_email.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block title %}Send Emails{% endblock %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Send Emails', None)]) }}
 <h1 class="text-2xl mb-4">Send Emails</h1>
 <form method="post">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Motions', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Motions</h1>
 <div class="mb-4 space-x-2">
   <a href="{{ url_for('meetings.import_members', meeting_id=meeting.id) }}" class="bp-btn-primary inline-block">Import Members</a>

--- a/app/templates/meetings/objection_confirmed.html
+++ b/app/templates/meetings/objection_confirmed.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Home', url_for('main.index')), ('Objection Confirmed', None)]) }}
 <div class="bp-card text-center space-y-4">
   <h1 class="text-3xl font-bold text-bp-blue">Objection confirmed</h1>
   <p class="text-bp-grey-700">Thank you. Your objection has been recorded.</p>

--- a/app/templates/meetings/prepare_stage2.html
+++ b/app/templates/meetings/prepare_stage2.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Prepare Stage 2', None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Finalise Motion Text</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 <form method="post" class="space-y-6">

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Stage 1 Results', None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Stage 1 Results</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 {% if meeting.extension_reason %}

--- a/app/templates/meetings/stage1_tally_form.html
+++ b/app/templates/meetings/stage1_tally_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Stage 1 Tally', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Record Stage 1 Tally</h1>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/stage2_tally_form.html
+++ b/app/templates/meetings/stage2_tally_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Stage 2 Tally', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Record Stage 2 Tally</h1>
 <form method="post" class="bp-form bp-card space-y-4">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/view_motion.html
+++ b/app/templates/meetings/view_motion.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (motion.meeting.title if motion.meeting else 'Meeting', url_for('meetings.edit_meeting', meeting_id=motion.meeting_id)), ('View Motion', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ motion.title }}</h1>
 <div class="bp-card bp-glow mb-4">{{ (motion.text_md or 'No motion text.')|markdown_to_html|safe }}</div>
 <h3 class="font-bold mb-2">Amendments</h3>

--- a/app/templates/meetings_list.html
+++ b/app/templates/meetings_list.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', None)]) }}
 <div class="mb-8">
   <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
     <div>

--- a/app/templates/notifications/resubscribed.html
+++ b/app/templates/notifications/resubscribed.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Home', url_for('main.index')), ('Email Preferences', None)]) }}
 <div class="bp-card text-center space-y-4">
   <h1 class="text-3xl font-bold text-bp-blue">You have resubscribed</h1>
   <p class="text-bp-grey-700">Notification emails will resume.</p>

--- a/app/templates/notifications/unsubscribed.html
+++ b/app/templates/notifications/unsubscribed.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Home', url_for('main.index')), ('Email Preferences', None)]) }}
 <div class="bp-card text-center space-y-4">
   <h1 class="text-3xl font-bold text-bp-blue">You have been unsubscribed</h1>
   <p class="text-bp-grey-700">You will no longer receive notification emails.</p>

--- a/app/templates/public_meeting.html
+++ b/app/templates/public_meeting.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }}</h1>
 <p class="mb-4">Stage: {{ meeting.status or 'Draft' }} | Members: {{ member_count }}</p>
 {% if meeting.opens_at_stage1 and meeting.closes_at_stage1 %}

--- a/app/templates/public_meetings.html
+++ b/app/templates/public_meetings.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Home', url_for('main.index')), ('Meetings', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Meetings</h1>
 <div class="bp-card">
   <ul class="space-y-2">

--- a/app/templates/public_results.html
+++ b/app/templates/public_results.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Results', url_for('main.results_index')), (meeting.title, None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} – Results</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 {% if meeting.extension_reason %}

--- a/app/templates/public_stage1_results.html
+++ b/app/templates/public_stage1_results.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Results', url_for('main.results_index')), (meeting.title, url_for('main.public_results', meeting_id=meeting.id)), ('Stage 1', None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Stage 1 Results</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 {% if meeting.extension_reason %}

--- a/app/templates/results_chart.html
+++ b/app/templates/results_chart.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Results', url_for('main.results_index')), (meeting.title, url_for('main.public_results', meeting_id=meeting.id)), ('Charts', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Charts</h1>
 <p class="mb-4"><a href="{{ url_for('main.public_results', meeting_id=meeting.id) }}" class="text-bp-blue underline">Back to table view</a></p>
 <div id="charts" data-url="{{ url_for('main.public_results_json', meeting_id=meeting.id) }}">

--- a/app/templates/results_index.html
+++ b/app/templates/results_index.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Home', url_for('main.index')), ('Results', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Results</h1>
 <div class="bp-card">
   <ul class="space-y-2">

--- a/app/templates/ro/dashboard.html
+++ b/app/templates/ro/dashboard.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('RO Dashboard', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Returning Officer Dashboard</h1>
 <div class="bp-card mb-4">
   <table class="bp-table">

--- a/app/templates/ro/tie_break_form.html
+++ b/app/templates/ro/tie_break_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('RO Dashboard', url_for('ro.dashboard')), (meeting.title, None), ('Tie Breaks', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Tie Breaks</h1>
 <form method="post" class="space-y-6">
   {{ form.hidden_tag() }}

--- a/app/templates/ro/tie_break_runoff_form.html
+++ b/app/templates/ro/tie_break_runoff_form.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('RO Dashboard', url_for('ro.dashboard')), (meeting.title, None), ('Run-off Tie Breaks', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Run-off Tie Breaks</h1>
 <form method="post" class="space-y-6">
   {{ form.hidden_tag() }}

--- a/app/templates/submissions/list.html
+++ b/app/templates/submissions/list.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Submissions', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Submissions for {{ meeting.title }}</h1>
 <h2 class="font-semibold mb-2">Motions</h2>
 {% for sub in motions %}

--- a/app/templates/voting/confirmation.html
+++ b/app/templates/voting/confirmation.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), ('Confirmation', None)]) }}
 {% if setting('site_logo') %}
 <img src="{{ url_for('static', filename=setting('site_logo')) }}" alt="{{ setting('site_title', 'VoteBuddy') }}" class="h-12 mx-auto mb-4">
 {% endif %}

--- a/app/templates/voting/home.html
+++ b/app/templates/voting/home.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Home', url_for('main.index')), ('Ballot', None)]) }}
 <div class="bp-card text-center">
   <p class="text-bp-grey-700">Voting interface placeholder.</p>
   {% if token %}

--- a/app/templates/voting/token_error.html
+++ b/app/templates/voting/token_error.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), ('Invalid Token', None)]) }}
 {% if setting('site_logo') %}
 <img src="{{ url_for('static', filename=setting('site_logo')) }}" alt="{{ setting('site_title', 'VoteBuddy') }}" class="h-12 mx-auto mb-4">
 {% endif %}

--- a/app/templates/voting/token_not_open.html
+++ b/app/templates/voting/token_not_open.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
 {% block content %}
+{{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), ('Token Not Open', None)]) }}
 {% if setting('site_logo') %}
 <img src="{{ url_for('static', filename=setting('site_logo')) }}" alt="{{ setting('site_title', 'VoteBuddy') }}" class="h-12 mx-auto mb-4">
 {% endif %}


### PR DESCRIPTION
## Summary
- add missing breadcrumb navigation to various templates
- improve edit comment breadcrumbs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857fe21838c832b81e315c4a01a95ea