### PR TITLE
Fix amendment results route

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -116,6 +116,14 @@ class Meeting(db.Model):
         "MeetingFile", backref="meeting", cascade="all, delete-orphan"
     )
 
+    motions = db.relationship(
+        "Motion", backref="meeting", cascade="all, delete-orphan"
+    )
+
+    amendments = db.relationship(
+        "Amendment", backref="meeting", cascade="all, delete-orphan"
+    )
+
     def stage1_votes_count(self) -> int:
         """Return number of verified Stage-1 votes."""
         if self.ballot_mode == "in-person":


### PR DESCRIPTION
## Summary
- add Meeting.motions and Meeting.amendments relationships so Amendment.meeting exists
- test amendment results page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685857c5147c832b9329d34583a57194