### PR TITLE
Add global form error macro

### DIFF
--- a/app/templates/_macros.html
+++ b/app/templates/_macros.html
@@ -20,3 +20,24 @@
   </ol>
 </nav>
 {% endmacro %}
+
+{# Display a list of form validation errors in a consistent alert style #}
+{% macro form_errors(form) %}
+  {% if form.errors %}
+  <div class="bp-alert bp-alert-error mb-4">
+    <svg class="bp-icon flex-shrink-0" viewBox="0 0 24 24">
+      <path d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" fill="none"/>
+    </svg>
+    <div>
+      <p class="font-semibold mb-1">Please correct the following errors:</p>
+      <ul class="list-disc list-inside">
+      {% for field, errors in form.errors.items() %}
+        {% for error in errors %}
+          <li>{{ error }}</li>
+        {% endfor %}
+      {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+{% endmacro %}

--- a/app/templates/admin/permission_form.html
+++ b/app/templates/admin/permission_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Permissions', url_for('admin.list_permissions')), ('Edit Permission' if permission else 'Create Permission', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if permission else 'Create' }} Permission</h1>
 <form method="post" class="bp-form bp-card space-y-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.name.label(class_='block font-semibold') }}
     {{ form.name(class_='border p-3 rounded w-full', **{'aria-describedby': form.name.id + '-error'}) }}

--- a/app/templates/admin/role_form.html
+++ b/app/templates/admin/role_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Roles', url_for('admin.list_roles')), ('Edit Role' if role else 'Create Role', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if role else 'Create' }} Role</h1>
 <form method="post" class="bp-form bp-card space-y-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.name.label(class_='block font-semibold') }}
     {{ form.name(class_='border p-3 rounded w-full', **{'aria-describedby': form.name.id + '-error'}) }}

--- a/app/templates/admin/user_form.html
+++ b/app/templates/admin/user_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Users', url_for('admin.list_users')), ('Edit User' if user else 'Create User', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if user else 'Create' }} User</h1>
 <form method="post" class="bp-form bp-card space-y-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.email.label(class_='block font-semibold') }}
     {{ form.email(class_='border p-3 rounded w-full', **{'aria-describedby': form.email.id + '-error'}) }}

--- a/app/templates/meetings/amendment_form.html
+++ b/app/templates/meetings/amendment_form.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {% set label = 'Edit Amendment' if amendment else 'Add Amendment' %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (label, None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ 'Edit Amendment' if amendment else 'Add Amendment' }}</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.text_md.label(class_='block font-semibold') }}
     {{ form.text_md(class_='border p-3 rounded w-full', **{'data-markdown-editor': '1'}) }}

--- a/app/templates/meetings/extend_stage.html
+++ b/app/templates/meetings/extend_stage.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Extend Stage', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Extend Stage {{ stage }}</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.opens_at.label(class_='block font-semibold') }}
     {{ form.opens_at(class_='border p-3 rounded w-full') }}

--- a/app/templates/meetings/import_members.html
+++ b/app/templates/meetings/import_members.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([
   ('Dashboard', url_for('admin.dashboard')),
@@ -15,6 +15,7 @@
 </p>
 <form method="post" enctype="multipart/form-data" class="bp-form bp-card space-y-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.csv_file.label(class_='block font-semibold') }}
     {{ form.csv_file(class_='border p-3 rounded w-full', **{'aria-describedby': form.csv_file.id + '-error'}) }}

--- a/app/templates/meetings/manage_conflicts.html
+++ b/app/templates/meetings/manage_conflicts.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (motion.meeting.title if motion.meeting else 'Meeting', url_for('meetings.edit_meeting', meeting_id=motion.meeting_id)), ('Manage Conflicts', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ motion.title }} - Manage Conflicts</h1>
 <form method="post" class="bp-form bp-card space-y-4 mb-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.amendment_a_id.label(class_='block font-semibold') }}
     {{ form.amendment_a_id(class_='border p-2 rounded w-full') }}

--- a/app/templates/meetings/manual_email.html
+++ b/app/templates/meetings/manual_email.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block title %}Send Emails{% endblock %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Send Emails', None)]) }}
 <h1 class="text-2xl mb-4">Send Emails</h1>
 <form method="post" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div class="mb-4">
     {{ form.email_type.label(class="block font-bold") }}
     {{ form.email_type(class="bp-input") }}

--- a/app/templates/meetings/meeting_files.html
+++ b/app/templates/meetings/meeting_files.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Files', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Meeting Files</h1>
 <form method="post" enctype="multipart/form-data" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.file.label(class_='block font-semibold') }}
     {{ form.file(class_='border p-3 rounded w-full', **{'aria-describedby': form.file.id + '-error'}) }}

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Edit Meeting' if meeting else 'Create Meeting', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if meeting else 'Create' }} Meeting</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.title.label(class_='block font-semibold') }}
     {{ form.title(class_='border p-3 rounded w-full', **{'aria-describedby': form.title.id + '-error'}) }}

--- a/app/templates/meetings/motion_change_form.html
+++ b/app/templates/meetings/motion_change_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Change Motion', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Request Change</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.text_md.label(class_='block font-semibold') }}
     {{ form.text_md(class_='border p-3 rounded w-full', **{'data-markdown-editor': '1'}) }}

--- a/app/templates/meetings/motion_form.html
+++ b/app/templates/meetings/motion_form.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {% set label = 'Edit Motion' if motion else 'Create Motion' %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (label, None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if motion else 'Create' }} Motion</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.title.label(class_='block font-semibold') }}
     {{ form.title(class_='border p-3 rounded w-full') }}

