### PR TITLE
Fix default sender email

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -68,8 +68,10 @@ def _resubscribe_url(member: Member) -> str:
     return url_for('notifications.resubscribe', token=token.token, _external=True)
 
 
-def _sender() -> str | None:
-    return AppSetting.get('from_email', current_app.config.get('MAIL_DEFAULT_SENDER'))
+def _sender() -> str:
+    """Return configured sender email or a safe default."""
+    sender = AppSetting.get("from_email") or current_app.config.get("MAIL_DEFAULT_SENDER")
+    return sender or "noreply@example.com"
 
 
 def _branding() -> dict[str, str | None]:


### PR DESCRIPTION
## Summary
- ensure an address is always returned by `_sender`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859124f01f0832b8f50b6f4478c4741