### PR TITLE
Fix admin dropdown hidden behind hero

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -211,6 +211,8 @@ h4 { font-size: 1.25rem; line-height: 1.4; }
   backdrop-filter: blur(10px);
   background: rgba(0, 45, 89, 0.95) !important;
   box-shadow: var(--shadow-md);
+  position: relative;
+  z-index: 50;
 }
 
 .bp-nav-link {

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1823,6 +1823,8 @@ h4 {
           backdrop-filter: blur(10px);
   background: rgba(0, 45, 89, 0.95) !important;
   box-shadow: var(--shadow-md);
+  position: relative;
+  z-index: 50;
 }
 
 .bp-nav-link {


### PR DESCRIPTION
## Summary
- elevate navigation bar to ensure dropdown overlays hero section

## Testing
- `pytest -q` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68580188a704832b90e862c9a769b731