### PR TITLE
Add meeting email notice and settings

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -81,6 +81,11 @@ class MeetingForm(FlaskForm):
     quorum = IntegerField("Quorum")
     status = StringField("Status")
     chair_notes_md = TextAreaField("Chair Notes")
+    notice_md = TextAreaField(
+        "Meeting Notice",
+        validators=[Optional()],
+        render_kw={"data-markdown-editor": "1"},
+    )
     submit = SubmitField("Save")
 
     def validate(self, extra_validators=None):

--- a/app/models.py
+++ b/app/models.py
@@ -106,6 +106,7 @@ class Meeting(db.Model):
     extension_reason = db.Column(db.Text)
     results_doc_published = db.Column(db.Boolean, default=False)
     results_doc_intro_md = db.Column(db.Text)
+    notice_md = db.Column(db.Text)
     stage1_manual_votes = db.Column(db.Integer, default=0)
     stage2_manual_for = db.Column(db.Integer, default=0)
     stage2_manual_against = db.Column(db.Integer, default=0)
@@ -114,6 +115,9 @@ class Meeting(db.Model):
 
     files = db.relationship(
         "MeetingFile", backref="meeting", cascade="all, delete-orphan"
+    )
+    email_settings = db.relationship(
+        "EmailSetting", backref="meeting", cascade="all, delete-orphan"
     )
 
     def stage1_votes_count(self) -> int:
@@ -535,6 +539,15 @@ class EmailLog(db.Model):
     type = db.Column(db.String(50))
     is_test = db.Column(db.Boolean, default=False)
     sent_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class EmailSetting(db.Model):
+    __tablename__ = "email_settings"
+
+    id = db.Column(db.Integer, primary_key=True)
+    meeting_id = db.Column(db.Integer, db.ForeignKey("meetings.id"), index=True)
+    email_type = db.Column(db.String(50))
+    auto_send = db.Column(db.Boolean, default=True)
 
 
 class AdminLog(db.Model):

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -18,6 +18,7 @@ from .services.email import (
     send_board_notice,
     send_amendment_reinstated,
     send_submission_invite,
+    auto_send_enabled,
 )
 
 
@@ -50,6 +51,8 @@ def send_stage1_reminders():
             hours=config_or_setting('REMINDER_COOLDOWN_HOURS', 24, parser=int)
         )
         if last and now - last < cooldown:
