### PR TITLE
Split meeting overview and motions pages

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -32,6 +32,8 @@ from ..models import (
     MeetingFile,
     EmailSetting,
     EmailLog,
+    MotionSubmission,
+    AmendmentSubmission,
 )
 from ..services.email import (
     send_vote_invite,
@@ -724,15 +726,17 @@ def meeting_files(meeting_id: int):
     )
 
 
-@bp.route("/<int:meeting_id>/motions")
+@bp.route("/<int:meeting_id>/meeting-overview")
 @login_required
 @permission_required("manage_meetings")
-def list_motions(meeting_id):
+def meeting_overview(meeting_id):
     meeting = db.session.get(Meeting, meeting_id)
     if meeting is None:
         abort(404)
     motions = (
-        Motion.query.filter_by(meeting_id=meeting.id).order_by(Motion.ordering).all()
+        Motion.query.filter_by(meeting_id=meeting.id)
+        .order_by(Motion.ordering)
+        .all()
     )
     amendments_count = Amendment.query.filter_by(meeting_id=meeting.id).count()
     votes_cast = meeting.stage1_votes_count()
@@ -751,8 +755,17 @@ def list_motions(meeting_id):
     timeline_end = max(dates) if dates else None
     schedule = _email_schedule(meeting)
     settings = {s.email_type: s for s in meeting.email_settings}
+    members_count = Member.query.filter_by(meeting_id=meeting.id).count()
+    pending_motions = MotionSubmission.query.filter_by(meeting_id=meeting.id).count()
+    pending_amendments = (
+        AmendmentSubmission.query.join(Motion, AmendmentSubmission.motion_id == Motion.id)
+        .filter(Motion.meeting_id == meeting.id)
+        .count()
+    )
+    files_count = MeetingFile.query.filter_by(meeting_id=meeting.id).count()
+
     return render_template(
-        "meetings/motions_list.html",
+        "meetings/meeting_overview.html",
         meeting=meeting,
         motions=motions,
         amendments_count=amendments_count,
@@ -763,6 +776,29 @@ def list_motions(meeting_id):
         schedule=schedule,
         settings=settings,
         now=datetime.utcnow(),
+        members_count=members_count,
+        pending_motions=pending_motions,
+        pending_amendments=pending_amendments,
+        files_count=files_count,
+    )
+
+
+@bp.route("/<int:meeting_id>/motions")
+@login_required
+@permission_required("manage_meetings")
+def list_motions(meeting_id: int):
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None:
+        abort(404)
+    motions = (
+        Motion.query.filter_by(meeting_id=meeting.id)
+        .order_by(Motion.ordering)
+        .all()
+    )
+    return render_template(
+        "meetings/motions_list.html",
+        meeting=meeting,
+        motions=motions,
     )
 
 

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -60,7 +60,7 @@
       <div class="bp-card hover:shadow-xl transition-all">
         <!-- Meeting Header - Title (Clickable) -->
         <div class="mb-4">
-          <a href="{{ url_for('meetings.list_motions', meeting_id=meeting.id) }}" class="block">
+          <a href="{{ url_for('meetings.meeting_overview', meeting_id=meeting.id) }}" class="block">
             <h3 class="text-xl font-bold text-bp-grey-900 hover:text-bp-blue-600 transition-colors mb-2">{{ meeting.title }}</h3>
           </a>
           

--- a/app/templates/meetings/_meeting_rows.html
+++ b/app/templates/meetings/_meeting_rows.html
@@ -12,7 +12,7 @@
         {% endif %}
       </div>
       <div>
-        <a href="{{ url_for('meetings.list_motions', meeting_id=meeting.id) }}" 
+        <a href="{{ url_for('meetings.meeting_overview', meeting_id=meeting.id) }}"
            class="bp-link font-semibold text-lg hover:text-bp-blue-600 transition-colors">
           {{ meeting.title }}
         </a>
@@ -85,7 +85,7 @@
                  alt="" class="bp-icon w-4 h-4 mr-3 text-bp-grey-400 group-hover:text-bp-grey-500">
             Edit Meeting
           </a>
