### PR TITLE
Add draft motion visibility and publish toggle

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1269,6 +1269,20 @@ def mark_amendment_merged(amendment_id: int):
     return redirect(url_for("meetings.view_motion", motion_id=amendment.motion_id))
 
 
+@bp.route("/motions/<int:motion_id>/toggle-publish", methods=["POST"])
+@login_required
+@permission_required("manage_meetings")
+def toggle_motion_publish(motion_id: int):
+    """Publish or unpublish a motion."""
+    motion = db.session.get(Motion, motion_id)
+    if motion is None:
+        abort(404)
+    motion.is_published = not motion.is_published
+    db.session.commit()
+    record_action("toggle_motion_publish", f"motion_id={motion.id}")
+    return redirect(request.referrer or url_for("meetings.view_motion", motion_id=motion.id))
+
+
 @bp.route("/<int:meeting_id>/member-search")
 def member_search(meeting_id: int):
     """Return member options filtered by query."""

--- a/app/routes.py
+++ b/app/routes.py
@@ -138,11 +138,10 @@ def review_motions(token: str, meeting_id: int):
     if token != 'preview' and meeting.motions_closes_at and now <= meeting.motions_closes_at:
         flash('Motion submission window is still open.', 'error')
         return redirect(url_for('main.public_meeting_detail', meeting_id=meeting.id))
-    motions = (
-        Motion.query.filter_by(meeting_id=meeting.id, is_published=True)
-        .order_by(Motion.ordering)
-        .all()
-    )
+    query = Motion.query.filter_by(meeting_id=meeting.id)
+    if not (token == "preview" and current_user.is_authenticated and current_user.has_permission("manage_meetings")):
+        query = query.filter_by(is_published=True)
+    motions = query.order_by(Motion.ordering).all()
     return render_template('public_review.html', meeting=meeting, motions=motions, token=token)
 
 

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -114,6 +114,12 @@
         </svg>
         View Details
       </a>
+      <form method="post" action="{{ url_for('meetings.toggle_motion_publish', motion_id=m.id) }}" class="inline" hx-boost="false">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button class="bp-btn-secondary bp-btn-compact ml-2" type="submit">
+          {{ 'Unpublish' if m.is_published else 'Publish' }}
+        </button>
+      </form>
     </div>
   </div>
   {% endfor %}

--- a/app/templates/meetings/view_motion.html
+++ b/app/templates/meetings/view_motion.html
@@ -2,7 +2,30 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (motion.meeting.title if motion.meeting else 'Meeting', url_for('meetings.edit_meeting', meeting_id=motion.meeting_id)), ('View Motion', None)]) }}
-<h1 class="font-bold text-bp-blue mb-4">{{ motion.title }}</h1>
+<h1 class="font-bold text-bp-blue mb-4 flex items-center gap-4">
+  <span>{{ motion.title }}</span>
+  {% if motion.is_published %}
+  <span class="inline-flex items-center gap-1 text-green-600 text-sm">
+    <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    Published
+  </span>
+  {% else %}
+  <span class="inline-flex items-center gap-1 text-bp-grey-500 text-sm">
+    <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+    </svg>
+    Draft
+  </span>
+  {% endif %}
+  <form method="post" action="{{ url_for('meetings.toggle_motion_publish', motion_id=motion.id) }}" class="inline" hx-boost="false">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <button type="submit" class="bp-btn-secondary bp-btn-sm">
+      {{ 'Unpublish' if motion.is_published else 'Publish' }}
+    </button>
+  </form>
+</h1>
 <div class="bp-card bp-glow mb-4">{{ (motion.text_md or 'No motion text.')|markdown_to_html|safe }}</div>
 <h3 class="font-bold mb-2">Amendments</h3>
 <a href="{{ url_for('meetings.manage_conflicts', motion_id=motion.id) }}" class="bp-btn-secondary mb-4 inline-block">Manage Conflicts</a>

--- a/app/templates/public_review.html
+++ b/app/templates/public_review.html
@@ -2,10 +2,20 @@
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
 {{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)), ('Review Motions', None)]) }}
-<h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} – Draft Motions</h1>
+<h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} – Motions</h1>
 {% for motion in motions %}
 <div class="bp-card bp-glow mb-4">
-  <h2 class="font-semibold mb-2">{{ motion.title }}</h2>
+  <h2 class="font-semibold mb-2 flex items-center gap-2">
+    <span>{{ motion.title }}</span>
+    {% if not motion.is_published %}
+    <span class="inline-flex items-center gap-1 text-bp-grey-500 text-sm">
+      <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+      </svg>
+      Draft
+    </span>
+    {% endif %}
+  </h2>
   <div class="prose">{{ motion.text_md|markdown_to_html|safe }}</div>
   {% if meeting.comments_enabled %}
   <p class="mt-2"><a href="{{ url_for('comments.motion_comments', token=token, motion_id=motion.id) }}" class="bp-link">View Comments</a></p>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -491,6 +491,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-09-02 – Updated motion submission form with markdown editor, seconder details entry and clause checkboxes.
 * 2025-08-01 – Added Roles and Permissions links in admin menu and migration granting root admins 'manage_users'.
 * 2025-07-05 – Added Audit Log menu with permission and preview comments for coordinators.
+* 2025-06-27 – Draft motions visible to coordinators on review preview with publish toggle.
 
 ---
 


### PR DESCRIPTION
## Summary
- allow coordinators to see draft motions in preview review mode
- toggle publish status for motions
- show publish button on motion list and detail pages
- mark draft motions in preview review template
- document feature in PRD changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ecf867bc0832bb2db16c270692f9c