### PR TITLE
Color email buttons

### DIFF
--- a/app/templates/meetings/_email_row.html
+++ b/app/templates/meetings/_email_row.html
@@ -7,7 +7,7 @@
   <td class="p-2">
     <form hx-post="{{ url_for('meetings.toggle_email_setting', meeting_id=meeting.id, email_type=email_type) }}" hx-target="closest tr" hx-swap="outerHTML">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <button type="submit" class="bp-btn-secondary">
+      <button type="submit" class="bp-btn-secondary {{ 'bg-green-500 text-white border-green-500' if (not setting) or setting.auto_send else 'bg-red-500 text-white border-red-500' }}">
         {{ 'On' if (not setting) or setting.auto_send else 'Off' }}
       </button>
     </form>


### PR DESCRIPTION
## Summary
- color toggle buttons on email settings

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a92d83a1c832b81eda104b9982641