### PR TITLE
Add markdown toggle to settings

### DIFF
--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -46,9 +46,21 @@ class SettingsForm(FlaskForm):
     stage2_reminder_cooldown_hours = IntegerField("Stage 2 Reminder Cooldown Hours")
     reminder_template = StringField("Reminder Template")
     tie_break_decisions = TextAreaField("Tie Break Decisions", validators=[Optional()])
-    clerical_text = TextAreaField("Clerical Amendment Text", validators=[Optional()])
-    move_text = TextAreaField("Articles/Bylaws Placement Text", validators=[Optional()])
-    final_message = TextAreaField("Final Stage Message", validators=[Optional()])
+    clerical_text = TextAreaField(
+        "Clerical Amendment Text",
+        validators=[Optional()],
+        render_kw={"data-markdown-editor": "1"},
+    )
+    move_text = TextAreaField(
+        "Articles/Bylaws Placement Text",
+        validators=[Optional()],
+        render_kw={"data-markdown-editor": "1"},
+    )
+    final_message = TextAreaField(
+        "Final Stage Message",
+        validators=[Optional()],
+        render_kw={"data-markdown-editor": "1"},
+    )
     manual_email_mode = BooleanField("Disable Automatic Emails")
     contact_url = StringField("Contact URL", validators=[Optional(), URL()])
     submit = SubmitField("Save")

--- a/app/templates/admin/settings_form.html
+++ b/app/templates/admin/settings_form.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Settings', url_for('admin.manage_settings'))]) }}
-<div class="bp-card max-w-lg space-y-4">
+<div class="bp-card max-w-4xl mx-auto space-y-4">
   <h1 class="font-bold text-bp-blue">Application Settings</h1>
   <form method="post">
     {{ form.hidden_tag() }}
@@ -97,7 +97,7 @@
     <div class="mb-4">
       {{ form.clerical_text.label(class='block mb-1') }}
       <div class="flex gap-2">
-        {{ form.clerical_text(class='bp-input w-full h-32', **{'data-markdown-editor': '1'}) }}
+        {{ form.clerical_text(class='bp-input w-full h-32') }}
         <form action="{{ url_for('admin.reset_setting', key='clerical_text') }}" method="post">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
@@ -107,7 +107,7 @@
     <div class="mb-4">
       {{ form.move_text.label(class='block mb-1') }}
       <div class="flex gap-2">
-        {{ form.move_text(class='bp-input w-full h-32', **{'data-markdown-editor': '1'}) }}
+        {{ form.move_text(class='bp-input w-full h-32') }}
         <form action="{{ url_for('admin.reset_setting', key='move_text') }}" method="post">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>
@@ -117,7 +117,7 @@
     <div class="mb-4">
       {{ form.final_message.label(class='block mb-1') }}
       <div class="flex gap-2">
-        {{ form.final_message(class='bp-input w-full h-32', **{'data-markdown-editor': '1'}) }}
+        {{ form.final_message(class='bp-input w-full h-32') }}
         <form action="{{ url_for('admin.reset_setting', key='final_message') }}" method="post">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <button type="submit" class="text-sm underline">Reset default</button>


### PR DESCRIPTION
## Summary
- enable markdown editor for site setting text areas
- widen settings card for better layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685800ee6218832b967296328ff1f7b4