### PR TITLE
Add meeting motion stats and timeline

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -484,8 +484,30 @@ def list_motions(meeting_id):
     motions = (
         Motion.query.filter_by(meeting_id=meeting.id).order_by(Motion.ordering).all()
     )
+    amendments_count = Amendment.query.filter_by(meeting_id=meeting.id).count()
+    votes_cast = meeting.stage1_votes_count()
+    from datetime import datetime
+    steps = [
+        ("Motions Open", meeting.motions_opens_at),
+        ("Notice", meeting.notice_date),
+        ("Stage 1 Opens", meeting.opens_at_stage1),
+        ("Stage 1 Closes", meeting.closes_at_stage1),
+        ("Stage 2 Opens", meeting.opens_at_stage2),
+        ("Stage 2 Closes", meeting.closes_at_stage2),
+    ]
+    dates = [d for _, d in steps if d]
+    timeline_start = min(dates) if dates else None
+    timeline_end = max(dates) if dates else None
     return render_template(
-        "meetings/motions_list.html", meeting=meeting, motions=motions
+        "meetings/motions_list.html",
+        meeting=meeting,
+        motions=motions,
+        amendments_count=amendments_count,
+        votes_cast=votes_cast,
+        timeline_steps=steps,
+        timeline_start=timeline_start,
+        timeline_end=timeline_end,
+        now=datetime.utcnow(),
     )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -196,6 +196,14 @@ class Meeting(db.Model):
         percent = max(0.0, min(100.0, (elapsed / total) * 100))
         return int(percent)
 
+    def motions_count(self) -> int:
+        """Return total motions for this meeting."""
+        return Motion.query.filter_by(meeting_id=self.id).count()
+
+    def amendments_count(self) -> int:
+        """Return total amendments across all motions."""
+        return Amendment.query.filter_by(meeting_id=self.id).count()
+
 
 class Member(db.Model):
     __tablename__ = "members"

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -488,6 +488,44 @@ h4 { font-size: 1.25rem; line-height: 1.4; }
   100% { transform: translateX(100%); }
 }
 
+/* Timeline */
+.bp-timeline {
+  position: relative;
+  width: 100%;
+  margin-bottom: 1.5rem;
+}
+
+.bp-timeline-marker {
+  position: absolute;
+  top: -0.75rem;
+  transform: translateX(-50%);
+  text-align: center;
+}
+
+.bp-timeline-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  background: var(--bp-blue);
+  border-radius: 9999px;
+  border: 2px solid white;
+  box-shadow: 0 0 0 2px var(--bp-blue);
+}
+
+.bp-timeline-label {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--bp-grey-700);
+  white-space: nowrap;
+}
+
+.bp-timeline-now {
+  position: absolute;
+  top: -0.25rem;
+  bottom: -0.25rem;
+  width: 2px;
+  background: var(--bp-red);
+}
+
 /* Dropdown Menu */
 .bp-dropdown {
   position: relative;

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2365,6 +2365,45 @@ h4 {
   }
 }
 
+/* Timeline */
+
+.bp-timeline {
+  position: relative;
+  width: 100%;
+  margin-bottom: 1.5rem;
+}
+
+.bp-timeline-marker {
+  position: absolute;
+  top: -0.75rem;
+  transform: translateX(-50%);
+  text-align: center;
+}
+
+.bp-timeline-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  background: var(--bp-blue);
+  border-radius: 9999px;
+  border: 2px solid white;
+  box-shadow: 0 0 0 2px var(--bp-blue);
+}
+
+.bp-timeline-label {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--bp-grey-700);
+  white-space: nowrap;
+}
+
+.bp-timeline-now {
+  position: absolute;
+  top: -0.25rem;
+  bottom: -0.25rem;
+  width: 2px;
+  background: var(--bp-red);
+}
+
 /* Dropdown Menu */
 
 .bp-dropdown {
@@ -2955,11 +2994,6 @@ html {
 .hover\:text-bp-blue:hover {
   --tw-text-opacity: 1;
   color: rgb(0 45 89 / var(--tw-text-opacity, 1));
-}
-
-.hover\:text-bp-blue-light:hover {
-  --tw-text-opacity: 1;
-  color: rgb(26 74 122 / var(--tw-text-opacity, 1));
 }
 
 .hover\:text-bp-grey-600:hover {

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -93,7 +93,43 @@
         </a>
         {% endif %}
       </div>
+
     </div>
+  </div>
+</div>
+
+{% if timeline_start and timeline_end %}
+<div class="bp-timeline">
+  <div class="bp-progress relative">
+    <div class="bp-progress-bar" style="width: {{ ((now - timeline_start).total_seconds() / (timeline_end - timeline_start).total_seconds() * 100) | round }}%"></div>
+    {% for label, dt in timeline_steps %}
+    {% if dt %}
+    {% set pct = ((dt - timeline_start).total_seconds() / (timeline_end - timeline_start).total_seconds() * 100) %}
+    <div class="bp-timeline-marker" style="left: {{ pct }}%">
+      <span class="bp-timeline-dot"></span>
+      <span class="bp-timeline-label">{{ label }}<br>{{ dt.strftime('%d %b') }}</span>
+    </div>
+    {% endif %}
+    {% endfor %}
+    {% if timeline_start <= now <= timeline_end %}
+    <div class="bp-timeline-now" style="left: {{ ((now - timeline_start).total_seconds() / (timeline_end - timeline_start).total_seconds() * 100) }}%"></div>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+  <div class="bp-stat-card">
+    <div class="bp-stat-value">{{ votes_cast }}</div>
+    <div class="bp-stat-label">Voters</div>
+  </div>
+  <div class="bp-stat-card">
+    <div class="bp-stat-value">{{ motions|length }}</div>
+    <div class="bp-stat-label">Motions</div>
+  </div>
+  <div class="bp-stat-card">
+    <div class="bp-stat-value">{{ amendments_count }}</div>
+    <div class="bp-stat-label">Amendments</div>
   </div>
 </div>
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -471,6 +471,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-22 – Expanded charts view to display per-motion graphs for counts,
   percentages and effective percentages.
 * 2025-06-22 – Added clear logo button on settings page to remove the site logo.
+* 2025-07-04 – Meeting motions page shows voting stats and timeline overview.
 
 
 ---


### PR DESCRIPTION
## Summary
- show numbers of motions, amendments and votes
- include a timeline progress bar on motion list pages
- expose helper methods for motion and amendment counts
- document new feature in PRD

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_b_685834379e94832ba1af04918374a013