### PR TITLE
Fix PDF generation for empty fields

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -213,8 +213,9 @@ def generate_results_pdf(meeting, stage1_results, stage2_results) -> bytes:
     story.append(Paragraph("Stage 1 Amendments", styles["Heading2"]))
     data = [["Amendment", "For", "Against", "Abstain"]]
     for amend, counts in stage1_results:
+        text = getattr(amend, "text_md", "") or ""
         data.append([
-            getattr(amend, "text_md", ""),
+            text,
             counts.get("for", 0),
             counts.get("against", 0),
             counts.get("abstain", 0),
@@ -236,8 +237,9 @@ def generate_results_pdf(meeting, stage1_results, stage2_results) -> bytes:
     story.append(Paragraph("Stage 2 Motions", styles["Heading2"]))
     data2 = [["Motion", "For", "Against", "Abstain", "Outcome"]]
     for motion, counts in stage2_results:
+        title = getattr(motion, "title", "") or ""
         data2.append([
-            getattr(motion, "title", ""),
+            title,
             counts.get("for", 0),
             counts.get("against", 0),
             counts.get("abstain", 0),


### PR DESCRIPTION
## Summary
- handle missing text in generate_results_pdf

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685baa249a54832ba8f7d056d9be72d2