### PR TITLE
Fix dropdown listeners duplicating

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -1,11 +1,16 @@
 // Modern Navigation JavaScript
+let navigationInitialized = false;
+
 function initNavigation() {
+    // Avoid attaching duplicate global listeners
+    const firstRun = !navigationInitialized;
+    navigationInitialized = true;
     // Mobile Navigation Toggle
     const navToggle = document.getElementById('nav-toggle');
     const navDrawerMobile = document.getElementById('nav-drawer-mobile');
     const body = document.body;
     
-    if (navToggle && navDrawerMobile) {
+    if (navToggle && navDrawerMobile && firstRun) {
         // Toggle mobile menu
         navToggle.addEventListener('click', function() {
             const isOpen = navToggle.getAttribute('aria-expanded') === 'true';
@@ -44,11 +49,13 @@ function initNavigation() {
         });
         
         // Close on escape key
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && navToggle.getAttribute('aria-expanded') === 'true') {
-                navToggle.click();
-            }
-        });
+        if (firstRun) {
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape' && navToggle.getAttribute('aria-expanded') === 'true') {
+                    navToggle.click();
+                }
+            });
+        }
     }
     
     // Theme Toggle
@@ -60,7 +67,7 @@ function initNavigation() {
     const currentTheme = localStorage.getItem('theme') || 'light';
     html.classList.toggle('dark', currentTheme === 'dark');
     
-    if (themeToggle && themeIcon) {
+    if (themeToggle && themeIcon && firstRun) {
         // Update icon based on theme
         const updateThemeIcon = (isDark) => {
             themeIcon.src = isDark ? themeIcon.dataset.sun : themeIcon.dataset.moon;
@@ -89,6 +96,8 @@ function initNavigation() {
     
     // Smooth scroll for anchor links
     document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+        if (anchor.dataset.smoothScrollInitialized) return;
+        anchor.dataset.smoothScrollInitialized = 'true';
         anchor.addEventListener('click', function(e) {
             const targetId = this.getAttribute('href');
             if (targetId === '#') return;
@@ -137,7 +146,9 @@ function initNavigation() {
     
     // Add loading states to forms
     document.querySelectorAll('form').forEach(form => {
-        form.addEventListener('submit', function(e) {
+        if (form.dataset.loadingStateInitialized) return;
+        form.dataset.loadingStateInitialized = 'true';
+        form.addEventListener('submit', function() {
             if (!this.hasAttribute('hx-post') && !this.hasAttribute('hx-get')) {
                 const submitBtn = this.querySelector('[type="submit"]');
                 if (submitBtn) {
@@ -150,14 +161,16 @@ function initNavigation() {
     
     // Enhanced tooltips
     document.querySelectorAll('[data-tooltip]').forEach(el => {
+        if (el.dataset.tooltipInitialized) return;
+        el.dataset.tooltipInitialized = 'true';
         let tooltipTimeout;
-        
+
         el.addEventListener('mouseenter', function() {
             tooltipTimeout = setTimeout(() => {
                 this.classList.add('tooltip-visible');
             }, 500);
         });
-        
+
         el.addEventListener('mouseleave', function() {
             clearTimeout(tooltipTimeout);
             this.classList.remove('tooltip-visible');
@@ -214,64 +227,66 @@ function initNavigation() {
     }
 
     // Event delegation for dropdown triggers
-    document.addEventListener('click', function(e) {
-        const trigger = e.target.closest('.dropdown-trigger');
-        if (trigger) {
-            e.preventDefault();
-            e.stopPropagation();
-            const targetId = trigger.getAttribute('data-dropdown-target');
-            if (targetId) {
-                toggleDropdown(targetId);
+    if (firstRun) {
+        document.addEventListener('click', function(e) {
+            const trigger = e.target.closest('.dropdown-trigger');
+            if (trigger) {
+                e.preventDefault();
+                e.stopPropagation();
+                const targetId = trigger.getAttribute('data-dropdown-target');
+                if (targetId) {
+                    toggleDropdown(targetId);
+                }
             }
-        }
-        // Close dropdowns when clicking outside
-        else if (!e.target.closest('.relative')) {
-            document.querySelectorAll('.dropdown-menu').forEach(menu => {
-                menu.classList.add('hidden');
-                menu.setAttribute('aria-hidden', 'true');
-            });
-        }
-    });
+            // Close dropdowns when clicking outside
+            else if (!e.target.closest('.relative')) {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                    menu.setAttribute('aria-hidden', 'true');
+                });
+            }
+        });
 
-    // Close dropdowns on escape key
-    document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') {
-            document.querySelectorAll('.dropdown-menu').forEach(menu => {
-                menu.classList.add('hidden');
-                menu.setAttribute('aria-hidden', 'true');
-            });
-        }
-    });
+        // Close dropdowns on escape key
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                    menu.setAttribute('aria-hidden', 'true');
+                });
+            }
+        });
 
-    // Keyboard navigation for dropdowns
-    document.addEventListener('keydown', function(e) {
-        const activeDropdown = document.querySelector('.dropdown-menu:not(.hidden)');
-        if (!activeDropdown) return;
-        
-        const menuItems = activeDropdown.querySelectorAll('[role="menuitem"]');
-        const currentIndex = Array.from(menuItems).findIndex(item => item === document.activeElement);
-        
-        switch (e.key) {
-            case 'ArrowDown':
-                e.preventDefault();
-                const nextIndex = currentIndex < menuItems.length - 1 ? currentIndex + 1 : 0;
-                menuItems[nextIndex].focus();
-                break;
-            case 'ArrowUp':
-                e.preventDefault();
-                const prevIndex = currentIndex > 0 ? currentIndex - 1 : menuItems.length - 1;
-                menuItems[prevIndex].focus();
-                break;
-            case 'Home':
-                e.preventDefault();
-                menuItems[0].focus();
-                break;
-            case 'End':
-                e.preventDefault();
-                menuItems[menuItems.length - 1].focus();
-                break;
-        }
-    });
+        // Keyboard navigation for dropdowns
+        document.addEventListener('keydown', function(e) {
+            const activeDropdown = document.querySelector('.dropdown-menu:not(.hidden)');
+            if (!activeDropdown) return;
+
+            const menuItems = activeDropdown.querySelectorAll('[role="menuitem"]');
+            const currentIndex = Array.from(menuItems).findIndex(item => item === document.activeElement);
+
+            switch (e.key) {
+                case 'ArrowDown':
+                    e.preventDefault();
+                    const nextIndex = currentIndex < menuItems.length - 1 ? currentIndex + 1 : 0;
+                    menuItems[nextIndex].focus();
+                    break;
+                case 'ArrowUp':
+                    e.preventDefault();
+                    const prevIndex = currentIndex > 0 ? currentIndex - 1 : menuItems.length - 1;
+                    menuItems[prevIndex].focus();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    menuItems[0].focus();
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    menuItems[menuItems.length - 1].focus();
+                    break;
+            }
+        });
+    }
 }
 
 document.addEventListener('DOMContentLoaded', initNavigation);


### PR DESCRIPTION
## Summary
- prevent multiple nav event listeners by tracking first run
- reinitialize tooltips and form loading states only once per element

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685bb40c2474832bb2d919d3085e60e5