### PR TITLE
Add amendment summaries and counts

### DIFF
--- a/app/templates/meetings/meeting_overview.html
+++ b/app/templates/meetings/meeting_overview.html
@@ -249,9 +249,11 @@
     <div class="flex items-start justify-between">
       <div class="flex-1">
         <div class="flex items-center gap-3">
-          <h3 class="font-semibold text-bp-grey-900 hover:text-bp-blue transition-colors">
-            {{ m.title }}
-          </h3>
+          <h4 class="font-semibold text-bp-grey-900 hover:text-bp-blue transition-colors">
+            <a href="{{ url_for('meetings.view_motion', motion_id=m.id) }}" class="bp-link">
+              {{ m.title }}
+            </a>
+          </h4>
           {% if m.status %}
           <span class="bp-badge text-xs {% if m.status == 'passed' %}bp-badge-success{% elif m.status == 'failed' %}bp-badge-danger{% else %}bg-bp-grey-100 text-bp-grey-800{% endif %}">
             {{ m.status|title }}
@@ -284,6 +286,13 @@
             #{{ m.ordering }}
           </span>
           {% endif %}
+          {% set ac = amendment_counts.get(m.id, 0) %}
+          <a href="{{ url_for('meetings.view_motion', motion_id=m.id) }}" class="inline-flex items-center gap-1">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2"></path>
+            </svg>
+            {{ ac }} Amendment{{ 's' if ac != 1 else '' }}
+          </a>
           {% if m.is_published %}
           <span class="inline-flex items-center gap-1 text-green-600">
             <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">

--- a/app/templates/meetings/motions_list.html
+++ b/app/templates/meetings/motions_list.html
@@ -81,6 +81,15 @@
           </p>
         </div>
         {% endif %}
+
+        {% set amends = amendments_by_motion.get(m.id, []) %}
+        {% if amends %}
+        <ul class="list-disc pl-5 text-sm text-bp-grey-700 mb-3">
+          {% for a in amends %}
+          <li class="line-clamp-1">A{{ a.order }} – {{ a.text_md[:80] }}{% if a.text_md|length > 80 %}...{% endif %}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
       </div>
     </div>
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -491,6 +491,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-09-02 – Updated motion submission form with markdown editor, seconder details entry and clause checkboxes.
 * 2025-09-03 – Meeting overview shows condensed motion cards with quick links.
 * 2025-09-03 – Coordinators can post comments via preview pages and motion detail links.
+* 2025-09-05 – Motion lists display amendment summaries and counts.
 * 2025-08-01 – Added Roles and Permissions links in admin menu and migration granting root admins 'manage_users'.
 * 2025-07-05 – Added Audit Log menu with permission and preview comments for coordinators.
 * 2025-06-27 – Audit log page paginated with htmx search support.


### PR DESCRIPTION
## Summary
- show amendment bullets in motions list
- show per-motion amendment counts on meeting overview
- link motion titles and amendment counts to motion detail
- document the feature in product changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ed9fbaeec832b9f31b5bf6b04d066