### PR TITLE
Fix email toggle default and link from overview

### DIFF
--- a/app/templates/meetings/_email_row.html
+++ b/app/templates/meetings/_email_row.html
@@ -7,7 +7,9 @@
   <td class="p-2">
     <form hx-post="{{ url_for('meetings.toggle_email_setting', meeting_id=meeting.id, email_type=email_type) }}" hx-target="closest tr" hx-swap="outerHTML">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <button type="submit" class="bp-btn-secondary">{{ 'On' if setting and setting.auto_send else 'Off' }}</button>
+      <button type="submit" class="bp-btn-secondary">
+        {{ 'On' if (not setting) or setting.auto_send else 'Off' }}
+      </button>
     </form>
   </td>
   <td class="p-2">{{ log.sent_at.strftime('%Y-%m-%d %H:%M') if log else 'Not sent' }}</td>

--- a/app/templates/meetings/meeting_overview.html
+++ b/app/templates/meetings/meeting_overview.html
@@ -196,9 +196,12 @@
   </div>
 </div>
 
-<div class="bp-card mb-8">
-  <h2 class="text-xl font-semibold text-bp-grey-900 mb-4">Auto Email Summary</h2>
-  <table class="bp-table w-full">
+<div class="bp-card p-4 mb-6">
+  <div class="flex items-center justify-between mb-2">
+    <h2 class="text-xl font-semibold text-bp-grey-900">Auto Email Summary</h2>
+    <a href="{{ url_for('meetings.email_settings', meeting_id=meeting.id) }}" class="bp-link text-sm">Edit</a>
+  </div>
+  <table class="bp-table w-full text-sm">
     <tbody>
     {% for t, _ in schedule.items() %}
       {% set s = settings.get(t) %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -479,6 +479,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-30 – Added Email Settings link in meeting menus and expanded meeting page actions.
 * 2025-08-20 – Added batch motion/amendment edit page with version history.
 * 2025-07-31 – Split meeting overview and motions list pages with new dashboard widgets.
+* 2025-07-10 – Fixed auto email toggle mismatch and compacted overview card.
 
 
 ---


### PR DESCRIPTION
## Summary
- show `On` in email settings when no record exists yet
- compact auto email summary card and link to email settings
- document email settings fix

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a54ef3dbc832bb95bef265d161186