### PR TITLE
Add motion review email

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -211,6 +211,7 @@ class ManualEmailForm(FlaskForm):
             ("runoff_invite", "Run-off Invite"),
             ("stage2_invite", "Stage 2 Invite"),
             ("submission_invite", "Motion Submission Invite"),
+            ("review_invite", "Motion Review Invite"),
         ],
         validators=[DataRequired()],
     )

--- a/app/templates/email/review_invite.html
+++ b/app/templates/email/review_invite.html
@@ -1,0 +1,12 @@
+{% if logo %}
+<p><img src="{{ logo }}" alt="{{ site_title }}" style="height:40px;"></p>
+{% else %}
+<p><strong>{{ site_title }}</strong></p>
+{% endif %}
+<p>Dear {{ member.name }},</p>
+<p>The draft motions for {{ meeting.title }} are available to review online. You may leave comments and propose amendments if needed.</p>
+<p><a href="{{ review_url }}">View Motions</a></p>
+<p><a href="{{ link }}">Submit Amendment</a></p>
+<p>More about online voting: <a href="{{ url_for('help.show_help', _external=True) }}">Voting Help</a></p>
+<p>To stop these emails, visit {{ unsubscribe_url }}</p>
+<p>To start them again later, visit {{ resubscribe_url }}</p>

--- a/app/templates/email/review_invite.txt
+++ b/app/templates/email/review_invite.txt
@@ -1,0 +1,11 @@
+Dear {{ member.name }},
+
+The draft motions for {{ meeting.title }} are now online for review. You may comment on them and submit amendments if appropriate.
+
+View motions: {{ review_url }}
+Submit amendment: {{ link }}
+
+Need help? {{ url_for('help.show_help', _external=True) }}
+
+To stop these emails, visit {{ unsubscribe_url }}
+To start them again later, visit {{ resubscribe_url }}

--- a/app/templates/meetings/_member_rows.html
+++ b/app/templates/meetings/_member_rows.html
@@ -45,6 +45,11 @@
             <button type="submit" class="group flex items-center px-4 py-2 text-sm text-bp-grey-700 hover:bg-bp-grey-50 hover:text-bp-grey-900 transition-colors" role="menuitem">Resend Submission Invite</button>
           </form>
           {% endif %}
+          {% if email_opts.review_invite %}
+          <form method="post" action="{{ url_for('meetings.send_member_email', meeting_id=meeting.id, member_id=m.id, kind='review_invite') }}">
+            <button type="submit" class="group flex items-center px-4 py-2 text-sm text-bp-grey-700 hover:bg-bp-grey-50 hover:text-bp-grey-900 transition-colors" role="menuitem">Resend Review Invite</button>
+          </form>
+          {% endif %}
           {% if email_opts.final_results %}
           <form method="post" action="{{ url_for('meetings.send_member_email', meeting_id=meeting.id, member_id=m.id, kind='final_results') }}">
             <button type="submit" class="group flex items-center px-4 py-2 text-sm text-bp-grey-700 hover:bg-bp-grey-50 hover:text-bp-grey-900 transition-colors" role="menuitem">Resend Final Results</button>

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -11,6 +11,7 @@ from app.services.email import (
     send_runoff_invite,
     send_stage1_reminder,
     send_stage2_invite,
+    send_review_invite,
     send_vote_receipt,
     send_quorum_failure,
     send_final_results,
@@ -268,3 +269,24 @@ def test_invite_includes_notice_text():
                 send_vote_invite(member, 'tok', meeting, test_mode=False)
                 sent = mock_send.call_args[0][0]
                 assert 'This is the **notice**' in sent.body
+
+
+def test_send_review_invite_links():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['MAIL_SUPPRESS_SEND'] = True
+    app.config['TOKEN_SALT'] = 's'
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        member = Member(name='Zoe', email='z@example.com', meeting_id=1)
+        db.session.add(member)
+        db.session.commit()
+        with app.test_request_context('/'):
+            with patch.object(mail, 'send') as mock_send:
+                send_review_invite(member, meeting, test_mode=False)
+                mock_send.assert_called_once()
+                sent = mock_send.call_args[0][0]
+                assert '/public/meetings/1' in sent.body
+                assert '/submit/' in sent.body

--- a/tests/test_email_settings.py
+++ b/tests/test_email_settings.py
@@ -48,6 +48,8 @@ def test_email_schedule_two_stage_includes_stage2():
         )
         schedule = meetings_routes._email_schedule(meeting)
         assert set(schedule.keys()) == {
+            'submission_invite',
+            'review_invite',
             'stage1_invite',
             'stage1_reminder',
             'stage2_invite',
@@ -68,4 +70,9 @@ def test_email_schedule_combined_excludes_stage2():
             closes_at_stage1=now + timedelta(days=1),
         )
         schedule = meetings_routes._email_schedule(meeting)
-        assert set(schedule.keys()) == {'stage1_invite', 'stage1_reminder'}
+        assert set(schedule.keys()) == {
+            'submission_invite',
+            'review_invite',
+            'stage1_invite',
+            'stage1_reminder',
+        }


### PR DESCRIPTION
## Summary
- add `review_invite` email templates and send function
- expose submission & review invites in email settings and member actions
- support previewing the new emails
- update tests for new email types

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a5d1d5c9c832babbc2b6741d84c46