### PR TITLE
Fix vote receipt opt-out

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -365,6 +365,8 @@ def send_stage2_reminder(member: Member, token: str, meeting: Meeting, *, test_m
 
 def send_vote_receipt(member: Member, meeting: Meeting, hashes: list[str], *, test_mode: bool = False) -> None:
     """Email a receipt containing vote hashes."""
+    if member.email_opt_out:
+        return
     unsubscribe = _unsubscribe_url(member)
     resubscribe = _resubscribe_url(member)
     msg = Message(

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -149,6 +149,21 @@ def test_send_vote_receipt_includes_hash():
                 assert '/unsubscribe/' in sent_msg.body
 
 
+def test_vote_receipt_not_sent_when_opted_out():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        member = Member(name='Ed', email='ed@example.com', meeting_id=1, email_opt_out=True)
+        db.session.add(member)
+        db.session.commit()
+        with app.test_request_context('/'):
+            with patch.object(mail, 'send') as mock_send:
+                send_vote_receipt(member, meeting, ['abc123'], test_mode=False)
+                mock_send.assert_not_called()
+
+
 def test_send_quorum_failure_email():
     app = _setup_app()
     with app.app_context():


### PR DESCRIPTION
## Summary
- add opt-out check when emailing vote receipts
- test that opted-out members don't receive vote receipts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859124f01f0832b8f50b6f4478c4741