### PR TITLE
Implement audit log link and preview comments

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -482,7 +482,7 @@ def revoke_api_token(token_id: int):
 
 @bp.route("/audit")
 @login_required
-@permission_required("manage_users")
+@permission_required("view_audit_log")
 def view_audit():
     page = request.args.get("page", 1, type=int)
     pagination = get_logs(page=page, per_page=20)

--- a/app/cli.py
+++ b/app/cli.py
@@ -12,6 +12,7 @@ from .models import (
     VoteToken,
     Motion,
     Amendment,
+    Comment,
     Vote,
 )
 from faker import Faker
@@ -154,6 +155,27 @@ def generate_fake_data() -> None:
                 amendments.append(amend)
 
         db.session.flush()
+
+        for motion in motions:
+            for _ in range(2):
+                comment = Comment(
+                    meeting_id=meeting.id,
+                    motion_id=motion.id,
+                    member_id=random.choice(members).id,
+                    text_md=fake.sentence(nb_words=8),
+                    created_at=now,
+                )
+                db.session.add(comment)
+        for amend in amendments:
+            for _ in range(2):
+                comment = Comment(
+                    meeting_id=meeting.id,
+                    amendment_id=amend.id,
+                    member_id=random.choice(members).id,
+                    text_md=fake.sentence(nb_words=8),
+                    created_at=now,
+                )
+                db.session.add(comment)
 
         choices = ["for", "against", "abstain"]
         for member in members:

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -36,6 +36,7 @@ from ..models import (
     AmendmentVersion,
     MotionSubmission,
     AmendmentSubmission,
+    Comment,
 )
 from ..services.email import (
     send_vote_invite,
@@ -1977,6 +1978,14 @@ def preview_voting(meeting_id: int, stage: int):
         for motion in motions:
             ams = [a for a in amendments if a.motion_id == motion.id]
             motions_grouped.append((motion, ams))
+        motion_counts = {
+            m.id: Comment.query.filter_by(motion_id=m.id, hidden=False).count()
+            for m in motions
+        }
+        amend_counts = {
+            a.id: Comment.query.filter_by(amendment_id=a.id, hidden=False).count()
+            for a in amendments
+        }
         return render_template(
             "voting/combined_ballot.html",
             form=form,
@@ -1985,6 +1994,8 @@ def preview_voting(meeting_id: int, stage: int):
             proxy_for=None,
             token="preview",
             preview=True,
+            motion_counts=motion_counts,
+            amend_counts=amend_counts,
         )
 
     if stage == 1:
@@ -2011,6 +2022,14 @@ def preview_voting(meeting_id: int, stage: int):
         for motion in motions:
             ams = [a for a in amendments if a.motion_id == motion.id]
             motions_grouped.append((motion, ams))
+        motion_counts = {
+            m.id: Comment.query.filter_by(motion_id=m.id, hidden=False).count()
+            for m in motions
+        }
+        amend_counts = {
+            a.id: Comment.query.filter_by(amendment_id=a.id, hidden=False).count()
+            for a in amendments
+        }
         return render_template(
             "voting/stage1_ballot.html",
             form=form,
@@ -2019,6 +2038,8 @@ def preview_voting(meeting_id: int, stage: int):
             proxy_for=None,
             token="preview",
             preview=True,
+            motion_counts=motion_counts,
+            amend_counts=amend_counts,
         )
 
     motions = (
@@ -2034,6 +2055,10 @@ def preview_voting(meeting_id: int, stage: int):
             final_message_default=current_app.config.get("FINAL_STAGE_MESSAGE"),
         )
     compiled = [(m, m.final_text_md or compile_motion_text(m)) for m in motions]
+    motion_counts = {
+        m.id: Comment.query.filter_by(motion_id=m.id, hidden=False).count()
+        for m in motions
+    }
     return render_template(
         "voting/stage2_ballot.html",
         form=form,
@@ -2042,6 +2067,7 @@ def preview_voting(meeting_id: int, stage: int):
         proxy_for=None,
         token="preview",
         preview=True,
+        motion_counts=motion_counts,
     )
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -235,6 +235,12 @@
               API Tokens
             </a>
             {% endif %}
+            {% if current_user.has_permission('view_audit_log') %}
+            <a href="{{ url_for('admin.view_audit') }}" class="bp-nav-link text-white">
+              <img src="{{ url_for('static', filename='icons/visibility_lock_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
+              Audit Log
+            </a>
+            {% endif %}
           </li>
           <li class="mt-4 pt-4 border-t border-white/20">
             <div class="text-white/80 text-sm mb-4">

--- a/app/templates/voting/combined_ballot.html
+++ b/app/templates/voting/combined_ballot.html
@@ -69,7 +69,7 @@
               {{ motion.text_md|markdown_to_html|safe }}
             </div>
           </div>
-          {% if not preview %}
+          {% if not preview or (current_user.is_authenticated and current_user.has_permission('manage_meetings')) %}
           <button type="button" class="ml-4 bg-white/20 hover:bg-white/30 px-3 py-1 rounded-lg text-sm flex items-center space-x-1 transition-colors"
                   data-modal-target="comments-modal"
                   hx-get="{{ url_for('comments.motion_comments', token=token, motion_id=motion.id) }}"
@@ -124,7 +124,7 @@
                     {% endfor %}
                   </div>
                   
-                  {% if not preview %}
+                  {% if not preview or (current_user.is_authenticated and current_user.has_permission('manage_meetings')) %}
                   <button type="button" class="text-sm text-gray-500 hover:text-gray-700 flex items-center space-x-1"
                           data-modal-target="comments-modal"
                           hx-get="{{ url_for('comments.amendment_comments', token=token, amendment_id=amend.id) }}"

--- a/app/templates/voting/stage1_ballot.html
+++ b/app/templates/voting/stage1_ballot.html
@@ -67,7 +67,7 @@
               {{ motion.text_md|markdown_to_html|safe }}
             </div>
           </div>
-          {% if not preview %}
+          {% if not preview or (current_user.is_authenticated and current_user.has_permission('manage_meetings')) %}
           <button type="button" class="ml-4 bg-white/20 hover:bg-white/30 px-3 py-1 rounded-lg text-sm flex items-center space-x-1 transition-colors"
                   data-modal-target="comments-modal"
                   hx-get="{{ url_for('comments.motion_comments', token=token, motion_id=motion.id) }}"
@@ -121,7 +121,7 @@
                     {% endfor %}
                   </div>
                   
-                  {% if not preview %}
+                  {% if not preview or (current_user.is_authenticated and current_user.has_permission('manage_meetings')) %}
                   <button type="button" class="text-sm text-gray-500 hover:text-gray-700 flex items-center space-x-1"
                           data-modal-target="comments-modal"
                           hx-get="{{ url_for('comments.amendment_comments', token=token, amendment_id=amend.id) }}"

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -32,7 +32,7 @@
   {{ form.hidden_tag() }}
   {% for motion, compiled in motions %}
     <blockquote class="bp-card bp-glow mb-4 whitespace-pre-line">{{ compiled|markdown_to_html|safe }}
-      {% if not preview %}
+      {% if not preview or (current_user.is_authenticated and current_user.has_permission('manage_meetings')) %}
       <a href="#" class="bp-link ml-2 text-sm" data-modal-target="comments-modal"
          hx-get="{{ url_for('comments.motion_comments', token=token, motion_id=motion.id) }}"
          hx-target="#comments-body" hx-trigger="click" hx-swap="innerHTML">Comments ({{ motion_counts[motion.id] }})</a>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -484,6 +484,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-08-21 – Fixed amendment form ignoring selected motion on batch edit page.
 * 2025-08-22 – Fixed dark mode toggle when navigating via htmx.
 * 2025-07-04 – Added summary paragraph field for meetings displayed on public pages.
+* 2025-07-05 – Added Audit Log menu with permission and preview comments for coordinators.
 
 
 ---

--- a/migrations/versions/w2x3y4z5_add_view_audit_permission.py
+++ b/migrations/versions/w2x3y4z5_add_view_audit_permission.py
@@ -1,0 +1,25 @@
+"""add view audit log permission
+
+Revision ID: w2x3y4z5
+Revises: v1w2x3y4
+Create Date: 2025-07-05 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'w2x3y4z5'
+down_revision = 'v1w2x3y4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    permissions = sa.table('permissions', sa.column('id', sa.Integer), sa.column('name', sa.String))
+    role_permissions = sa.table('roles_permissions', sa.column('role_id', sa.Integer), sa.column('permission_id', sa.Integer))
+    op.bulk_insert(permissions, [{'id': 5, 'name': 'view_audit_log'}])
+    op.bulk_insert(role_permissions, [{'role_id': 1, 'permission_id': 5}])
+
+
+def downgrade():
+    op.execute('DELETE FROM roles_permissions WHERE permission_id=5')
+    op.execute('DELETE FROM permissions WHERE id=5')


### PR DESCRIPTION
## Summary
- require new `view_audit_log` permission for audit route
- show Audit Log in admin navigation
- allow admins/coordinators to open comment modals in preview ballots
- seed fake comments in the CLI faker
- add migration for new permission
- document feature in PRD changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d0afcce8c832bb2d9ee036c92c255