### PR TITLE
Add final results trigger and unify email style

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -2438,6 +2438,23 @@ def send_member_email(meeting_id: int, member_id: int, kind: str):
     return redirect(url_for("meetings.list_members", meeting_id=meeting.id))
 
 
+@bp.route("/<int:meeting_id>/send-final-results", methods=["POST"])
+@login_required
+@permission_required("manage_meetings")
+def send_final_results_all(meeting_id: int):
+    """Email certified results to all meeting members."""
+    meeting = db.session.get(Meeting, meeting_id)
+    if meeting is None or meeting.status != "Completed":
+        abort(404)
+
+    members = Member.query.filter_by(meeting_id=meeting.id).all()
+    for member in members:
+        send_final_results(member, meeting)
+
+    flash("Final results emailed", "success")
+    return redirect(url_for("meetings.meeting_overview", meeting_id=meeting.id))
+
+
 @bp.route("/<int:meeting_id>/proxy-tokens/<token>/resend", methods=["POST"])
 @login_required
 @permission_required("manage_meetings")

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -141,6 +141,14 @@
               {{ 'Unpublish Doc' if meeting.results_doc_published else 'Publish Doc' }}
             </button>
           </form>
+          {% if meeting.status == 'Completed' %}
+          <form action="{{ url_for('meetings.send_final_results_all', meeting_id=meeting.id) }}" method="post" class="flex-1">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <button type="submit" class="bp-btn-primary text-sm w-full" onclick="return confirm('Send final results to all members?');">
+              Email Final Results
+            </button>
+          </form>
+          {% endif %}
         </div>
       </div>
       {% endfor %}

--- a/app/templates/email/amendment_reinstated.html
+++ b/app/templates/email/amendment_reinstated.html
@@ -1,6 +1,8 @@
-<table width="600" style="font-family:Gotham,Arial,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
-  <tr><td style="padding:24px;background-color:#FFFFFF;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
+  <tr><td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>Amendment {{ amendment.id }} has met the objection threshold and is reinstated for Stage 1.</p>
       <p><strong>Meeting:</strong> {{ meeting.title }}</p>
+      </div>
   </td></tr>
 </table>

--- a/app/templates/email/board_notice.html
+++ b/app/templates/email/board_notice.html
@@ -1,8 +1,10 @@
-<table width="600" style="font-family:Gotham,Arial,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
-  <tr><td style="padding:24px;background-color:#FFFFFF;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
+  <tr><td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>An amendment has received at least 10 confirmed objections.</p>
       <p><strong>Meeting:</strong> {{ meeting.title }}<br>
       <strong>Amendment ID:</strong> {{ amendment.id }}</p>
       <p>Please review and respond within five days.</p>
+      </div>
   </td></tr>
 </table>

--- a/app/templates/email/final_results.html
+++ b/app/templates/email/final_results.html
@@ -1,7 +1,8 @@
-<table width="600" style="font-family:Gotham,Arial,Helvetica Neue,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
   {% include 'email/_brand_header.html' %}
   <tr>
-    <td style="padding:24px;background-color:#FFFFFF;">
+    <td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>Hello {{ member.name }},</p>
       <p><strong>{{ meeting.title }}</strong> has concluded.</p>
       <div style="border:1px solid #F7F7F9;border-radius:16px;padding:12px;margin:16px 0;">
@@ -15,6 +16,7 @@
       {% if test_mode %}
       <p style="color:#DC0714;"><strong>TEST MODE:</strong> results below come from a test ballot.</p>
       {% endif %}
+      </div>
     </td>
   </tr>
   <tr>

--- a/app/templates/email/objection_confirm.html
+++ b/app/templates/email/objection_confirm.html
@@ -1,10 +1,12 @@
-<table width="600" style="font-family:Gotham,Arial,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
-  <tr><td style="padding:24px;background-color:#FFFFFF;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
+  <tr><td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>Please confirm your objection by clicking the link below:</p>
       <p style="text-align:center;margin:32px 0;">
         <a href="{{ link }}" style="background-color:#DC0714;color:#FFFFFF;padding:12px 24px;text-decoration:none;border-radius:4px;display:inline-block;">Confirm</a>
       </p>
       <p>If the button does not work, copy this link into your browser:</p>
       <p>{{ link }}</p>
+      </div>
   </td></tr>
 </table>

--- a/app/templates/email/password_reset.html
+++ b/app/templates/email/password_reset.html
@@ -1,10 +1,12 @@
-<table width="600" style="font-family:Gotham,Arial,Helvetica Neue,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
   {% include 'email/_brand_header.html' %}
   <tr>
-    <td style="padding:24px;background-color:#FFFFFF;">
+    <td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>A request was received to reset the password for {{ user.email }}.</p>
       <p><a href="{{ link }}">Click here to set a new password</a></p>
       <p>If you did not request this, you can ignore this email.</p>
+      </div>
     </td>
   </tr>
 </table>

