### PR TITLE
Fix newline handling in comments

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -68,8 +68,12 @@ def config_or_setting(
 
 
 def markdown_to_html(text: str) -> Markup:
-    """Convert Markdown text to safe HTML."""
-    raw_html = markdown(text or "")
+    """Convert Markdown text to safe HTML.
+
+    Newlines are converted to ``<br>`` so comments keep their original
+    line breaks.
+    """
+    raw_html = markdown(text or "", extensions=["nl2br"])
     cleaned = bleach.clean(raw_html, tags=ALLOWED_TAGS, strip=True)
     return Markup(cleaned)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,12 @@ def test_markdown_to_html_sanitizes_and_marks_safe():
     assert '<script>' not in html
     assert '<h1>' in html
     assert isinstance(html, Markup)
+
+
+def test_markdown_to_html_preserves_linebreaks():
+    md = 'line1\nline2'
+    html = markdown_to_html(md)
+    assert '<br' in html
 from dataclasses import dataclass
 from datetime import datetime
 import pytest


### PR DESCRIPTION
## Summary
- preserve line breaks in markdown_to_html using the nl2br extension
- add regression test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ed87ebc20832b93e18043555b5c5b