### PR TITLE
Add email previews and summary on motions page

### DIFF
--- a/app/templates/meetings/_email_row.html
+++ b/app/templates/meetings/_email_row.html
@@ -1,5 +1,8 @@
 <tr>
   <td class="p-2">{{ email_type.replace('_', ' ').title() }}</td>
+  <td class="p-2">
+    <a href="{{ url_for('meetings.preview_email', meeting_id=meeting.id, email_type=email_type) }}" target="_blank" class="bp-link">Preview</a>
+  </td>
   <td class="p-2">{{ schedule_time or 'n/a' }}</td>
   <td class="p-2">
     <form hx-post="{{ url_for('meetings.toggle_email_setting', meeting_id=meeting.id, email_type=email_type) }}" hx-target="closest tr" hx-swap="outerHTML">

--- a/app/templates/meetings/_meeting_rows.html
+++ b/app/templates/meetings/_meeting_rows.html
@@ -133,7 +133,7 @@
              role="menuitem">
             <img src="{{ url_for('static', filename='icons/settings_30dp_000000_FILL0_wght400_GRAD0_opsz24.svg') }}"
                  alt="" class="bp-icon w-4 h-4 mr-3 text-bp-grey-400 group-hover:text-bp-grey-500">
-            Email Settings
+            Auto Send Email Settings
           </a>
         </div>
 

--- a/app/templates/meetings/email_settings.html
+++ b/app/templates/meetings/email_settings.html
@@ -5,7 +5,13 @@
 <h1 class="font-bold text-bp-blue mb-4">Email Settings</h1>
 <table class="bp-table">
   <thead>
-    <tr><th class="p-2">Email</th><th class="p-2">Scheduled</th><th class="p-2">Auto</th><th class="p-2">Last Sent</th></tr>
+    <tr>
+      <th class="p-2">Email</th>
+      <th class="p-2">Preview</th>
+      <th class="p-2">Scheduled</th>
+      <th class="p-2">Auto</th>
+      <th class="p-2">Last Sent</th>
+    </tr>
   </thead>
   <tbody id="email-rows">
     {% for email_type, schedule_time in schedule.items() %}

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -37,7 +37,7 @@
           <a href="{{ url_for('meetings.import_members', meeting_id=meeting.id) }}" class="bp-dropdown-item">Import Members</a>
           <a href="{{ url_for('meetings.list_members', meeting_id=meeting.id) }}" class="bp-dropdown-item">View Members</a>
           <a href="{{ url_for('meetings.manual_send_emails', meeting_id=meeting.id) }}" class="bp-dropdown-item">Send Emails</a>
-          <a href="{{ url_for('meetings.email_settings', meeting_id=meeting.id) }}" class="bp-dropdown-item">Email Settings</a>
+          <a href="{{ url_for('meetings.email_settings', meeting_id=meeting.id) }}" class="bp-dropdown-item">Auto Send Email Settings</a>
           <a href="{{ url_for('meetings.clone_meeting', meeting_id=meeting.id) }}" class="bp-dropdown-item">Clone Meeting</a>
           <a href="{{ url_for('submissions.list_submissions', meeting_id=meeting.id) }}" class="bp-dropdown-item">Review Submissions</a>
           {% if meeting.status == 'Completed' or meeting.public_results %}
@@ -171,6 +171,27 @@
     <div class="bp-stat-value">{{ amendments_count }}</div>
     <div class="bp-stat-label">Amendments</div>
   </div>
+</div>
+
+<div class="bp-card mb-8">
+  <h2 class="text-xl font-semibold text-bp-grey-900 mb-4">Auto Email Summary</h2>
+  <table class="bp-table w-full">
+    <tbody>
+    {% for t, _ in schedule.items() %}
+      {% set s = settings.get(t) %}
+      <tr>
+        <td class="p-2">{{ t.replace('_', ' ').title() }}</td>
+        <td class="p-2">
+          {% if s and not s.auto_send %}
+            <span class="bp-badge">Off</span>
+          {% else %}
+            <span class="bp-badge bp-badge-success">On</span>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
 </div>
 
 <!-- Motions List -->


### PR DESCRIPTION
## Summary
- add new route to preview email templates
- show preview links in email settings table
- rename email settings menu items to "Auto Send Email Settings"
- display auto email summary on motions list page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859a9d4925c832b973dfed85b85d152