### PR TITLE
Fix admin dropdown hidden behind hero

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -207,10 +207,16 @@ h4 { font-size: 1.25rem; line-height: 1.4; }
 }
 
 /* Enhanced Navigation */
+.bp-header {
+  position: relative;
+  z-index: 60;
+}
 .bp-header-nav {
   backdrop-filter: blur(10px);
   background: rgba(0, 45, 89, 0.95) !important;
   box-shadow: var(--shadow-md);
+  position: relative;
+  z-index: 50;
 }
 
 .bp-nav-link {

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1817,12 +1817,18 @@ h4 {
 }
 
 /* Enhanced Navigation */
+.bp-header {
+  position: relative;
+  z-index: 60;
+}
 
 .bp-header-nav {
   -webkit-backdrop-filter: blur(10px);
           backdrop-filter: blur(10px);
   background: rgba(0, 45, 89, 0.95) !important;
   box-shadow: var(--shadow-md);
+  position: relative;
+  z-index: 50;
 }
 
 .bp-nav-link {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,7 +9,7 @@
   </head>
   <body hx-boost="true" class="flex flex-col min-h-screen bg-gradient-to-b from-bp-grey-50 to-white font-sans" data-notice-days="{{ notice_days }}">
     <a href="#main" class="bp-skip-link sr-only focus:not-sr-only">Skip to main content</a>
-    <header>
+    <header class="bp-header">
       <nav class="bp-header-nav bg-bp-blue text-white shadow-lg">
         <div class="max-w-[1200px] mx-auto flex items-center justify-between px-4 py-4">
           <a href="{{ url_for('main.index') }}" class="font-bold text-xl flex items-center gap-2">


### PR DESCRIPTION
## Summary
- keep header above hero section to allow dropdown overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68580188a704832b90e862c9a769b731