### PR TITLE
Add meeting summary field

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -76,15 +76,26 @@ class MeetingForm(FlaskForm):
     public_results = BooleanField("Public Results")
     early_public_results = BooleanField("Early Public Results")
     results_doc_published = BooleanField("Publish Final Results Doc")
-    results_doc_intro_md = TextAreaField("Results Doc Intro")
+    results_doc_intro_md = TextAreaField(
+        "Results Doc Intro",
+        description="Intro paragraph added to the certified results document.",
+    )
     comments_enabled = BooleanField("Enable Comments")
     quorum = IntegerField("Quorum")
     status = StringField("Status")
-    chair_notes_md = TextAreaField("Chair Notes")
+    chair_notes_md = TextAreaField(
+        "Chair Notes",
+        description="Private notes for meeting admins; not shown to members.",
+    )
+    summary_md = TextAreaField(
+        "Summary Paragraph",
+        description="Shown on public motion pages as an overview of the meeting.",
+    )
     notice_md = TextAreaField(
         "Meeting Notice",
         validators=[Optional()],
         render_kw={"data-markdown-editor": "1"},
+        description="Markdown included in Stage 1 invite emails.",
     )
     submit = SubmitField("Save")
 

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -351,6 +351,7 @@ def clone_meeting(meeting_id: int):
         "extension_reason",
         "results_doc_published",
         "results_doc_intro_md",
+        "summary_md",
     ]:
         setattr(new_meeting, field, getattr(src, field))
     db.session.add(new_meeting)

--- a/app/models.py
+++ b/app/models.py
@@ -106,6 +106,7 @@ class Meeting(db.Model):
     extension_reason = db.Column(db.Text)
     results_doc_published = db.Column(db.Boolean, default=False)
     results_doc_intro_md = db.Column(db.Text)
+    summary_md = db.Column(db.Text)
     notice_md = db.Column(db.Text)
     stage1_manual_votes = db.Column(db.Integer, default=0)
     stage2_manual_for = db.Column(db.Integer, default=0)

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -11,6 +11,12 @@
     <p id="{{ form.title.id }}-error" class="bp-error-text">{{ form.title.errors[0] if form.title.errors else '' }}</p>
   </div>
   <div>
+    {{ form.summary_md.label(class_='block font-semibold') }}
+    {{ form.summary_md(class_='border p-3 rounded w-full', **{'aria-describedby': form.summary_md.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.summary_md.description }}</p>
+    <p id="{{ form.summary_md.id }}-error" class="bp-error-text">{{ form.summary_md.errors[0] if form.summary_md.errors else '' }}</p>
+  </div>
+  <div>
     {{ form.type.label(class_='block font-semibold') }}
     {{ form.type(class_='border p-3 rounded w-full', **{'aria-describedby': form.type.id + '-error'}) }}
     <p id="{{ form.type.id }}-error" class="bp-error-text">{{ form.type.errors[0] if form.type.errors else '' }}</p>
@@ -112,16 +118,19 @@
   <div>
     {{ form.chair_notes_md.label(class_='block font-semibold') }}
     {{ form.chair_notes_md(class_='border p-3 rounded w-full', **{'aria-describedby': form.chair_notes_md.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.chair_notes_md.description }}</p>
     <p id="{{ form.chair_notes_md.id }}-error" class="bp-error-text">{{ form.chair_notes_md.errors[0] if form.chair_notes_md.errors else '' }}</p>
   </div>
   <div>
     {{ form.notice_md.label(class_='block font-semibold') }}
     {{ form.notice_md(class_='border p-3 rounded w-full', **{'aria-describedby': form.notice_md.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.notice_md.description }}</p>
     <p id="{{ form.notice_md.id }}-error" class="bp-error-text">{{ form.notice_md.errors[0] if form.notice_md.errors else '' }}</p>
   </div>
   <div>
     {{ form.results_doc_intro_md.label(class_='block font-semibold') }}
     {{ form.results_doc_intro_md(class_='border p-3 rounded w-full', **{'aria-describedby': form.results_doc_intro_md.id + '-error'}) }}
+    <p class="text-xs text-bp-grey-700 mt-1">{{ form.results_doc_intro_md.description }}</p>
     <p id="{{ form.results_doc_intro_md.id }}-error" class="bp-error-text">{{ form.results_doc_intro_md.errors[0] if form.results_doc_intro_md.errors else '' }}</p>
   </div>
   <button type="submit" class="bp-btn-primary">Save</button>

--- a/app/templates/public_meeting.html
+++ b/app/templates/public_meeting.html
@@ -3,6 +3,9 @@
 {% block content %}
 {{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }}</h1>
+{% if meeting.summary_md %}
+<div class="mb-4">{{ meeting.summary_md|markdown_to_html|safe }}</div>
+{% endif %}
 <p class="mb-4">Stage: {{ meeting.status or 'Draft' }} | Members: {{ member_count }}</p>
 {% if meeting.opens_at_stage1 and meeting.closes_at_stage1 %}
 <p class="mb-2">

--- a/app/templates/public_motion.html
+++ b/app/templates/public_motion.html
@@ -3,6 +3,9 @@
 {% block content %}
 {{ breadcrumbs([('Results', url_for('main.results_index')), (meeting.title, url_for('main.public_results', meeting_id=meeting.id)), (motion.title, None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ motion.title }}</h1>
+{% if meeting.summary_md %}
+<div class="mb-4">{{ meeting.summary_md|markdown_to_html|safe }}</div>
+{% endif %}
 <div class="bp-card bp-glow mb-4 whitespace-pre-line">{{ text|markdown_to_html|safe }}</div>
 <p><a href="{{ url_for('main.public_results', meeting_id=meeting.id) }}" class="text-bp-blue underline">Back to results</a></p>
 {% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -483,6 +483,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-24 – Results summary page now mirrors public view with charts and PDF link.
 * 2025-08-21 – Fixed amendment form ignoring selected motion on batch edit page.
 * 2025-08-22 – Fixed dark mode toggle when navigating via htmx.
+* 2025-07-04 – Added summary paragraph field for meetings displayed on public pages.
 
 
 ---

--- a/migrations/versions/v1w2x3y4_add_summary_md.py
+++ b/migrations/versions/v1w2x3y4_add_summary_md.py
@@ -1,0 +1,23 @@
+"""add meeting summary field
+
+Revision ID: v1w2x3y4
+Revises: u2v3w4x5
+Create Date: 2025-07-04 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'v1w2x3y4'
+down_revision = 'u2v3w4x5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('meetings', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('summary_md', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('meetings', schema=None) as batch_op:
+        batch_op.drop_column('summary_md')


### PR DESCRIPTION
## Summary
- add `summary_md` column on `Meeting`
- explain Chair Notes, Meeting Notice, Results Doc Intro fields
- allow editing summary text next to meeting title
- show meeting summary on public pages
- document update
- database migration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a974685e4832b922d2a1f7154465a