### PR TITLE
Improve results charts layout

### DIFF
--- a/app/static/js/results_chart.js
+++ b/app/static/js/results_chart.js
@@ -4,67 +4,104 @@ async function initCharts() {
   const url = container.dataset.url;
   const resp = await fetch(url);
   const data = await resp.json();
-  const stage1Rows = data.tallies.filter(r => r.type === 'amendment');
-  const stage2Rows = data.tallies.filter(r => r.type === 'motion');
-  const modeSelect = document.getElementById('share-mode');
 
-  function percent(value, row, effective) {
-    let denom = row.for + row.against + row.abstain;
-    if (effective) denom -= row.abstain;
-    if (!denom) return 0;
-    return ((value / denom) * 100).toFixed(1);
+  const stage1Grid = document.getElementById('stage1-grid');
+  const stage2Grid = document.getElementById('stage2-grid');
+
+  function createCard(title, id, grid) {
+    const card = document.createElement('div');
+    card.className = 'bp-card overflow-x-auto';
+    const h3 = document.createElement('h3');
+    h3.className = 'font-semibold mb-2';
+    h3.textContent = title;
+    const canvas = document.createElement('canvas');
+    canvas.id = id;
+    canvas.height = 240;
+    canvas.className = 'w-full';
+    card.appendChild(h3);
+    card.appendChild(canvas);
+    grid.appendChild(card);
+    return canvas;
   }
 
-  function makeData(rows, effective) {
+  function countsData(row) {
     return {
-      labels: rows.map(r => r.text),
-      datasets: [
-        { label: 'For', data: rows.map(r => percent(r.for, r, effective)), backgroundColor: '#00b894' },
-        { label: 'Against', data: rows.map(r => percent(r.against, r, effective)), backgroundColor: '#d63031' },
-        { label: 'Abstain', data: rows.map(r => percent(r.abstain, r, effective)), backgroundColor: '#fdcb6e' }
-      ]
+      labels: ['For', 'Against', 'Abstain'],
+      datasets: [{
+        label: 'Votes',
+        data: [row.for, row.against, row.abstain],
+        backgroundColor: ['#00b894', '#d63031', '#fdcb6e']
+      }]
     };
   }
 
-  function tooltip(rows) {
-    return ctx => {
-      const row = rows[ctx.dataIndex];
-      const key = ctx.dataset.label.toLowerCase();
-      const count = row[key];
-      const pct = percent(count, row, modeSelect.value === 'effective');
-      return `${ctx.dataset.label}: ${pct}% (${count})`;
+  function percentData(row, effective) {
+    let total = row.for + row.against + row.abstain;
+    if (effective) total -= row.abstain;
+    if (!total) total = 1;
+    const labels = ['For', 'Against'];
+    const values = [
+      (row.for / total * 100).toFixed(1),
+      (row.against / total * 100).toFixed(1)
+    ];
+    const colors = ['#00b894', '#d63031'];
+    if (!effective) {
+      labels.push('Abstain');
+      values.push((row.abstain / total * 100).toFixed(1));
+      colors.push('#fdcb6e');
+    }
+    return {
+      labels,
+      datasets: [{
+        label: 'Percent',
+        data: values,
+        backgroundColor: colors
+      }]
     };
   }
 
-  function chartOpts(rows) {
+  function opts(yLabel, titleText) {
     return {
       responsive: true,
-      scales: { y: { beginAtZero: true, max: 100, ticks: { callback: v => v + '%' } } },
-      plugins: { tooltip: { callbacks: { label: tooltip(rows) } } }
+      scales: {
+        x: { title: { display: true, text: 'Choice' } },
+        y: {
+          beginAtZero: true,
+          max: yLabel.includes('%') ? 100 : undefined,
+          ticks: {
+            callback: v => yLabel.includes('%') ? v + '%' : v
+          },
+          title: { display: true, text: yLabel }
+        }
+      },
+      plugins: { title: { display: true, text: titleText } }
     };
   }
 
-  let stage1Chart = new Chart(document.getElementById('stage1-chart'), {
-    type: 'bar',
-    data: makeData(stage1Rows, modeSelect.value === 'effective'),
-    options: chartOpts(stage1Rows)
-  });
+  function renderRow(row, grid, prefix) {
+    const short = row.text;
+    const countCanvas = createCard(short + ' – Count', `${prefix}${row.id}-c`, grid);
+    new Chart(countCanvas, {
+      type: 'bar',
+      data: countsData(row),
+      options: opts('Votes', short + ' – Vote Count')
+    });
+    const pctCanvas = createCard(short + ' – %', `${prefix}${row.id}-p`, grid);
+    new Chart(pctCanvas, {
+      type: 'bar',
+      data: percentData(row, false),
+      options: opts('%', short + ' – Vote Share')
+    });
+    const effCanvas = createCard(short + ' – Effective %', `${prefix}${row.id}-e`, grid);
+    new Chart(effCanvas, {
+      type: 'bar',
+      data: percentData(row, true),
+      options: opts('%', short + ' – Effective Share')
+    });
+  }
 
-  let stage2Chart = new Chart(document.getElementById('stage2-chart'), {
-    type: 'bar',
-    data: makeData(stage2Rows, modeSelect.value === 'effective'),
-    options: chartOpts(stage2Rows)
-  });
-
-  modeSelect.addEventListener('change', () => {
-    const eff = modeSelect.value === 'effective';
-    stage1Chart.data = makeData(stage1Rows, eff);
-    stage1Chart.options.plugins.tooltip.callbacks.label = tooltip(stage1Rows);
-    stage1Chart.update();
-    stage2Chart.data = makeData(stage2Rows, eff);
-    stage2Chart.options.plugins.tooltip.callbacks.label = tooltip(stage2Rows);
-    stage2Chart.update();
-  });
+  data.tallies.filter(r => r.type === 'amendment').forEach(r => renderRow(r, stage1Grid, 'a'));
+  data.tallies.filter(r => r.type === 'motion').forEach(r => renderRow(r, stage2Grid, 'm'));
 }
 
 if (document.readyState === 'loading') {

--- a/app/templates/results_chart.html
+++ b/app/templates/results_chart.html
@@ -4,22 +4,12 @@
 {{ breadcrumbs([('Results', url_for('main.results_index')), (meeting.title, url_for('main.public_results', meeting_id=meeting.id)), ('Charts', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Charts</h1>
 <p class="mb-4"><a href="{{ url_for('main.public_results', meeting_id=meeting.id) }}" class="text-bp-blue underline">Back to table view</a></p>
-<p class="mb-4">
-  <label for="share-mode" class="font-semibold mr-2">Vote share:</label>
-  <select id="share-mode" class="bp-input w-auto">
-    <option value="absolute">Absolute</option>
-    <option value="effective">Effective</option>
-  </select>
-</p>
 <div id="charts" data-url="{{ url_for('main.public_results_json', meeting_id=meeting.id) }}">
-  <div class="bp-card mb-8 overflow-x-auto">
-    <h3 class="font-semibold mb-2">Stage 1 Amendments</h3>
-    <canvas id="stage1-chart" class="w-full" height="240"></canvas>
-  </div>
-  <div class="bp-card overflow-x-auto">
-    <h3 class="font-semibold mb-2">Stage 2 Motions</h3>
-    <canvas id="stage2-chart" class="w-full" height="240"></canvas>
-  </div>
+  <h2 class="font-bold text-bp-blue mb-2">Stage 1 Amendments</h2>
+  <div id="stage1-grid" class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8"></div>
+
+  <h2 class="font-bold text-bp-blue mb-2">Stage 2 Motions</h2>
+  <div id="stage2-grid" class="grid grid-cols-1 md:grid-cols-3 gap-6"></div>
 </div>
 <script src="{{ url_for('static', filename='js/chart.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/results_chart.js') }}"></script>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -468,6 +468,8 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-22 – Fixed public results charts not rendering after page load.
 * 2025-06-22 – Results index displays meetings as individual cards with turnout info.
 * 2025-06-22 – Charts page shows vote share percentages with absolute/effective toggle.
+* 2025-06-22 – Expanded charts view to display per-motion graphs for counts,
+  percentages and effective percentages.
 
 
 ---

--- a/tests/test_public_results.py
+++ b/tests/test_public_results.py
@@ -87,4 +87,4 @@ def test_public_results_charts_has_toggle():
 
         with app.test_request_context(f'/results/{meeting.id}/charts'):
             html = main.public_results_charts(meeting.id)
-            assert 'id="share-mode"' in html
+            assert 'id="stage1-grid"' in html


### PR DESCRIPTION
## Summary
- show vote charts for each motion/amendment individually
- display vote count, share and effective share charts
- adjust charts template and JS
- update tests for new layout
- document charts view changes in PRD

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6858055b4aec832bb2f9d4460b259f41