### PR TITLE
Fix breadcrumbs to use meeting overview

### DIFF
--- a/app/templates/meetings/extend_stage.html
+++ b/app/templates/meetings/extend_stage.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Extend Stage', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Extend Stage', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Extend Stage {{ stage }}</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/import_members.html
+++ b/app/templates/meetings/import_members.html
@@ -4,7 +4,7 @@
 {{ breadcrumbs([
   ('Dashboard', url_for('admin.dashboard')),
   ('Meetings', url_for('meetings.list_meetings')),
-  (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)),
+  (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)),
   ('Members', url_for('meetings.list_members', meeting_id=meeting.id)),
   ('Import Members', None)
 ]) }}

--- a/app/templates/meetings/manage_conflicts.html
+++ b/app/templates/meetings/manage_conflicts.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (motion.meeting.title if motion.meeting else 'Meeting', url_for('meetings.edit_meeting', meeting_id=motion.meeting_id)), ('Manage Conflicts', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (motion.meeting.title if motion.meeting else 'Meeting', url_for('meetings.meeting_overview', meeting_id=motion.meeting_id)), ('Manage Conflicts', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ motion.title }} - Manage Conflicts</h1>
 <form method="post" class="bp-form bp-card space-y-4 mb-6" hx-boost="false">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/manual_email.html
+++ b/app/templates/meetings/manual_email.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block title %}Send Emails{% endblock %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Send Emails', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Send Emails', None)]) }}
 <h1 class="text-2xl mb-4">Send Emails</h1>
 <form method="post" hx-boost="false">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/meeting_files.html
+++ b/app/templates/meetings/meeting_files.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Files', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Files', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Meeting Files</h1>
 <form method="post" enctype="multipart/form-data" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/meeting_overview.html
+++ b/app/templates/meetings/meeting_overview.html
@@ -2,7 +2,7 @@
 {% from '_macros.html' import breadcrumbs %}
 
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Motions', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Motions', None)]) }}
 
 <!-- Page Header -->
 <div class="mb-8">

--- a/app/templates/meetings/members.html
+++ b/app/templates/meetings/members.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Members', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Members', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Members</h1>
 <div class="flex items-center gap-4 mb-4">
   <form method="post" action="{{ url_for('meetings.delete_all_members', meeting_id=meeting.id) }}" onsubmit="return confirm('Remove all members?');" hx-boost="false">

--- a/app/templates/meetings/prepare_stage2.html
+++ b/app/templates/meetings/prepare_stage2.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Prepare Stage 2', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Prepare Stage 2', None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Finalise Motion Text</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 <form method="post" class="space-y-6" hx-boost="false">

--- a/app/templates/meetings/results_summary.html
+++ b/app/templates/meetings/results_summary.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Results', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Results', None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} - Results</h1>
 <p class="mb-4">Notice given {{ meeting.notice_date.strftime('%Y-%m-%d') if meeting.notice_date else 'N/A' }}</p>
 {% if meeting.extension_reason %}

--- a/app/templates/meetings/stage1_tally_form.html
+++ b/app/templates/meetings/stage1_tally_form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Stage 1 Tally', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Stage 1 Tally', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Record Stage 1 Tally</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/stage2_tally_form.html
+++ b/app/templates/meetings/stage2_tally_form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Stage 2 Tally', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Stage 2 Tally', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ meeting.title }} – Record Stage 2 Tally</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}

--- a/app/templates/meetings/view_motion.html
+++ b/app/templates/meetings/view_motion.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (motion.meeting.title if motion.meeting else 'Meeting', url_for('meetings.edit_meeting', meeting_id=motion.meeting_id)), ('View Motion', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (motion.meeting.title if motion.meeting else 'Meeting', url_for('meetings.meeting_overview', meeting_id=motion.meeting_id)), ('View Motion', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4 flex items-center gap-4">
   <span>{{ motion.title }}</span>
   {% if motion.is_published %}

--- a/app/templates/submissions/list.html
+++ b/app/templates/submissions/list.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.edit_meeting', meeting_id=meeting.id)), ('Submissions', None)]) }}
+{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), (meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id)), ('Submissions', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Submissions for {{ meeting.title }}</h1>
 <h2 class="font-semibold mb-2">Motions</h2>
 {% for sub in motions %}


### PR DESCRIPTION
## Summary
- fix meeting breadcrumb links so they point to meeting overview instead of the edit page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685edb8f0c14832b8946f38cc717882d