### PR TITLE
Add meeting link to breadcrumb

### DIFF
--- a/app/templates/meetings/email_settings.html
+++ b/app/templates/meetings/email_settings.html
@@ -1,7 +1,12 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Email Settings', None)]) }}
+{{ breadcrumbs([
+    ('Dashboard', url_for('admin.dashboard')),
+    ('Meetings', url_for('meetings.list_meetings')),
+    (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)),
+    ('Email Settings', None)
+]) }}
 <h1 class="font-bold text-bp-blue mb-4">Email Settings</h1>
 <table class="bp-table">
   <thead>


### PR DESCRIPTION
## Summary
- update the email settings breadcrumb trail to link back to the meeting overview page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a58e45d54832b99f73b21a0655757