### PR TITLE
Add manage_permissions link and permission

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -295,7 +295,7 @@ def _save_permission(form: PermissionForm, perm: Permission | None = None) -> Pe
 
 @bp.route("/permissions")
 @login_required
-@permission_required("manage_users")
+@permission_required("manage_permissions")
 def list_permissions():
     permissions = Permission.query.order_by(Permission.name).all()
     return render_template("admin/permissions.html", permissions=permissions)
@@ -303,7 +303,7 @@ def list_permissions():
 
 @bp.route("/permissions/create", methods=["GET", "POST"])
 @login_required
-@permission_required("manage_users")
+@permission_required("manage_permissions")
 def create_permission():
     form = PermissionForm()
     if form.validate_on_submit():
@@ -314,7 +314,7 @@ def create_permission():
 
 @bp.route("/permissions/<int:permission_id>/edit", methods=["GET", "POST"])
 @login_required
-@permission_required("manage_users")
+@permission_required("manage_permissions")
 def edit_permission(permission_id):
     perm = db.session.get(Permission, permission_id)
     if perm is None:

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -219,6 +219,18 @@
               <img src="{{ url_for('static', filename='icons/group_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
               Users
             </a>
+            {% if current_user.has_permission('manage_users') %}
+            <a href="{{ url_for('admin.list_roles') }}" class="bp-nav-link text-white">
+              <img src="{{ url_for('static', filename='icons/how_to_reg_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
+              Roles
+            </a>
+            {% endif %}
+            {% if current_user.has_permission('manage_permissions') %}
+            <a href="{{ url_for('admin.list_permissions') }}" class="bp-nav-link text-white">
+              <img src="{{ url_for('static', filename='icons/visibility_lock_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
+              Permissions
+            </a>
+            {% endif %}
             {% if current_user.has_permission('manage_meetings') %}
             <a href="{{ url_for('ro.dashboard') }}" class="bp-nav-link text-white">
               <img src="{{ url_for('static', filename='icons/dashboard_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -483,6 +483,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-24 – Results summary page now mirrors public view with charts and PDF link.
 * 2025-08-21 – Fixed amendment form ignoring selected motion on batch edit page.
 * 2025-08-22 – Fixed dark mode toggle when navigating via htmx.
+* 2025-08-23 – Added admin Roles and Permissions links with new 'manage_permissions' right granted to root admins.
 * 2025-07-04 – Added summary paragraph field for meetings displayed on public pages.
 
 

--- a/migrations/versions/y1z2a3b4c5_add_manage_permissions_permission.py
+++ b/migrations/versions/y1z2a3b4c5_add_manage_permissions_permission.py
@@ -1,0 +1,32 @@
+"""add manage permissions permission
+
+Revision ID: y1z2a3b4c5
+Revises: v1w2x3y4
+Create Date: 2025-08-23 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'y1z2a3b4c5'
+down_revision = 'v1w2x3y4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    permissions = sa.table('permissions',
+        sa.column('id', sa.Integer),
+        sa.column('name', sa.String)
+    )
+    role_permissions = sa.table('roles_permissions',
+        sa.column('role_id', sa.Integer),
+        sa.column('permission_id', sa.Integer)
+    )
+
+    op.bulk_insert(permissions, [{'id': 5, 'name': 'manage_permissions'}])
+    op.bulk_insert(role_permissions, [{'role_id': 1, 'permission_id': 5}])
+
+
+def downgrade():
+    op.execute('DELETE FROM roles_permissions WHERE permission_id=5')
+    op.execute('DELETE FROM permissions WHERE id=5')

--- a/tests/test_admin_permissions.py
+++ b/tests/test_admin_permissions.py
@@ -26,7 +26,7 @@ def test_save_permission_creates_record():
 
 
 def _make_user(has_permission: bool):
-    perm = Permission(name='manage_users') if has_permission else None
+    perm = Permission(name='manage_permissions') if has_permission else None
     role = Role(permissions=[perm] if perm else [])
     user = User(role=role)
     user.email = 'admin@example.com'
@@ -59,7 +59,7 @@ def test_list_permissions_contains_create_and_edit_links():
         perm = Permission(name='view_dashboard')
         db.session.add(perm)
         db.session.commit()
-        admin_perm = Permission(name='manage_users')
+        admin_perm = Permission(name='manage_permissions')
         role = Role(name='Admin', permissions=[admin_perm])
         db.session.add_all([admin_perm, role])
         db.session.commit()

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -90,3 +90,21 @@ def test_nav_includes_ro_dashboard_when_authorized():
             with patch('flask_login.utils._get_user', return_value=user):
                 html = render_template('base.html')
                 assert 'RO Dashboard' in html
+
+
+def test_nav_includes_roles_and_permissions_when_authorized():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        perm_users = Permission(name='manage_users')
+        perm_perms = Permission(name='manage_permissions')
+        role = Role(name='Admin', permissions=[perm_users, perm_perms])
+        db.session.add_all([perm_users, perm_perms, role])
+        db.session.commit()
+        user = User(email='role@example.com', role=role)
+        user.is_active = True
+        with app.test_request_context('/'):
+            with patch('flask_login.utils._get_user', return_value=user):
+                html = render_template('base.html')
+                assert 'Roles' in html
+                assert 'Permissions' in html


### PR DESCRIPTION
## Summary
- add new `manage_permissions` permission
- update admin pages to require it
- show Roles and Permissions in the admin menu
- grant root admins the new permission via migration
- document change in PRD
- adjust tests for new permission

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c22f86a28832bafe2d02c939b7f0b