### PR TITLE
Fix batch edit amendment and refresh

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -872,7 +872,13 @@ def batch_edit_motions(meeting_id: int):
             )
             db.session.add(m)
         if request.form.get("new_amend_text_md"):
-            m_id = int(request.form.get("new_amend_motion_id"))
+            motion_id_raw = request.form.get("new_amend_motion_id", "").strip()
+            if not motion_id_raw.isdigit():
+                flash("Select the motion this amendment applies to.", "error")
+                return redirect(
+                    url_for("meetings.batch_edit_motions", meeting_id=meeting.id)
+                )
+            m_id = int(motion_id_raw)
             order = Amendment.query.filter_by(motion_id=m_id).count() + 1
             a = Amendment(
                 meeting_id=meeting.id,

--- a/app/templates/meetings/batch_edit_motions.html
+++ b/app/templates/meetings/batch_edit_motions.html
@@ -7,7 +7,7 @@
 <div class="max-w-7xl mx-auto">
   <h1 class="font-bold text-bp-blue mb-6 text-2xl">Batch Edit Motions & Amendments</h1>
   
-  <form method="post" class="space-y-8">
+  <form method="post" class="space-y-8" hx-boost="false">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     
     <!-- Existing Motions Section -->

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -480,6 +480,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-08-20 – Added batch motion/amendment edit page with version history.
 * 2025-07-31 – Split meeting overview and motions list pages with new dashboard widgets.
 * 2025-07-10 – Fixed auto email toggle mismatch and compacted overview card.
+* 2025-08-21 – Fixed amendment form ignoring selected motion on batch edit page.
 
 
 ---


### PR DESCRIPTION
## Summary
- validate motion selection when adding new amendment
- disable htmx boosting on batch edit form to force full refresh
- document fix in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a5a4c09c0832b87be72651ec500c9