### PR TITLE
Ensure files download instead of opening in browser

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1453,14 +1453,14 @@ def results_docx(meeting_id: int):
     buf = io.BytesIO()
     doc.save(buf)
     buf.seek(0)
-    return send_file(
+    resp = send_file(
         buf,
-        mimetype=(
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        ),
+        mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         as_attachment=True,
         download_name="results.docx",
     )
+    resp.headers["Content-Disposition"] = "attachment; filename=\"results.docx\""
+    return resp
 
 
 @bp.route("/<int:meeting_id>/prepare-stage2", methods=["GET", "POST"])
@@ -1591,12 +1591,16 @@ def results_stage2_docx(meeting_id: int):
     buf = io.BytesIO()
     doc.save(buf)
     buf.seek(0)
-    return send_file(
+    resp = send_file(
         buf,
         mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         as_attachment=True,
         download_name="final_results.docx",
     )
+    resp.headers["Content-Disposition"] = (
+        "attachment; filename=\"final_results.docx\""
+    )
+    return resp
 
 
 @bp.route("/<int:meeting_id>/stage1.ics")

--- a/app/routes.py
+++ b/app/routes.py
@@ -208,13 +208,17 @@ def public_meeting_file(meeting_id: int, file_id: int):
         'UPLOAD_FOLDER', os.path.join(current_app.instance_path, 'files')
     )
     meeting_dir = os.path.join(root, str(meeting.id))
-    return send_from_directory(
+    resp = send_from_directory(
         meeting_dir,
         file_rec.filename,
-        mimetype='application/pdf',
+        mimetype="application/pdf",
         as_attachment=True,
         download_name=f"{file_rec.title or 'file'}.pdf",
     )
+    resp.headers["Content-Disposition"] = (
+        f"attachment; filename=\"{file_rec.title or 'file'}.pdf\""
+    )
+    return resp
 
 
 def _vote_counts(query):
@@ -361,9 +365,11 @@ def public_results_pdf(meeting_id: int):
     stage2 = [(m, _vote_counts(Vote.motion_id == m.id)) for m in motions]
 
     pdf_bytes = generate_results_pdf(meeting, stage1, stage2)
-    return send_file(
+    resp = send_file(
         io.BytesIO(pdf_bytes),
-        mimetype='application/pdf',
+        mimetype="application/pdf",
         as_attachment=True,
-        download_name='final_results.pdf',
+        download_name="final_results.pdf",
     )
+    resp.headers["Content-Disposition"] = "attachment; filename=\"final_results.pdf\""
+    return resp

--- a/tests/test_meetings_routes.py
+++ b/tests/test_meetings_routes.py
@@ -553,6 +553,8 @@ def test_results_stage2_docx_returns_file():
             assert resp.mimetype == (
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
             )
+            cd = resp.headers["Content-Disposition"]
+            assert "final_results.docx" in cd
             resp.direct_passthrough = False
             doc = Document(io.BytesIO(resp.get_data()))
             assert "draft summary" in doc.paragraphs[0].text

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -70,6 +70,8 @@ def test_public_results_pdf_route():
         with app.test_request_context(f"/results/{meeting.id}/final.pdf"):
             resp = main.public_results_pdf(meeting.id)
             assert resp.mimetype == "application/pdf"
+            cd = resp.headers["Content-Disposition"]
+            assert "final_results.pdf" in cd
             resp.direct_passthrough = False
             data = resp.get_data()
             assert data.startswith(b"%PDF")


### PR DESCRIPTION
## Summary
- force Content-Disposition attachment headers on PDF/DOCX responses
- verify headers in existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685801d5f354832b8a1b93858bc49584