### PR TITLE
Implement motion handling preference block

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -86,7 +86,7 @@ from docx.shared import RGBColor, Inches, Pt
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import parse_xml
 from docx.oxml.ns import nsdecls
-from ..utils import config_or_setting
+from ..utils import config_or_setting, append_motion_preferences
 import os
 
 bp = Blueprint("meetings", __name__, url_prefix="/meetings")
@@ -924,11 +924,13 @@ def create_motion(meeting_id):
     move_text = config_or_setting("MOVE_TEXT", "")
     if form.validate_on_submit():
         ordering = Motion.query.filter_by(meeting_id=meeting.id).count() + 1
-        text_md = form.text_md.data
-        if form.allow_clerical.data and clerical_text:
-            text_md += f"\n\n{clerical_text}"
-        if form.allow_move.data and move_text:
-            text_md += f"\n\n{move_text}"
+        text_md = append_motion_preferences(
+            form.text_md.data,
+            form.allow_clerical.data,
+            form.allow_move.data,
+            clerical_text,
+            move_text,
+        )
         motion = Motion(
             meeting_id=meeting.id,
             title=form.title.data,

--- a/app/submissions/routes.py
+++ b/app/submissions/routes.py
@@ -1,6 +1,6 @@
 from flask import render_template, redirect, url_for, flash, abort, current_app
 from datetime import datetime
-from ..utils import config_or_setting
+from ..utils import config_or_setting, append_motion_preferences
 from ..extensions import db
 from ..models import (
     Meeting,
@@ -186,11 +186,13 @@ def submit_motion(token: str, meeting_id: int):
     clerical_text = config_or_setting("CLERICAL_TEXT", "")
     move_text = config_or_setting("MOVE_TEXT", "")
     if form.validate_on_submit():
-        text_md = form.text_md.data
-        if form.allow_clerical.data and clerical_text:
-            text_md += f"\n\n{clerical_text}"
-        if form.allow_move.data and move_text:
-            text_md += f"\n\n{move_text}"
+        text_md = append_motion_preferences(
+            form.text_md.data,
+            form.allow_clerical.data,
+            form.allow_move.data,
+            clerical_text,
+            move_text,
+        )
         seconder = (
             Member.query.filter_by(
                 meeting_id=meeting.id,

--- a/app/utils.py
+++ b/app/utils.py
@@ -190,6 +190,26 @@ def motion_results_summary(meeting: "Meeting") -> str:
     return "\n".join(lines)
 
 
+def append_motion_preferences(
+    text: str,
+    allow_clerical: bool,
+    allow_move: bool,
+    clerical_text: str,
+    move_text: str,
+) -> str:
+    """Append motion handling preferences to the motion text if selected."""
+
+    prefs: list[str] = []
+    if allow_clerical and clerical_text:
+        prefs.append(clerical_text)
+    if allow_move and move_text:
+        prefs.append(move_text)
+    if not prefs:
+        return text
+    prefs_md = "\n".join(f"- {p}" for p in prefs)
+    return text.rstrip() + "\n\n---\n### Motion Handling Preferences\n\n" + prefs_md
+
+
 def generate_results_pdf(meeting, stage1_results, stage2_results) -> bytes:
     """Return PDF bytes summarising Stage 1 and Stage 2 results."""
     from reportlab.lib import colors

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -493,6 +493,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-07-05 – Added Audit Log menu with permission and preview comments for coordinators.
 * 2025-06-27 – Audit log page paginated with htmx search support.
 * 2025-06-27 – Draft motions visible to coordinators on review preview with publish toggle.
+* 2025-09-03 – Motion submissions append selected handling preferences as a Markdown list.
 
 ---
 

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -3,7 +3,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app import create_app
 from app.extensions import db
-from app.models import Meeting, Motion, Member, SubmissionToken
+from app.models import Meeting, Motion, Member, MotionSubmission, SubmissionToken
 
 
 def setup_app():
@@ -57,3 +57,36 @@ def test_preview_token_allows_submission():
     client = app.test_client()
     resp = client.get(f'/submit/preview/motion/{meeting_id}')
     assert resp.status_code == 200
+
+
+def test_motion_submission_appends_preferences():
+    app = setup_app()
+    with app.app_context():
+        db.create_all()
+        meeting = Meeting(title='T')
+        db.session.add(meeting)
+        db.session.flush()
+        member = Member(meeting_id=meeting.id, name='A', email='a@x.com')
+        db.session.add(member)
+        db.session.flush()
+        token_obj, plain = SubmissionToken.create(member.id, meeting.id, 's')
+        db.session.commit()
+        meeting_id = meeting.id
+    client = app.test_client()
+    data = {
+        'name': 'A',
+        'email': 'a@x.com',
+        'title': 'M',
+        'text_md': 'Text',
+        'seconder_member_number': '1',
+        'seconder_name': 'X',
+        'allow_clerical': 'y',
+        'allow_move': 'y',
+    }
+    resp = client.post(f'/submit/{plain}/motion/{meeting_id}', data=data)
+    assert resp.status_code == 200
+    with app.app_context():
+        sub = MotionSubmission.query.first()
+        assert 'Motion Handling Preferences' in sub.text_md
+        assert 'The Board may correct typographical or numbering errors with no change to meaning.' in sub.text_md
+        assert 'The Board may place this change in the Articles or Bylaws as most appropriate.' in sub.text_md


### PR DESCRIPTION
## Summary
- add `append_motion_preferences` helper
- include handling preferences when creating or submitting motions
- document new behaviour in PRD
- test handling preference block

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ed698611c832b82ba6fbf17b21bc1