### PR TITLE
Make email labels link to previews

### DIFF
--- a/app/templates/meetings/meeting_overview.html
+++ b/app/templates/meetings/meeting_overview.html
@@ -212,7 +212,11 @@
     {% for t, _ in schedule.items() %}
       {% set s = settings.get(t) %}
       <tr>
-        <td class="p-2">{{ t.replace('_', ' ').title() }}</td>
+        <td class="p-2">
+          <a href="{{ url_for('meetings.preview_email', meeting_id=meeting.id, email_type=t) }}" target="_blank" class="bp-link">
+            {{ t.replace('_', ' ').title() }}
+          </a>
+        </td>
         <td class="p-2">
           {% if s and not s.auto_send %}
             <span class="bp-badge">Off</span>


### PR DESCRIPTION
## Summary
- link the Auto Email Summary table rows in `meeting_overview.html` to the template preview

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ece311668832b969d00e3352aa4d2