+            continue
+        if not auto_send_enabled(meeting, 'stage1_reminder'):
             continue
         members = (
             Member.query.join(
@@ -95,6 +98,8 @@ def send_stage2_reminders():
             hours=config_or_setting('STAGE2_REMINDER_COOLDOWN_HOURS', 24, parser=int)
         )
         if last and now - last < cooldown:
+            continue
+        if not auto_send_enabled(meeting, 'stage2_reminder'):
             continue
         members = (
             Member.query.join(

--- a/app/templates/email/invite.html
+++ b/app/templates/email/invite.html
@@ -4,6 +4,9 @@
     <td style="padding:24px;background-color:#FFFFFF;">
       <p>Hello {{ member.name }},</p>
       <p>You are invited to vote in <strong>{{ meeting.title }}</strong>.</p>
+      {% if notice_html %}
+      <div>{{ notice_html|safe }}</div>
+      {% endif %}
       <p>This link is unique to you. For an overview of how online voting works, see <a href="{{ url_for('help.show_help', _external=True) }}">the voting help page</a>.</p>
       {% if test_mode %}
       <p style="color:#DC0714;"><strong>TEST MODE:</strong> votes cast using this link will be recorded as test data.</p>

--- a/app/templates/email/invite.txt
+++ b/app/templates/email/invite.txt
@@ -4,6 +4,10 @@ Hello {{ member.name }},
 {% endif %}
 
 You are invited to vote in {{ meeting.title }}.
+{% if notice_text %}
+Meeting Notice:
+{{ notice_text }}
+{% endif %}
 This link is unique to you. For an overview see {{ url_for('help.show_help', _external=True) }}
 Use the link below to cast your ballot:
 

--- a/app/templates/meetings/_email_row.html
+++ b/app/templates/meetings/_email_row.html
@@ -1,0 +1,11 @@
+<tr>
+  <td class="p-2">{{ email_type.replace('_', ' ').title() }}</td>
+  <td class="p-2">{{ schedule_time or 'n/a' }}</td>
+  <td class="p-2">
+    <form hx-post="{{ url_for('meetings.toggle_email_setting', meeting_id=meeting.id, email_type=email_type) }}" hx-target="closest tr" hx-swap="outerHTML">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <button type="submit" class="bp-btn-secondary">{{ 'On' if setting.auto_send else 'Off' }}</button>
+    </form>
+  </td>
+  <td class="p-2">{{ log.sent_at.strftime('%Y-%m-%d %H:%M') if log else 'Not sent' }}</td>
+</tr>

--- a/app/templates/meetings/email_settings.html
+++ b/app/templates/meetings/email_settings.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
+{% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Email Settings', None)]) }}
+<h1 class="font-bold text-bp-blue mb-4">Email Settings</h1>
+<table class="bp-table">
+  <thead>
+    <tr><th class="p-2">Email</th><th class="p-2">Scheduled</th><th class="p-2">Auto</th><th class="p-2">Last Sent</th></tr>
+  </thead>
+  <tbody id="email-rows">
+    {% for et, time in schedule.items() %}
+      {% set s = settings.get(et) %}
+      {% set l = logs.get(et) %}
+      {% include 'meetings/_email_row.html' with context %}
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -115,6 +115,11 @@
     <p id="{{ form.chair_notes_md.id }}-error" class="bp-error-text">{{ form.chair_notes_md.errors[0] if form.chair_notes_md.errors else '' }}</p>
   </div>
   <div>
+    {{ form.notice_md.label(class_='block font-semibold') }}
+    {{ form.notice_md(class_='border p-3 rounded w-full', **{'aria-describedby': form.notice_md.id + '-error'}) }}
+    <p id="{{ form.notice_md.id }}-error" class="bp-error-text">{{ form.notice_md.errors[0] if form.notice_md.errors else '' }}</p>
+  </div>
+  <div>
     {{ form.results_doc_intro_md.label(class_='block font-semibold') }}
     {{ form.results_doc_intro_md(class_='border p-3 rounded w-full', **{'aria-describedby': form.results_doc_intro_md.id + '-error'}) }}
     <p id="{{ form.results_doc_intro_md.id }}-error" class="bp-error-text">{{ form.results_doc_intro_md.errors[0] if form.results_doc_intro_md.errors else '' }}</p>
@@ -124,6 +129,7 @@
   <div class="mt-4">
     <a href="{{ url_for('meetings.stage1_ics', meeting_id=meeting.id) }}" class="bp-btn-secondary inline-block" download hx-boost="false">Stage 1 Calendar</a>
     <a href="{{ url_for('meetings.stage2_ics', meeting_id=meeting.id) }}" class="bp-btn-secondary inline-block ml-2" download hx-boost="false">Stage 2 Calendar</a>
+    <a href="{{ url_for('meetings.email_settings', meeting_id=meeting.id) }}" class="bp-btn-secondary inline-block ml-2">Email Settings</a>
   </div>
   {% endif %}
 </form>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -496,3 +496,4 @@ SES/SMTP  ─── Outbound mail
 
 
 
+* 2025-07-30 – Added per-meeting email settings with notice text and auto-send toggles.

--- a/migrations/versions/t1u2v3w4_add_notice_and_email_settings.py
+++ b/migrations/versions/t1u2v3w4_add_notice_and_email_settings.py
@@ -1,0 +1,27 @@
+"""add meeting notice and email settings"""
+
+revision = 't1u2v3w4'
+down_revision = 's1t2u3v4'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('meetings') as batch_op:
+        batch_op.add_column(sa.Column('notice_md', sa.Text()))
+    op.create_table(
+        'email_settings',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('meeting_id', sa.Integer(), sa.ForeignKey('meetings.id'), index=True),
+        sa.Column('email_type', sa.String(length=50)),
+        sa.Column('auto_send', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+    )
+
+
+def downgrade():
+    op.drop_table('email_settings')
+    with op.batch_alter_table('meetings') as batch_op:
+        batch_op.drop_column('notice_md')

--- a/tests/test_email_settings.py
+++ b/tests/test_email_settings.py
@@ -1,0 +1,30 @@
+from app.services.email import auto_send_enabled
+from app import create_app
+from app.extensions import db
+from app.models import Meeting, EmailSetting, AppSetting
+
+
+def test_auto_send_disabled_via_setting():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='M')
+        db.session.add(meeting)
+        db.session.commit()
+        es = EmailSetting(meeting_id=meeting.id, email_type='stage1_invite', auto_send=False)
+        db.session.add(es)
+        db.session.commit()
+        assert auto_send_enabled(meeting, 'stage1_invite') is False
+
+
+def test_auto_send_disabled_global():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='M')
+        db.session.add(meeting)
+        db.session.commit()
+        AppSetting.set('manual_email_mode', '1')
+        assert auto_send_enabled(meeting, 'stage1_invite') is False


### PR DESCRIPTION
## Summary
- allow storing meeting notice markdown text
- render notice text in invite emails
- store per-meeting email settings with toggleable auto-send
- add admin page to manage meeting email settings
- include new migration
- test email notice and auto-send logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685909852f14832b98fa0c16fca73cb3