--- a/app/templates/meetings/objection_form.html
+++ b/app/templates/meetings/objection_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Submit Objection', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Submit Objection</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     <label for="member-search" class="block font-semibold">{{ form.member_id.label.text }}</label>
     <input id="member-search" name="q" type="text"

--- a/app/templates/meetings/prepare_stage2.html
+++ b/app/templates/meetings/prepare_stage2.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Prepare Stage 2', None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Finalise Motion Text</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 <form method="post" class="space-y-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   {% for motion in motions %}
   <div class="bp-card grid md:grid-cols-2 gap-4">
     <div>

--- a/app/templates/meetings/stage1_tally_form.html
+++ b/app/templates/meetings/stage1_tally_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Stage 1 Tally', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Record Stage 1 Tally</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.votes_cast.label(class_='block font-semibold') }}
     {{ form.votes_cast(class_='bp-input w-full') }}

--- a/app/templates/meetings/stage2_tally_form.html
+++ b/app/templates/meetings/stage2_tally_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Stage 2 Tally', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Record Stage 2 Tally</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.for_votes.label(class_='block font-semibold') }}
     {{ form.for_votes(class_='bp-input w-full') }}

--- a/app/templates/ro/tie_break_form.html
+++ b/app/templates/ro/tie_break_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('RO Dashboard', url_for('ro.dashboard')), (meeting.title, None), ('Tie Breaks', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Tie Breaks</h1>
 <form method="post" class="space-y-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   {% for amend in amendments %}
   <div class="bp-card p-4 space-y-2">
     <p class="font-semibold">Amendment {{ amend.order }}</p>

--- a/app/templates/ro/tie_break_runoff_form.html
+++ b/app/templates/ro/tie_break_runoff_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('RO Dashboard', url_for('ro.dashboard')), (meeting.title, None), ('Run-off Tie Breaks', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} - Run-off Tie Breaks</h1>
 <form method="post" class="space-y-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   {% for r, a, b in runoffs %}
   <div class="bp-card p-4 space-y-2">
     <p class="font-semibold">Amendment {{ a.order }} vs {{ b.order }}</p>

--- a/app/templates/submissions/amendment_form.html
+++ b/app/templates/submissions/amendment_form.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)), (motion.title, url_for('meetings.view_motion', motion_id=motion.id)), ('Submit Amendment', None)]) }}
 {% if setting('site_logo') %}
@@ -8,6 +8,7 @@
 <h1 class="font-bold text-bp-blue mb-4">Submit Amendment</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.name.label(class_='block font-semibold') }}
     {{ form.name(class_='border p-2 rounded w-full') }}

--- a/app/templates/submissions/motion_form.html
+++ b/app/templates/submissions/motion_form.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)), ('Submit Motion', None)]) }}
 {% if setting('site_logo') %}
@@ -8,6 +8,7 @@
 <h1 class="font-bold text-bp-blue mb-4">Submit Motion</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.name.label(class_='block font-semibold') }}
     {{ form.name(class_='border p-2 rounded w-full') }}

--- a/app/templates/voting/combined_ballot.html
+++ b/app/templates/voting/combined_ballot.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Combined', None)]) }}
 
@@ -57,6 +57,7 @@
 
   <form id="vote-form" method="post" class="space-y-8 pb-24" hx-boost="false">
     {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
     
     {% for motion, ams in motions %}
     <div class="motion-section">

--- a/app/templates/voting/runoff_ballot.html
+++ b/app/templates/voting/runoff_ballot.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Run-off', None)]) }}
 {% if setting('site_logo') %}
@@ -16,6 +16,7 @@
 {% endif %}
 <form id="vote-form" method="post" class="bp-form bp-card space-y-6 pb-20" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   {% for runoff, amend_a, amend_b in runoffs %}
     <div class="bp-card bp-glow mb-4 grid md:grid-cols-2 gap-4">
       <div class="whitespace-pre-line">{{ amend_a.text_md }}</div>

--- a/app/templates/voting/stage1_ballot.html
+++ b/app/templates/voting/stage1_ballot.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Stage 1', None)]) }}
 
@@ -55,6 +55,7 @@
 
   <form id="vote-form" method="post" class="space-y-8 pb-24" hx-boost="false">
     {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
     
     {% for motion, ams in motions %}
     <div class="motion-section">

--- a/app/templates/voting/stage2_ballot.html
+++ b/app/templates/voting/stage2_ballot.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Ballot', url_for('voting.ballot_home')), (meeting.title, None), ('Stage 2', None)]) }}
 {% if setting('site_logo') %}
@@ -30,6 +30,7 @@
 {% endif %}
 <form id="vote-form" method="post" class="bp-form bp-card space-y-4 pb-20" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   {% for motion, compiled in motions %}
     <blockquote class="bp-card bp-glow mb-4 whitespace-pre-line">{{ compiled|markdown_to_html|safe }}
       {% if not preview or (current_user.is_authenticated and current_user.has_permission('manage_meetings')) %}

--- a/app/templates/voting/verify_receipt.html
+++ b/app/templates/voting/verify_receipt.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from '_macros.html' import breadcrumbs %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
 {{ breadcrumbs([('Voting Help', url_for('help.show_help')), ('Verify Receipt', None)]) }}
 {% if setting('site_logo') %}
@@ -8,6 +8,7 @@
 <h1 class="font-bold text-bp-blue mb-4">Verify Vote Receipt</h1>
 <form method="post" class="bp-form bp-card space-y-6" hx-boost="false">
   {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
   <div>
     {{ form.hash.label(class_='block font-semibold') }}
     {{ form.hash(class_='border p-3 rounded w-full') }}


### PR DESCRIPTION
## Summary
- add `form_errors` macro for consistent validation alerts
- show validation error alerts on all forms

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ecdb7ff28832ba770016522bd791f