### PR TITLE
Implement comment preview routes

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -53,6 +53,7 @@ from ..services.email import (
 )
 from ..services import runoff
 from ..services.audit import record_action
+from ..comments import routes as comments
 from ..permissions import permission_required
 from .forms import (
     MeetingForm,
@@ -1942,6 +1943,24 @@ def stage2_tally(meeting_id: int):
         form=form,
         meeting=meeting,
     )
+
+
+@bp.route("/<int:meeting_id>/preview/comments/motion/<int:motion_id>", methods=["GET", "POST"])
+@login_required
+@permission_required("manage_meetings")
+def preview_motion_comments(meeting_id: int, motion_id: int):
+    if request.method == "POST":
+        return comments.add_motion_comment("preview", motion_id)
+    return comments.motion_comments("preview", motion_id)
+
+
+@bp.route("/<int:meeting_id>/preview/comments/amendment/<int:amendment_id>", methods=["GET", "POST"])
+@login_required
+@permission_required("manage_meetings")
+def preview_amendment_comments(meeting_id: int, amendment_id: int):
+    if request.method == "POST":
+        return comments.add_amendment_comment("preview", amendment_id)
+    return comments.amendment_comments("preview", amendment_id)
 
 
 @bp.route("/<int:meeting_id>/preview/<int:stage>", methods=["GET", "POST"])

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -486,6 +486,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-08-22 – Fixed dark mode toggle when navigating via htmx.
 * 2025-07-04 – Added summary paragraph field for meetings displayed on public pages.
 * 2025-08-30 – Added root-admin audit log page with search and filters.
+* 2025-08-31 – Added admin preview routes for comment pages with non-persistent submissions.
 
 
 ---


### PR DESCRIPTION
## Summary
- allow `_verify_token` to handle preview mode
- add preview routes for comment pages
- record changelog entry for new admin preview feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cef37e154832ba460408445a162ee