### PR TITLE
Improve submission management

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -680,7 +680,10 @@ def send_motion_submission_alert(submission: MotionSubmission, meeting: Meeting,
         meeting=meeting,
         **branding,
     )
-    mail.send(msg)
+    try:
+        mail.send(msg)
+    except OSError as exc:
+        current_app.logger.warning("Email send failed: %s", exc)
 
 
 def send_amendment_submission_alert(submission: AmendmentSubmission, motion: Motion, meeting: Meeting, *, test_mode: bool = False) -> None:
@@ -703,7 +706,10 @@ def send_amendment_submission_alert(submission: AmendmentSubmission, motion: Mot
         motion=motion,
         **branding,
     )
-    mail.send(msg)
+    try:
+        mail.send(msg)
+    except OSError as exc:
+        current_app.logger.warning("Email send failed: %s", exc)
 
 
 def notify_seconder_motion(seconder: Member, meeting: Meeting, *, test_mode: bool = False) -> None:

--- a/app/submissions/forms.py
+++ b/app/submissions/forms.py
@@ -35,3 +35,22 @@ class AmendmentSubmissionForm(FlaskForm):
     text_md = TextAreaField('Amendment Text', validators=[DataRequired()])
     seconder_id = SelectField('Seconder', coerce=int)
     submit = SubmitField('Submit Amendment')
+
+
+class MotionSubmissionEditForm(FlaskForm):
+    """Form for admins to edit a motion submission."""
+
+    title = StringField("Motion Title", validators=[DataRequired()])
+    text_md = TextAreaField(
+        "Motion Text", validators=[DataRequired()], render_kw={"data-markdown-editor": "1"}
+    )
+    submit = SubmitField("Save Changes")
+
+
+class AmendmentSubmissionEditForm(FlaskForm):
+    """Form for admins to edit an amendment submission."""
+
+    text_md = TextAreaField(
+        "Amendment Text", validators=[DataRequired()], render_kw={"data-markdown-editor": "1"}
+    )
+    submit = SubmitField("Save Changes")

--- a/app/templates/submissions/edit_amendment_submission.html
+++ b/app/templates/submissions/edit_amendment_submission.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
+{% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Edit Amendment Submission', None)]) }}
+<h1 class="font-bold text-bp-blue mb-4">Edit Amendment Submission</h1>
+<form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
+  {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
+  <div>
+    {{ form.text_md.label(class_='block font-semibold') }}
+    {{ form.text_md(class_='border p-3 rounded w-full', **{'data-markdown-editor': '1'}) }}
+  </div>
+  <button type="submit" class="bp-btn-primary">Save Changes</button>
+</form>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/easymde.min.css') }}">
+<script src="{{ url_for('static', filename='js/easymde.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/markdown_editor.js') }}"></script>
+{% endblock %}

--- a/app/templates/submissions/edit_motion_submission.html
+++ b/app/templates/submissions/edit_motion_submission.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import breadcrumbs, form_errors %}
+{% block content %}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Edit Motion Submission', None)]) }}
+<h1 class="font-bold text-bp-blue mb-4">Edit Motion Submission</h1>
+<form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
+  {{ form.hidden_tag() }}
+  {{ form_errors(form) }}
+  <div>
+    {{ form.title.label(class_='block font-semibold') }}
+    {{ form.title(class_='border p-3 rounded w-full') }}
+  </div>
+  <div>
+    {{ form.text_md.label(class_='block font-semibold') }}
+    {{ form.text_md(class_='border p-3 rounded w-full', **{'data-markdown-editor': '1'}) }}
+  </div>
+  <button type="submit" class="bp-btn-primary">Save Changes</button>
+</form>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/easymde.min.css') }}">
+<script src="{{ url_for('static', filename='js/easymde.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/markdown_editor.js') }}"></script>
+{% endblock %}

--- a/app/templates/submissions/list.html
+++ b/app/templates/submissions/list.html
@@ -7,10 +7,14 @@
 {% for sub in motions %}
   <div class="bp-card mb-2">
     <p class="font-semibold">{{ sub.title }}</p>
+    <p class="whitespace-pre-line mb-2">{{ sub.text_md }}</p>
+    <a href="{{ url_for('submissions.edit_motion_submission', submission_id=sub.id) }}" class="bp-btn-secondary bp-btn-icon mb-2">Edit</a>
     <form method="post" action="{{ url_for('submissions.publish_motion', submission_id=sub.id) }}" class="inline" hx-boost="false">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <button class="bp-btn-primary">Publish</button>
     </form>
     <form method="post" action="{{ url_for('submissions.reject_motion', submission_id=sub.id) }}" class="inline ml-2" hx-boost="false">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <button class="bp-btn-secondary">Reject</button>
     </form>
   </div>
@@ -20,11 +24,14 @@
 <h2 class="font-semibold mt-4 mb-2">Amendments</h2>
 {% for sub in amendments %}
   <div class="bp-card mb-2">
-    <p class="mb-1">{{ sub.text_md }}</p>
+    <p class="whitespace-pre-line mb-2">{{ sub.text_md }}</p>
+    <a href="{{ url_for('submissions.edit_amendment_submission', submission_id=sub.id) }}" class="bp-btn-secondary bp-btn-icon mb-2">Edit</a>
     <form method="post" action="{{ url_for('submissions.publish_amendment', submission_id=sub.id) }}" class="inline" hx-boost="false">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <button class="bp-btn-primary">Publish</button>
     </form>
     <form method="post" action="{{ url_for('submissions.reject_amendment', submission_id=sub.id) }}" class="inline ml-2" hx-boost="false">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <button class="bp-btn-secondary">Reject</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- show motion text on submission list and add edit link
- add admin forms for editing motion and amendment submissions
- catch email send failures so submission doesn't crash
- include CSRF tokens in publish/reject forms

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ed0d862b0832b8569c3c3f8e4e596