-          <a href="{{ url_for('meetings.list_motions', meeting_id=meeting.id) }}" 
+          <a href="{{ url_for('meetings.meeting_overview', meeting_id=meeting.id) }}"
              class="group flex items-center px-4 py-2 text-sm text-bp-grey-700 hover:bg-bp-grey-50 hover:text-bp-grey-900 transition-colors"
              role="menuitem">
             <img src="{{ url_for('static', filename='icons/how_to_vote_30dp_000000_FILL0_wght400_GRAD0_opsz24.svg') }}" 

--- a/app/templates/meetings/meeting_overview.html
+++ b/app/templates/meetings/meeting_overview.html
@@ -1,0 +1,350 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
+
+{% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Motions', None)]) }}
+
+<!-- Page Header -->
+<div class="mb-8">
+  <div class="flex items-center justify-between mb-4">
+    <div>
+      <h1 class="text-3xl font-bold text-bp-grey-900 mb-2">{{ meeting.title }}</h1>
+      <p class="text-bp-grey-600 flex items-center gap-2">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012-2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
+        </svg>
+        {{ motions|length }} Motion{{ 's' if motions|length != 1 else '' }}
+      </p>
+    </div>
+    
+    <div class="flex items-center gap-2">
+      <a href="{{ url_for('meetings.create_motion', meeting_id=meeting.id) }}"
+         class="bp-btn-primary bp-btn-icon">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+        </svg>
+        <span>Add Motion</span>
+      </a>
+      <a href="{{ url_for('meetings.list_motions', meeting_id=meeting.id) }}" class="bp-btn-secondary bp-btn-icon">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2"/>
+        </svg>
+        <span>View Motions</span>
+      </a>
+
+      <div class="bp-dropdown">
+        <button class="bp-btn-secondary bp-btn-compact" aria-label="More actions">
+          <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+          </svg>
+        </button>
+        <div class="bp-dropdown-menu w-56">
+          <a href="{{ url_for('meetings.edit_meeting', meeting_id=meeting.id) }}" class="bp-dropdown-item">Edit Meeting</a>
+          <a href="{{ url_for('meetings.import_members', meeting_id=meeting.id) }}" class="bp-dropdown-item">Import Members</a>
+          <a href="{{ url_for('meetings.list_members', meeting_id=meeting.id) }}" class="bp-dropdown-item">View Members</a>
+          <a href="{{ url_for('meetings.manual_send_emails', meeting_id=meeting.id) }}" class="bp-dropdown-item">Send Emails</a>
+          <a href="{{ url_for('meetings.email_settings', meeting_id=meeting.id) }}" class="bp-dropdown-item">Auto Send Email Settings</a>
+          <a href="{{ url_for('meetings.clone_meeting', meeting_id=meeting.id) }}" class="bp-dropdown-item">Clone Meeting</a>
+          <a href="{{ url_for('submissions.list_submissions', meeting_id=meeting.id) }}" class="bp-dropdown-item">Review Submissions</a>
+          {% if meeting.status == 'Completed' or meeting.public_results %}
+          <a href="{{ url_for('meetings.results_summary', meeting_id=meeting.id) }}" class="bp-dropdown-item">View Results</a>
+          <a href="{{ url_for('meetings.results_docx', meeting_id=meeting.id) }}" class="bp-dropdown-item">Export Results (Word)</a>
+          {% endif %}
+          <a href="{{ url_for('meetings.meeting_files', meeting_id=meeting.id) }}" class="bp-dropdown-item">Manage Files</a>
+          {% if meeting.ballot_mode == 'combined' %}
+          <a href="{{ url_for('meetings.preview_voting', meeting_id=meeting.id, stage=1) }}" class="bp-dropdown-item">Preview Combined Ballot</a>
+          {% else %}
+          <a href="{{ url_for('meetings.preview_voting', meeting_id=meeting.id, stage=1) }}" class="bp-dropdown-item">Preview Stage 1</a>
+          <a href="{{ url_for('meetings.preview_voting', meeting_id=meeting.id, stage=2) }}" class="bp-dropdown-item">Preview Stage 2</a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% if timeline_start and timeline_end %}
+<!-- Meeting Timeline -->
+<div class="bp-card mb-8">
+  <h2 class="text-xl font-semibold text-bp-grey-900 mb-6 flex items-center gap-2">
+    <svg class="w-5 h-5 text-bp-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+    </svg>
+    Meeting Timeline
+  </h2>
+  
+  <div class="bp-timeline">
+    <div class="bp-timeline-wrapper">
+      <div class="bp-timeline-container">
+        <!-- Progress bar showing elapsed time -->
+        {% if now >= timeline_start %}
+          {# Calculate progress width to match the "Today" marker position #}
+          {% set progress_width = 50 %}  {# Default to middle if calculation fails #}
+          {% for i in range(valid_milestones|length - 1) %}
+            {% set curr_label, curr_dt = valid_milestones[i] %}
+            {% set next_label, next_dt = valid_milestones[i + 1] %}
+            {% if curr_dt and next_dt and curr_dt <= now <= next_dt %}
+              {# Calculate position between these two milestones #}
+              {% set curr_position = 2.5 + (i * spacing) %}
+              {% set next_position = 2.5 + ((i + 1) * spacing) %}
+              {% set time_ratio = ((now - curr_dt).total_seconds() / (next_dt - curr_dt).total_seconds()) %}
+              {% set progress_width = curr_position + (time_ratio * (next_position - curr_position)) %}
+            {% elif i == 0 and curr_dt and now < curr_dt %}
+              {# Before first milestone #}
+              {% set progress_width = 2.5 %}
+            {% elif i == valid_milestones|length - 2 and next_dt and now > next_dt %}
+              {# After last milestone #}
+              {% set progress_width = 2.5 + ((valid_milestones|length - 1) * spacing) %}
+            {% endif %}
+          {% endfor %}
+          <div class="bp-timeline-progress" style="width: {{ progress_width }}%"></div>
+        {% endif %}
+        
+        <!-- Timeline markers with equal spacing -->
+        {% set valid_milestones = timeline_steps|selectattr('1')|list %}
+        {% set total_milestones = valid_milestones|length %}
+        {% set spacing = 95 / (total_milestones - 1) if total_milestones > 1 else 0 %}
+        {% for milestone in valid_milestones %}
+          {% set label, dt = milestone %}
+          {% set milestone_index = loop.index0 %}
+          {% set position = 2.5 + (milestone_index * spacing) %}
+          
+          <div class="bp-timeline-marker {{ 'bp-timeline-marker-alt' if loop.index0 % 2 == 1 else '' }}" 
+               style="left: {{ position }}%">
+            <div class="bp-timeline-dot"></div>
+            <div class="bp-timeline-label">
+              <div class="font-semibold">{{ label }}</div>
+              <div class="text-xs opacity-75">{{ dt.strftime('%d %b') }}</div>
+            </div>
+          </div>
+        {% endfor %}
+        
+        <!-- Current time indicator -->
+        {% if timeline_start <= now <= timeline_end %}
+          {# Find which two milestones the current time falls between #}
+          {% set now_position = 50 %}  {# Default to middle if calculation fails #}
+          {% for i in range(valid_milestones|length - 1) %}
+            {% set curr_label, curr_dt = valid_milestones[i] %}
+            {% set next_label, next_dt = valid_milestones[i + 1] %}
+            {% if curr_dt and next_dt and curr_dt <= now <= next_dt %}
+              {# Calculate position between these two milestones #}
+              {% set curr_position = 2.5 + (i * spacing) %}
+              {% set next_position = 2.5 + ((i + 1) * spacing) %}
+              {% set time_ratio = ((now - curr_dt).total_seconds() / (next_dt - curr_dt).total_seconds()) %}
+              {% set now_position = curr_position + (time_ratio * (next_position - curr_position)) %}
+            {% elif i == 0 and curr_dt and now < curr_dt %}
+              {# Before first milestone #}
+              {% set now_position = 2.5 %}
+            {% elif i == valid_milestones|length - 2 and next_dt and now > next_dt %}
+              {# After last milestone #}
+              {% set now_position = 2.5 + ((valid_milestones|length - 1) * spacing) %}
+            {% endif %}
+          {% endfor %}
+          <div class="bp-timeline-now" style="--now-position: {{ now_position }}%"></div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  
+  <!-- Timeline Legend -->
+  <div class="mt-6 flex flex-wrap items-center gap-4 text-sm text-bp-grey-600">
+    <div class="flex items-center gap-2">
+      <div class="w-3 h-3 bg-bp-blue rounded-full"></div>
+      <span>Milestone</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <div class="w-3 h-3 bg-bp-red rounded-full animate-pulse"></div>
+      <span>Current Date</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <div class="w-8 h-1 bg-gradient-to-r from-bp-blue to-bp-blue-light rounded"></div>
+      <span>Progress</span>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+  <div class="bp-stat-card">
+    <div class="bp-stat-value">{{ votes_cast }} / {{ members_count }}</div>
+    <div class="bp-stat-label">Members Voted</div>
+  </div>
+  <div class="bp-stat-card">
+    <div class="bp-stat-value">{{ motions|length }}</div>
+    <div class="bp-stat-label">Motions</div>
+  </div>
+  <div class="bp-stat-card">
+    <div class="bp-stat-value">{{ amendments_count }}</div>
+    <div class="bp-stat-label">Amendments</div>
+  </div>
+  <div class="bp-stat-card">
+  <div class="bp-stat-value">{{ files_count }}</div>
+  <div class="bp-stat-label">Files</div>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+  <div class="bp-card">
+    <h2 class="text-xl font-semibold text-bp-grey-900 mb-2">Pending Submissions</h2>
+    <p class="mb-4">{{ pending_motions }} motion{{ 's' if pending_motions != 1 else '' }}, {{ pending_amendments }} amendment{{ 's' if pending_amendments != 1 else '' }}</p>
+    <a href="{{ url_for('submissions.list_submissions', meeting_id=meeting.id) }}" class="bp-btn-secondary bp-btn-sm">Review Submissions</a>
+  </div>
+  <div class="bp-card">
+    <h2 class="text-xl font-semibold text-bp-grey-900 mb-2">Meeting Files</h2>
+    <p class="mb-4">{{ files_count }} uploaded file{{ 's' if files_count != 1 else '' }}</p>
+    <a href="{{ url_for('meetings.meeting_files', meeting_id=meeting.id) }}" class="bp-btn-secondary bp-btn-sm">Manage Files</a>
+  </div>
+</div>
+
+<div class="bp-card mb-8">
+  <h2 class="text-xl font-semibold text-bp-grey-900 mb-4">Auto Email Summary</h2>
+  <table class="bp-table w-full">
+    <tbody>
+    {% for t, _ in schedule.items() %}
+      {% set s = settings.get(t) %}
+      <tr>
+        <td class="p-2">{{ t.replace('_', ' ').title() }}</td>
+        <td class="p-2">
+          {% if s and not s.auto_send %}
+            <span class="bp-badge">Off</span>
+          {% else %}
+            <span class="bp-badge bp-badge-success">On</span>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Motions List -->
+{% if motions %}
+<div class="grid gap-6">
+  {% for m in motions %}
+  <div class="bp-card hover:shadow-xl transition-all duration-200 border-l-4 
+              {% if m.status == 'passed' %}border-green-500
+              {% elif m.status == 'failed' %}border-red-500
+              {% elif m.withdrawn %}border-bp-grey-400
+              {% else %}border-bp-blue{% endif %}">
+    
+    <div class="flex items-start justify-between mb-4">
+      <div class="flex-1">
+        <div class="flex items-center gap-3 mb-2">
+          <h3 class="text-xl font-semibold text-bp-grey-900 hover:text-bp-blue transition-colors">
+            {{ m.title }}
+          </h3>
+          
+          <!-- Status Badge -->
+          {% if m.status %}
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                       {% if m.status == 'passed' %}bg-green-100 text-green-800
+                       {% elif m.status == 'failed' %}bg-red-100 text-red-800
+                       {% else %}bg-bp-grey-100 text-bp-grey-800{% endif %}">
+            {{ m.status|title }}
+          </span>
+          {% endif %}
+          
+          {% if m.withdrawn %}
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-bp-grey-100 text-bp-grey-800">
+            Withdrawn
+          </span>
+          {% endif %}
+        </div>
+        
+        <div class="flex items-center gap-4 text-sm text-bp-grey-600 mb-3">
+          <span class="inline-flex items-center gap-1">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
+            </svg>
+            {{ m.category|title }}
+          </span>
+          
+          {% if m.threshold %}
+          <span class="inline-flex items-center gap-1">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+            </svg>
+            {{ m.threshold|title }} Threshold
+          </span>
+          {% endif %}
+          
+          {% if m.ordering %}
+          <span class="inline-flex items-center gap-1">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"></path>
+            </svg>
+            Order #{{ m.ordering }}
+          </span>
+          {% endif %}
+        </div>
+        
+        <!-- Motion Preview -->
+        {% if m.text_md %}
+        <div class="bg-bp-grey-50 rounded-md p-3 mb-3 border-l-2 border-bp-grey-200">
+          <p class="text-sm text-bp-grey-700 line-clamp-2">
+            {{ m.text_md[:150] }}{% if m.text_md|length > 150 %}...{% endif %}
+          </p>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    
+    <div class="flex items-center justify-between pt-4 border-t border-bp-grey-100">
+      <div class="flex items-center gap-4 text-xs text-bp-grey-600">
+        {% if m.is_published %}
+        <span class="inline-flex items-center gap-1 text-green-600">
+          <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+          </svg>
+          Published
+        </span>
+        {% else %}
+        <span class="inline-flex items-center gap-1 text-bp-grey-500">
+          <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+          </svg>
+          Draft
+        </span>
+        {% endif %}
+        
+        {% if m.modified_at %}
+        <span>Modified {{ m.modified_at.strftime('%b %d, %Y') }}</span>
+        {% endif %}
+      </div>
+      
+      <a href="{{ url_for('meetings.view_motion', motion_id=m.id) }}" 
+         class="bp-btn-secondary bp-btn-compact bp-btn-icon">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
+        </svg>
+        View Details
+      </a>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+{% else %}
+<!-- Empty State -->
+<div class="text-center py-12">
+  <div class="bg-bp-grey-50 rounded-full w-24 h-24 flex items-center justify-center mx-auto mb-6">
+    <svg class="w-12 h-12 text-bp-grey-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+    </svg>
+  </div>
+  <h3 class="text-lg font-semibold text-bp-grey-900 mb-2">No motions yet</h3>
+  <p class="text-bp-grey-600 mb-6 max-w-md mx-auto">
+    Get started by creating your first motion for this meeting. You can add the motion text, set categories, and manage amendments.
+  </p>
+  <a href="{{ url_for('meetings.create_motion', meeting_id=meeting.id) }}" 
+     class="bp-btn-primary bp-btn-icon">
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+    </svg>
+    Create Your First Motion
+  </a>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -2,216 +2,26 @@
 {% from '_macros.html' import breadcrumbs %}
 
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Motions', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Motions', None)]) }}
 
-<!-- Page Header -->
-<div class="mb-8">
-  <div class="flex items-center justify-between mb-4">
-    <div>
-      <h1 class="text-3xl font-bold text-bp-grey-900 mb-2">{{ meeting.title }}</h1>
-      <p class="text-bp-grey-600 flex items-center gap-2">
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012-2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
-        </svg>
-        {{ motions|length }} Motion{{ 's' if motions|length != 1 else '' }}
-      </p>
-    </div>
-    
-    <div class="flex items-center gap-2">
-      <a href="{{ url_for('meetings.create_motion', meeting_id=meeting.id) }}"
-         class="bp-btn-primary bp-btn-icon">
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
-        </svg>
-        <span>Add Motion</span>
-      </a>
+<h1 class="text-3xl font-bold mb-6">Motions</h1>
 
-      <div class="bp-dropdown">
-        <button class="bp-btn-secondary bp-btn-compact" aria-label="More actions">
-          <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-            <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
-          </svg>
-        </button>
-        <div class="bp-dropdown-menu w-56">
-          <a href="{{ url_for('meetings.edit_meeting', meeting_id=meeting.id) }}" class="bp-dropdown-item">Edit Meeting</a>
-          <a href="{{ url_for('meetings.import_members', meeting_id=meeting.id) }}" class="bp-dropdown-item">Import Members</a>
-          <a href="{{ url_for('meetings.list_members', meeting_id=meeting.id) }}" class="bp-dropdown-item">View Members</a>
-          <a href="{{ url_for('meetings.manual_send_emails', meeting_id=meeting.id) }}" class="bp-dropdown-item">Send Emails</a>
-          <a href="{{ url_for('meetings.email_settings', meeting_id=meeting.id) }}" class="bp-dropdown-item">Auto Send Email Settings</a>
-          <a href="{{ url_for('meetings.clone_meeting', meeting_id=meeting.id) }}" class="bp-dropdown-item">Clone Meeting</a>
-          <a href="{{ url_for('submissions.list_submissions', meeting_id=meeting.id) }}" class="bp-dropdown-item">Review Submissions</a>
-          {% if meeting.status == 'Completed' or meeting.public_results %}
-          <a href="{{ url_for('meetings.results_summary', meeting_id=meeting.id) }}" class="bp-dropdown-item">View Results</a>
-          <a href="{{ url_for('meetings.results_docx', meeting_id=meeting.id) }}" class="bp-dropdown-item">Export Results (Word)</a>
-          {% endif %}
-          <a href="{{ url_for('meetings.meeting_files', meeting_id=meeting.id) }}" class="bp-dropdown-item">Manage Files</a>
-          {% if meeting.ballot_mode == 'combined' %}
-          <a href="{{ url_for('meetings.preview_voting', meeting_id=meeting.id, stage=1) }}" class="bp-dropdown-item">Preview Combined Ballot</a>
-          {% else %}
-          <a href="{{ url_for('meetings.preview_voting', meeting_id=meeting.id, stage=1) }}" class="bp-dropdown-item">Preview Stage 1</a>
-          <a href="{{ url_for('meetings.preview_voting', meeting_id=meeting.id, stage=2) }}" class="bp-dropdown-item">Preview Stage 2</a>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-{% if timeline_start and timeline_end %}
-<!-- Meeting Timeline -->
-<div class="bp-card mb-8">
-  <h2 class="text-xl font-semibold text-bp-grey-900 mb-6 flex items-center gap-2">
-    <svg class="w-5 h-5 text-bp-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-    </svg>
-    Meeting Timeline
-  </h2>
-  
-  <div class="bp-timeline">
-    <div class="bp-timeline-wrapper">
-      <div class="bp-timeline-container">
-        <!-- Progress bar showing elapsed time -->
-        {% if now >= timeline_start %}
-          {# Calculate progress width to match the "Today" marker position #}
-          {% set progress_width = 50 %}  {# Default to middle if calculation fails #}
-          {% for i in range(valid_milestones|length - 1) %}
-            {% set curr_label, curr_dt = valid_milestones[i] %}
-            {% set next_label, next_dt = valid_milestones[i + 1] %}
-            {% if curr_dt and next_dt and curr_dt <= now <= next_dt %}
-              {# Calculate position between these two milestones #}
-              {% set curr_position = 2.5 + (i * spacing) %}
-              {% set next_position = 2.5 + ((i + 1) * spacing) %}
-              {% set time_ratio = ((now - curr_dt).total_seconds() / (next_dt - curr_dt).total_seconds()) %}
-              {% set progress_width = curr_position + (time_ratio * (next_position - curr_position)) %}
-            {% elif i == 0 and curr_dt and now < curr_dt %}
-              {# Before first milestone #}
-              {% set progress_width = 2.5 %}
-            {% elif i == valid_milestones|length - 2 and next_dt and now > next_dt %}
-              {# After last milestone #}
-              {% set progress_width = 2.5 + ((valid_milestones|length - 1) * spacing) %}
-            {% endif %}
-          {% endfor %}
-          <div class="bp-timeline-progress" style="width: {{ progress_width }}%"></div>
-        {% endif %}
-        
-        <!-- Timeline markers with equal spacing -->
-        {% set valid_milestones = timeline_steps|selectattr('1')|list %}
-        {% set total_milestones = valid_milestones|length %}
-        {% set spacing = 95 / (total_milestones - 1) if total_milestones > 1 else 0 %}
-        {% for milestone in valid_milestones %}
-          {% set label, dt = milestone %}
-          {% set milestone_index = loop.index0 %}
-          {% set position = 2.5 + (milestone_index * spacing) %}
-          
-          <div class="bp-timeline-marker {{ 'bp-timeline-marker-alt' if loop.index0 % 2 == 1 else '' }}" 
-               style="left: {{ position }}%">
-            <div class="bp-timeline-dot"></div>
-            <div class="bp-timeline-label">
-              <div class="font-semibold">{{ label }}</div>
-              <div class="text-xs opacity-75">{{ dt.strftime('%d %b') }}</div>
-            </div>
-          </div>
-        {% endfor %}
-        
-        <!-- Current time indicator -->
-        {% if timeline_start <= now <= timeline_end %}
-          {# Find which two milestones the current time falls between #}
-          {% set now_position = 50 %}  {# Default to middle if calculation fails #}
-          {% for i in range(valid_milestones|length - 1) %}
-            {% set curr_label, curr_dt = valid_milestones[i] %}
-            {% set next_label, next_dt = valid_milestones[i + 1] %}
-            {% if curr_dt and next_dt and curr_dt <= now <= next_dt %}
-              {# Calculate position between these two milestones #}
-              {% set curr_position = 2.5 + (i * spacing) %}
-              {% set next_position = 2.5 + ((i + 1) * spacing) %}
-              {% set time_ratio = ((now - curr_dt).total_seconds() / (next_dt - curr_dt).total_seconds()) %}
-              {% set now_position = curr_position + (time_ratio * (next_position - curr_position)) %}
-            {% elif i == 0 and curr_dt and now < curr_dt %}
-              {# Before first milestone #}
-              {% set now_position = 2.5 %}
-            {% elif i == valid_milestones|length - 2 and next_dt and now > next_dt %}
-              {# After last milestone #}
-              {% set now_position = 2.5 + ((valid_milestones|length - 1) * spacing) %}
-            {% endif %}
-          {% endfor %}
-          <div class="bp-timeline-now" style="--now-position: {{ now_position }}%"></div>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-  
-  <!-- Timeline Legend -->
-  <div class="mt-6 flex flex-wrap items-center gap-4 text-sm text-bp-grey-600">
-    <div class="flex items-center gap-2">
-      <div class="w-3 h-3 bg-bp-blue rounded-full"></div>
-      <span>Milestone</span>
-    </div>
-    <div class="flex items-center gap-2">
-      <div class="w-3 h-3 bg-bp-red rounded-full animate-pulse"></div>
-      <span>Current Date</span>
-    </div>
-    <div class="flex items-center gap-2">
-      <div class="w-8 h-1 bg-gradient-to-r from-bp-blue to-bp-blue-light rounded"></div>
-      <span>Progress</span>
-    </div>
-  </div>
-</div>
-{% endif %}
-
-<div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-  <div class="bp-stat-card">
-    <div class="bp-stat-value">{{ votes_cast }}</div>
-    <div class="bp-stat-label">Voters</div>
-  </div>
-  <div class="bp-stat-card">
-    <div class="bp-stat-value">{{ motions|length }}</div>
-    <div class="bp-stat-label">Motions</div>
-  </div>
-  <div class="bp-stat-card">
-    <div class="bp-stat-value">{{ amendments_count }}</div>
-    <div class="bp-stat-label">Amendments</div>
-  </div>
-</div>
-
-<div class="bp-card mb-8">
-  <h2 class="text-xl font-semibold text-bp-grey-900 mb-4">Auto Email Summary</h2>
-  <table class="bp-table w-full">
-    <tbody>
-    {% for t, _ in schedule.items() %}
-      {% set s = settings.get(t) %}
-      <tr>
-        <td class="p-2">{{ t.replace('_', ' ').title() }}</td>
-        <td class="p-2">
-          {% if s and not s.auto_send %}
-            <span class="bp-badge">Off</span>
-          {% else %}
-            <span class="bp-badge bp-badge-success">On</span>
-          {% endif %}
-        </td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
-</div>
-
-<!-- Motions List -->
 {% if motions %}
 <div class="grid gap-6">
   {% for m in motions %}
-  <div class="bp-card hover:shadow-xl transition-all duration-200 border-l-4 
+  <div class="bp-card hover:shadow-xl transition-all duration-200 border-l-4
               {% if m.status == 'passed' %}border-green-500
               {% elif m.status == 'failed' %}border-red-500
               {% elif m.withdrawn %}border-bp-grey-400
               {% else %}border-bp-blue{% endif %}">
-    
+
     <div class="flex items-start justify-between mb-4">
       <div class="flex-1">
         <div class="flex items-center gap-3 mb-2">
           <h3 class="text-xl font-semibold text-bp-grey-900 hover:text-bp-blue transition-colors">
             {{ m.title }}
           </h3>
-          
-          <!-- Status Badge -->
+
           {% if m.status %}
           <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
                        {% if m.status == 'passed' %}bg-green-100 text-green-800
@@ -220,42 +30,41 @@
             {{ m.status|title }}
           </span>
           {% endif %}
-          
+
           {% if m.withdrawn %}
           <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-bp-grey-100 text-bp-grey-800">
             Withdrawn
           </span>
           {% endif %}
         </div>
-        
+
         <div class="flex items-center gap-4 text-sm text-bp-grey-600 mb-3">
           <span class="inline-flex items-center gap-1">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
             </svg>
             {{ m.category|title }}
           </span>
-          
+
           {% if m.threshold %}
           <span class="inline-flex items-center gap-1">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
             </svg>
             {{ m.threshold|title }} Threshold
           </span>
           {% endif %}
-          
+
           {% if m.ordering %}
           <span class="inline-flex items-center gap-1">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"></path>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"/>
             </svg>
             Order #{{ m.ordering }}
           </span>
           {% endif %}
         </div>
-        
-        <!-- Motion Preview -->
+
         {% if m.text_md %}
         <div class="bg-bp-grey-50 rounded-md p-3 mb-3 border-l-2 border-bp-grey-200">
           <p class="text-sm text-bp-grey-700 line-clamp-2">
@@ -265,35 +74,34 @@
         {% endif %}
       </div>
     </div>
-    
+
     <div class="flex items-center justify-between pt-4 border-t border-bp-grey-100">
       <div class="flex items-center gap-4 text-xs text-bp-grey-600">
         {% if m.is_published %}
         <span class="inline-flex items-center gap-1 text-green-600">
           <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
           </svg>
           Published
         </span>
         {% else %}
         <span class="inline-flex items-center gap-1 text-bp-grey-500">
           <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
           </svg>
           Draft
         </span>
         {% endif %}
-        
+
         {% if m.modified_at %}
         <span>Modified {{ m.modified_at.strftime('%b %d, %Y') }}</span>
         {% endif %}
       </div>
-      
-      <a href="{{ url_for('meetings.view_motion', motion_id=m.id) }}" 
-         class="bp-btn-secondary bp-btn-compact bp-btn-icon">
+
+      <a href="{{ url_for('meetings.view_motion', motion_id=m.id) }}" class="bp-btn-secondary bp-btn-compact bp-btn-icon">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
         </svg>
         View Details
       </a>
@@ -303,21 +111,19 @@
 </div>
 
 {% else %}
-<!-- Empty State -->
 <div class="text-center py-12">
   <div class="bg-bp-grey-50 rounded-full w-24 h-24 flex items-center justify-center mx-auto mb-6">
     <svg class="w-12 h-12 text-bp-grey-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
     </svg>
   </div>
   <h3 class="text-lg font-semibold text-bp-grey-900 mb-2">No motions yet</h3>
   <p class="text-bp-grey-600 mb-6 max-w-md mx-auto">
     Get started by creating your first motion for this meeting. You can add the motion text, set categories, and manage amendments.
   </p>
-  <a href="{{ url_for('meetings.create_motion', meeting_id=meeting.id) }}" 
-     class="bp-btn-primary bp-btn-icon">
+  <a href="{{ url_for('meetings.create_motion', meeting_id=meeting.id) }}" class="bp-btn-primary bp-btn-icon">
     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
     </svg>
     Create Your First Motion
   </a>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -477,6 +477,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-26 – Added Import Members button on members page and breadcrumb link.* 2025-07-27 – Added member actions menu with resend email options.
 * 2025-07-27 – Member management buttons moved above table for quicker access.
 * 2025-07-30 – Added Email Settings link in meeting menus and expanded meeting page actions.
+* 2025-07-31 – Split meeting overview and motions list pages with new dashboard widgets.
 
 
 ---


### PR DESCRIPTION
## Summary
- move original motions dashboard to `/meeting-overview`
- create new `/motions` page listing just motions
- add voting and file stats with submission widget
- update links to overview
- document the change

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859c20b9368832ba393babf5b29b654