### PR TITLE
Fix Resend Voting Email modal

### DIFF
--- a/app/templates/resend_modal_content.html
+++ b/app/templates/resend_modal_content.html
@@ -5,6 +5,7 @@
   {% endif %}
 {% else %}
   <form hx-post="{{ url_for('main.resend_meeting_link_public', meeting_id=meeting.id) }}" class="bp-form space-y-4">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <div class="bp-form-group">
       <input id="member_number" name="member_number" class="bp-input" required>
       <label for="member_number" class="bp-form-label">Member Number</label>


### PR DESCRIPTION
## Summary
- add CSRF token to public resend email form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68580ef43990832b87faab8d697871f2