--- a/app/templates/email/proxy_invite.html
+++ b/app/templates/email/proxy_invite.html
@@ -1,7 +1,8 @@
-<table width="600" style="font-family:Gotham,Arial,Helvetica Neue,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
   {% include 'email/_brand_header.html' %}
   <tr>
-    <td style="padding:24px;background-color:#FFFFFF;">
+    <td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>Hello {{ proxy.name }},</p>
       <p>You have been nominated as a proxy for <strong>{{ principal.name }}</strong> in <strong>{{ meeting.title }}</strong>.</p>
       {% if test_mode %}
@@ -12,6 +13,7 @@
       </p>
       <p>If the button does not work, copy this link into your browser:</p>
       <p>{{ link }}</p>
+      </div>
     </td>
   </tr>
   <tr>

--- a/app/templates/email/quorum_failure.html
+++ b/app/templates/email/quorum_failure.html
@@ -1,10 +1,12 @@
-<table width="600" style="font-family:Gotham,Arial,Helvetica Neue,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
   {% include 'email/_brand_header.html' %}
   <tr>
-    <td style="padding:24px;background-color:#FFFFFF;">
+    <td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>Hello {{ member.name }},</p>
       <p>The Stage 1 vote for <strong>{{ meeting.title }}</strong> did not reach quorum and has been declared void.</p>
       <p>The Board will review next steps and you will be notified when a new ballot is scheduled.</p>
+      </div>
     </td>
   </tr>
   <tr>

--- a/app/templates/email/receipt.html
+++ b/app/templates/email/receipt.html
@@ -1,7 +1,8 @@
-<table width="600" style="font-family:Gotham,Arial,Helvetica Neue,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
   {% include 'email/_brand_header.html' %}
   <tr>
-    <td style="padding:24px;background-color:#FFFFFF;">
+    <td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>Hello {{ member.name }},</p>
       {% if test_mode %}
       <p style="color:#DC0714;"><strong>TEST MODE:</strong> the receipt below is from a test vote.</p>
@@ -14,6 +15,7 @@
       {% endfor %}
       </ul>
       <p>You can verify these hashes at <a href="{{ url_for('voting.verify_receipt', _external=True) }}">this page</a>.</p>
+      </div>
     </td>
   </tr>
   <tr>

--- a/app/templates/email/runoff_invite.html
+++ b/app/templates/email/runoff_invite.html
@@ -1,7 +1,8 @@
-<table width="600" style="font-family:Gotham,Arial,Helvetica Neue,sans-serif;font-size:16px;line-height:1.4;color:#3F4854;margin:0 auto;">
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
   {% include 'email/_brand_header.html' %}
   <tr>
-    <td style="padding:24px;background-color:#FFFFFF;">
+    <td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 24px 32px;">
       <p>Hello {{ member.name }},</p>
       <p>A run-off vote is needed for <strong>{{ meeting.title }}</strong>.</p>
       {% if test_mode %}
@@ -13,6 +14,7 @@
       <p>If the button does not work, copy this link into your browser:</p>
       <p>{{ link }}</p>
       <p>A calendar file showing the run-off voting window is attached.</p>
+      </div>
     </td>
   </tr>
   <tr>

--- a/app/templates/meetings/meeting_overview.html
+++ b/app/templates/meetings/meeting_overview.html
@@ -31,6 +31,12 @@
         </svg>
         <span>Batch Edit</span>
       </a>
+      {% if meeting.status == 'Completed' %}
+      <form method="post" action="{{ url_for('meetings.send_final_results_all', meeting_id=meeting.id) }}" class="inline-block">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button type="submit" class="bp-btn-primary" onclick="return confirm('Send final results to all members?');">Send Final Results</button>
+      </form>
+      {% endif %}
 
       <div class="bp-dropdown">
         <button class="bp-btn-secondary bp-btn-compact" aria-label="More actions">

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -133,6 +133,11 @@
 {% endif %}
 <a href="{{ url_for('meetings.results_docx', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block" download="results.docx" hx-boost="false">Download DOCX</a>
 <a href="{{ url_for('meetings.results_stage2_docx', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block ml-2" download="final_results.docx" hx-boost="false">Download Final DOCX</a>
+{% if meeting.status == 'Completed' %}
+<form method="post" action="{{ url_for('meetings.send_final_results_all', meeting_id=meeting.id) }}" class="inline-block ml-2">
+  <button type="submit" class="bp-btn-primary mt-4" onclick="return confirm('Send final results to all members?');">Send Final Results</button>
+</form>
+{% endif %}
 {% if manual_email_mode and current_user.has_permission('manage_meetings') %}
 <a href="{{ url_for('meetings.manual_send_emails', meeting_id=meeting.id) }}" class="bp-btn-secondary mt-4 inline-block ml-2">Send Emails</a>
 {% endif %}


### PR DESCRIPTION
## Summary
- add `/send-final-results` route
- show **Email Final Results** button on admin dashboard and meeting pages
- apply consistent styling to event-based email templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a900746ac832bae9b23de90088429