### PR TITLE
Improve public meetings list

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -83,13 +83,12 @@ def results_index():
 @bp.route('/public/meetings')
 def public_meetings():
     """List meetings for public view."""
-    meetings = Meeting.query.order_by(Meeting.title).all()
-    member_counts = {
-        m.id: Member.query.filter_by(meeting_id=m.id).count() for m in meetings
-    }
-    return render_template(
-        'public_meetings.html', meetings=meetings, member_counts=member_counts
+    meetings = (
+        Meeting.query.filter(Meeting.status != 'Draft')
+        .order_by(Meeting.title)
+        .all()
     )
+    return render_template('public_meetings.html', meetings=meetings)
 
 
 @bp.route('/public/meetings/<int:meeting_id>')
@@ -97,7 +96,6 @@ def public_meeting_detail(meeting_id: int):
     meeting = db.session.get(Meeting, meeting_id)
     if meeting is None:
         abort(404)
-    member_count = Member.query.filter_by(meeting_id=meeting.id).count()
     files = MeetingFile.query.filter_by(meeting_id=meeting.id).all()
     contact_url = AppSetting.get(
         'contact_url', 'https://www.britishpowerlifting.org/contactus'
@@ -108,7 +106,6 @@ def public_meeting_detail(meeting_id: int):
     return render_template(
         'public_meeting.html',
         meeting=meeting,
-        member_count=member_count,
         contact_url=contact_url,
         stage1_ics_url=stage1_ics_url,
         runoff_ics_url=runoff_ics_url,

--- a/app/templates/public_meeting.html
+++ b/app/templates/public_meeting.html
@@ -6,7 +6,6 @@
 {% if meeting.summary_md %}
 <div class="mb-4">{{ meeting.summary_md|markdown_to_html|safe }}</div>
 {% endif %}
-<p class="mb-4">Stage: {{ meeting.status or 'Draft' }} | Members: {{ member_count }}</p>
 {% if meeting.opens_at_stage1 and meeting.closes_at_stage1 %}
 <p class="mb-2">
   Stage 1:

--- a/app/templates/public_meetings.html
+++ b/app/templates/public_meetings.html
@@ -3,17 +3,23 @@
 {% block content %}
 {{ breadcrumbs([('Home', url_for('main.index')), ('Meetings', None)]) }}
 <h1 class="font-bold text-bp-blue mb-4">Meetings</h1>
-<div class="bp-card">
-  <ul class="space-y-2">
+<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
   {% for meeting in meetings %}
-    <li>
-      <a href="{{ url_for('main.public_meeting_detail', meeting_id=meeting.id) }}" class="text-bp-blue hover:underline">{{ meeting.title }}</a>
-      <span class="ml-2 text-sm">{{ meeting.status or 'Draft' }}</span>
-      <span class="ml-2 text-sm">{{ member_counts[meeting.id] }} members</span>
-    </li>
+  <div class="bp-card flex flex-col justify-between">
+    <div>
+      <h2 class="font-semibold text-lg mb-1">
+        <a href="{{ url_for('main.public_meeting_detail', meeting_id=meeting.id) }}" class="bp-link hover:underline">{{ meeting.title }}</a>
+      </h2>
+      {% if meeting.summary_md %}
+      <div class="prose text-sm mb-2">{{ meeting.summary_md|markdown_to_html|safe }}</div>
+      {% endif %}
+    </div>
+    <div class="mt-auto">
+      <a href="{{ url_for('main.public_meeting_detail', meeting_id=meeting.id) }}" class="bp-btn-secondary">View Details</a>
+    </div>
+  </div>
   {% else %}
-    <li>No meetings available.</li>
+  <p>No meetings available.</p>
   {% endfor %}
-  </ul>
 </div>
 {% endblock %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -378,6 +378,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-16 – Added `node_modules/` to `.gitignore` to ignore Node packages.
 * 2025-06-16 – Documented Python package installation in README.
 * 2025-06-16 – Added rate limiting to login and vote routes using Flask-Limiter.
+* 2025-07-04 – Public meeting pages hide admin-only details and exclude drafts.
 * 2025-06-16 – Added skip link for keyboard users and assigned id="main" to content container.
 * 2025-06-16 – Navigation drawer closes via Escape key for keyboard users.
 * 2025-06-16 – Increased default rate limit to 1000 per day.


### PR DESCRIPTION
## Summary
- clean up public meetings list UI with card layout and details link
- remove admin-only status and member count info from public views
- filter out draft meetings from public lists
- update changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685edc4ad408832ba7fe40c4e749b0e3