### PR TITLE
Configure wsgi for production

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -1,6 +1,10 @@
+import os
 from app import create_app
 
-app = create_app()
 
-if __name__ == '__main__':
-    app.run()
+config_path = os.getenv("APP_CONFIG", "config.ProductionConfig")
+app = create_app(config_path)
+
+if __name__ == "__main__":
+    debug_mode = config_path.endswith("DevelopmentConfig")
+    app.run(debug=debug_mode)


### PR DESCRIPTION
## Summary
- default to `config.ProductionConfig` when creating the app
- allow overriding via `APP_CONFIG` env var
- only enable debug when using `DevelopmentConfig`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68591bc4cf94832b9db265821b955e38