### PR TITLE
Add motion review page and preview token flow

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -482,7 +482,7 @@ def revoke_api_token(token_id: int):
 
 @bp.route("/audit")
 @login_required
-@permission_required("view_audit_log")
+@permission_required("manage_users")
 def view_audit():
     page = request.args.get("page", 1, type=int)
     q = request.args.get("q", "").strip()

--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1752,7 +1752,7 @@ def preview_email(meeting_id: int, email_type: str):
             "email/review_invite.html",
             member=member,
             meeting=meeting,
-            review_url=url_for('main.public_meeting_detail', meeting_id=meeting.id, _external=True),
+            review_url=url_for('main.review_motions', token='preview', meeting_id=meeting.id, _external=True),
             link=url_for('submissions.submit_motion', token='preview', meeting_id=meeting.id, _external=True),
             unsubscribe_url=unsubscribe,
             resubscribe_url=resubscribe,

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -798,7 +798,7 @@ def send_review_invite(member: Member, meeting: Meeting, *, test_mode: bool = Fa
         salt=current_app.config["TOKEN_SALT"],
     )
     db.session.commit()
-    review_url = url_for('main.public_meeting_detail', meeting_id=meeting.id, _external=True)
+    review_url = url_for('main.review_motions', token=plain, meeting_id=meeting.id, _external=True)
     link = url_for('submissions.submit_motion', token=plain, meeting_id=meeting.id, _external=True)
     unsubscribe = _unsubscribe_url(member)
     resubscribe = _resubscribe_url(member)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -129,7 +129,7 @@
                     Permissions
                   </a>
                   {% endif %}
-                  {% if current_user.has_permission('view_audit_log') %}
+                  {% if current_user.has_permission('manage_users') %}
                   <a href="{{ url_for('admin.view_audit') }}" class="bp-dropdown-item" role="menuitem">
                     <img src="{{ url_for('static', filename='icons/visibility_lock_30dp_000000_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
                     Audit Log
@@ -272,7 +272,7 @@
               API Tokens
             </a>
             {% endif %}
-            {% if current_user.has_permission('view_audit_log') %}
+            {% if current_user.has_permission('manage_users') %}
             <a href="{{ url_for('admin.view_audit') }}" class="bp-nav-link text-white">
               <img src="{{ url_for('static', filename='icons/visibility_lock_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
               Audit Log

--- a/app/templates/public_review.html
+++ b/app/templates/public_review.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
+{% block content %}
+{{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)), ('Review Motions', None)]) }}
+<h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} – Draft Motions</h1>
+{% for motion in motions %}
+<div class="bp-card bp-glow mb-4">
+  <h2 class="font-semibold mb-2">{{ motion.title }}</h2>
+  <div class="prose">{{ motion.text_md|markdown_to_html|safe }}</div>
+  {% if meeting.comments_enabled %}
+  <p class="mt-2"><a href="{{ url_for('comments.motion_comments', token=token, motion_id=motion.id) }}" class="bp-link">View Comments</a></p>
+  {% endif %}
+</div>
+{% else %}
+<p>No motions available.</p>
+{% endfor %}
+{% endblock %}

--- a/app/templates/submissions/motion_submitted.html
+++ b/app/templates/submissions/motion_submitted.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs %}
+{% block content %}
+{{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)), ('Submit Motion', None)]) }}
+<h1 class="font-bold text-bp-blue mb-4">Motion Submitted</h1>
+<p class="mb-4">Your motion has been submitted for coordinator review.</p>
+<form method="get" action="{{ url_for('submissions.submit_motion', token=token, meeting_id=meeting.id) }}">
+  <button class="bp-btn-primary">Submit Another Motion</button>
+</form>
+<p class="mt-4"><a href="{{ url_for('main.public_meeting_detail', meeting_id=meeting.id) }}" class="bp-link">Return to meeting page</a></p>
+{% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -487,6 +487,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-04 – Added summary paragraph field for meetings displayed on public pages.
 * 2025-08-30 – Added root-admin audit log page with search and filters.
 * 2025-08-31 – Added admin preview routes for comment pages with non-persistent submissions.
+* 2025-09-01 – Added motion review page with comment links and preview token support.
 * 2025-08-01 – Added Roles and Permissions links in admin menu and migration granting root admins 'manage_users'.
 * 2025-07-05 – Added Audit Log menu with permission and preview comments for coordinators.
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -12,6 +12,7 @@ from app.services.email import (
     send_stage1_reminder,
     send_stage2_invite,
     send_review_invite,
+    send_submission_invite,
     send_vote_receipt,
     send_quorum_failure,
     send_final_results,
@@ -288,5 +289,24 @@ def test_send_review_invite_links():
                 send_review_invite(member, meeting, test_mode=False)
                 mock_send.assert_called_once()
                 sent = mock_send.call_args[0][0]
-                assert '/public/meetings/1' in sent.body
+                assert '/review/' in sent.body
+                assert '/submit/' in sent.body
+
+def test_send_submission_invite_links():
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['MAIL_SUPPRESS_SEND'] = True
+    app.config['TOKEN_SALT'] = 's'
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='AGM')
+        db.session.add(meeting)
+        member = Member(name='Ann', email='a@example.com', meeting_id=1)
+        db.session.add(member)
+        db.session.commit()
+        with app.test_request_context('/'):
+            with patch.object(mail, 'send') as mock_send:
+                send_submission_invite(member, meeting, test_mode=False)
+                mock_send.assert_called_once()
+                sent = mock_send.call_args[0][0]
                 assert '/submit/' in sent.body

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -40,3 +40,20 @@ def test_submit_pages_load():
         db.session.commit()
     resp = client.get(f'/submit/{plain2}/amendment/{motion_id}')
     assert resp.status_code == 200
+
+def test_preview_token_allows_submission():
+    app = setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='T')
+        db.session.add(meeting)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name='A', email='a@x.com')
+        db.session.add(member)
+        motion = Motion(meeting_id=meeting.id, title='M', text_md='t', category='motion', threshold='normal', ordering=1, is_published=True)
+        db.session.add(motion)
+        db.session.commit()
+        meeting_id = meeting.id
+    client = app.test_client()
+    resp = client.get(f'/submit/preview/motion/{meeting_id}')
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow preview token to load the submission form
- send review emails to new motion review page
- add review page route and template with comment links
- show submission confirmation page with repeat option
- update navigation and audit log permission
- document motion review feature

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d95afc700832b9ecefc9dbcb73c98