### PR TITLE
Expand meeting context menus

### DIFF
--- a/app/templates/meetings/_meeting_rows.html
+++ b/app/templates/meetings/_meeting_rows.html
@@ -128,6 +128,13 @@
             </svg>
             Send Emails
           </a>
+          <a href="{{ url_for('meetings.email_settings', meeting_id=meeting.id) }}"
+             class="group flex items-center px-4 py-2 text-sm text-bp-grey-700 hover:bg-bp-grey-50 hover:text-bp-grey-900 transition-colors"
+             role="menuitem">
+            <img src="{{ url_for('static', filename='icons/settings_30dp_000000_FILL0_wght400_GRAD0_opsz24.svg') }}"
+                 alt="" class="bp-icon w-4 h-4 mr-3 text-bp-grey-400 group-hover:text-bp-grey-500">
+            Email Settings
+          </a>
         </div>
 
         <!-- Results & Reports -->

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -33,9 +33,18 @@
           </svg>
         </button>
         <div class="bp-dropdown-menu w-56">
+          <a href="{{ url_for('meetings.edit_meeting', meeting_id=meeting.id) }}" class="bp-dropdown-item">Edit Meeting</a>
           <a href="{{ url_for('meetings.import_members', meeting_id=meeting.id) }}" class="bp-dropdown-item">Import Members</a>
+          <a href="{{ url_for('meetings.list_members', meeting_id=meeting.id) }}" class="bp-dropdown-item">View Members</a>
+          <a href="{{ url_for('meetings.manual_send_emails', meeting_id=meeting.id) }}" class="bp-dropdown-item">Send Emails</a>
+          <a href="{{ url_for('meetings.email_settings', meeting_id=meeting.id) }}" class="bp-dropdown-item">Email Settings</a>
           <a href="{{ url_for('meetings.clone_meeting', meeting_id=meeting.id) }}" class="bp-dropdown-item">Clone Meeting</a>
           <a href="{{ url_for('submissions.list_submissions', meeting_id=meeting.id) }}" class="bp-dropdown-item">Review Submissions</a>
+          {% if meeting.status == 'Completed' or meeting.public_results %}
+          <a href="{{ url_for('meetings.results_summary', meeting_id=meeting.id) }}" class="bp-dropdown-item">View Results</a>
+          <a href="{{ url_for('meetings.results_docx', meeting_id=meeting.id) }}" class="bp-dropdown-item">Export Results (Word)</a>
+          {% endif %}
+          <a href="{{ url_for('meetings.meeting_files', meeting_id=meeting.id) }}" class="bp-dropdown-item">Manage Files</a>
           {% if meeting.ballot_mode == 'combined' %}
           <a href="{{ url_for('meetings.preview_voting', meeting_id=meeting.id, stage=1) }}" class="bp-dropdown-item">Preview Combined Ballot</a>
           {% else %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -476,6 +476,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-18 – Added members list page with vote filtering and CSV export.
 * 2025-07-26 – Added Import Members button on members page and breadcrumb link.* 2025-07-27 – Added member actions menu with resend email options.
 * 2025-07-27 – Member management buttons moved above table for quicker access.
+* 2025-07-30 – Added Email Settings link in meeting menus and expanded meeting page actions.
 
 
 ---


### PR DESCRIPTION
## Summary
- include email settings option in meeting row context menu
- replicate full meeting actions dropdown on meeting detail page
- document change

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859a4230b50832b939c0e65698a81f6