### PR TITLE
Add Import Members button

### DIFF
--- a/app/templates/meetings/import_members.html
+++ b/app/templates/meetings/import_members.html
@@ -1,7 +1,13 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Import Members', None)]) }}
+{{ breadcrumbs([
+  ('Dashboard', url_for('admin.dashboard')),
+  ('Meetings', url_for('meetings.list_meetings')),
+  (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)),
+  ('Members', url_for('meetings.list_members', meeting_id=meeting.id)),
+  ('Import Members', None)
+]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Import Members</h1>
 <p class="mb-4">
   <a href="{{ url_for('meetings.download_sample_csv') }}" class="bp-btn-secondary inline-block" download>Download sample CSV</a>

--- a/app/templates/meetings/members.html
+++ b/app/templates/meetings/members.html
@@ -43,6 +43,7 @@
     <button type="submit" class="bp-btn-secondary">Remove All</button>
   </form>
   <a href="{{ url_for('meetings.members_csv', meeting_id=meeting.id) }}" class="bp-btn-secondary" download="members.csv">Download CSV</a>
+  <a href="{{ url_for('meetings.import_members', meeting_id=meeting.id) }}" class="bp-btn-secondary">Import Members</a>
 </div>
 {% if pagination.pages > 1 %}
 <nav id="member-pagination" aria-label="Pagination" class="mt-6 flex justify-center">

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -500,3 +500,4 @@ SES/SMTP  ─── Outbound mail
 
 
 * 2025-07-18 – Added members list page with vote filtering and CSV export.
+* 2025-07-26 – Added Import Members button on members page and breadcrumb link.


### PR DESCRIPTION
## Summary
- add an Import Members button on the meeting members page
- link to the members page from the Import Members breadcrumb
- document feature in PRD

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6858485217a8832bb309505dfb5a55cf