### PR TITLE
Add vote share percentages to charts

### DIFF
--- a/app/static/js/results_chart.js
+++ b/app/static/js/results_chart.js
@@ -6,28 +6,64 @@ async function initCharts() {
   const data = await resp.json();
   const stage1Rows = data.tallies.filter(r => r.type === 'amendment');
   const stage2Rows = data.tallies.filter(r => r.type === 'motion');
+  const modeSelect = document.getElementById('share-mode');
 
-  function makeData(rows) {
+  function percent(value, row, effective) {
+    let denom = row.for + row.against + row.abstain;
+    if (effective) denom -= row.abstain;
+    if (!denom) return 0;
+    return ((value / denom) * 100).toFixed(1);
+  }
+
+  function makeData(rows, effective) {
     return {
       labels: rows.map(r => r.text),
       datasets: [
-        { label: 'For', data: rows.map(r => r.for), backgroundColor: '#00b894' },
-        { label: 'Against', data: rows.map(r => r.against), backgroundColor: '#d63031' },
-        { label: 'Abstain', data: rows.map(r => r.abstain), backgroundColor: '#fdcb6e' }
+        { label: 'For', data: rows.map(r => percent(r.for, r, effective)), backgroundColor: '#00b894' },
+        { label: 'Against', data: rows.map(r => percent(r.against, r, effective)), backgroundColor: '#d63031' },
+        { label: 'Abstain', data: rows.map(r => percent(r.abstain, r, effective)), backgroundColor: '#fdcb6e' }
       ]
     };
   }
 
-  new Chart(document.getElementById('stage1-chart'), {
+  function tooltip(rows) {
+    return ctx => {
+      const row = rows[ctx.dataIndex];
+      const key = ctx.dataset.label.toLowerCase();
+      const count = row[key];
+      const pct = percent(count, row, modeSelect.value === 'effective');
+      return `${ctx.dataset.label}: ${pct}% (${count})`;
+    };
+  }
+
+  function chartOpts(rows) {
+    return {
+      responsive: true,
+      scales: { y: { beginAtZero: true, max: 100, ticks: { callback: v => v + '%' } } },
+      plugins: { tooltip: { callbacks: { label: tooltip(rows) } } }
+    };
+  }
+
+  let stage1Chart = new Chart(document.getElementById('stage1-chart'), {
     type: 'bar',
-    data: makeData(stage1Rows),
-    options: { responsive: true, scales: { y: { beginAtZero: true } } }
+    data: makeData(stage1Rows, modeSelect.value === 'effective'),
+    options: chartOpts(stage1Rows)
   });
 
-  new Chart(document.getElementById('stage2-chart'), {
+  let stage2Chart = new Chart(document.getElementById('stage2-chart'), {
     type: 'bar',
-    data: makeData(stage2Rows),
-    options: { responsive: true, scales: { y: { beginAtZero: true } } }
+    data: makeData(stage2Rows, modeSelect.value === 'effective'),
+    options: chartOpts(stage2Rows)
+  });
+
+  modeSelect.addEventListener('change', () => {
+    const eff = modeSelect.value === 'effective';
+    stage1Chart.data = makeData(stage1Rows, eff);
+    stage1Chart.options.plugins.tooltip.callbacks.label = tooltip(stage1Rows);
+    stage1Chart.update();
+    stage2Chart.data = makeData(stage2Rows, eff);
+    stage2Chart.options.plugins.tooltip.callbacks.label = tooltip(stage2Rows);
+    stage2Chart.update();
   });
 }
 

--- a/app/templates/results_chart.html
+++ b/app/templates/results_chart.html
@@ -4,6 +4,13 @@
 {{ breadcrumbs([('Results', url_for('main.results_index')), (meeting.title, url_for('main.public_results', meeting_id=meeting.id)), ('Charts', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Charts</h1>
 <p class="mb-4"><a href="{{ url_for('main.public_results', meeting_id=meeting.id) }}" class="text-bp-blue underline">Back to table view</a></p>
+<p class="mb-4">
+  <label for="share-mode" class="font-semibold mr-2">Vote share:</label>
+  <select id="share-mode" class="bp-input w-auto">
+    <option value="absolute">Absolute</option>
+    <option value="effective">Effective</option>
+  </select>
+</p>
 <div id="charts" data-url="{{ url_for('main.public_results_json', meeting_id=meeting.id) }}">
   <div class="bp-card mb-8 overflow-x-auto">
     <h3 class="font-semibold mb-2">Stage 1 Amendments</h3>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -467,6 +467,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-22 – Fixed results download links to force file save instead of opening in browser.
 * 2025-06-22 – Fixed public results charts not rendering after page load.
 * 2025-06-22 – Results index displays meetings as individual cards with turnout info.
+* 2025-06-22 – Charts page shows vote share percentages with absolute/effective toggle.
 
 
 ---

--- a/tests/test_public_results.py
+++ b/tests/test_public_results.py
@@ -71,3 +71,20 @@ def test_public_results_json_counts():
             m_row = next(r for r in data['tallies'] if r['type'] == 'motion')
             assert a_row['for'] == 1
             assert m_row['against'] == 1
+
+
+def test_public_results_charts_has_toggle():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM', public_results=True)
+        db.session.add(meeting)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name='Bob')
+        amend = Amendment(meeting_id=meeting.id, motion_id=None, text_md='A1', order=1)
+        db.session.add_all([member, amend])
+        db.session.commit()
+
+        with app.test_request_context(f'/results/{meeting.id}/charts'):
+            html = main.public_results_charts(meeting.id)
+            assert 'id="share-mode"' in html


### PR DESCRIPTION
## Summary
- allow toggling between absolute and effective vote share on results charts
- compute percentages client-side and display in tooltips
- document new feature in PRD
- test charts page renders the vote share toggle

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6858023d30e4832b8eca881a66c4923c