### PR TITLE
Add markdown editors to meeting form

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -79,10 +79,21 @@ class MeetingForm(FlaskForm):
     results_doc_intro_md = TextAreaField(
         "Results Doc Intro",
         description="Intro paragraph added to the certified results document.",
+        render_kw={"data-markdown-editor": "1"},
     )
     comments_enabled = BooleanField("Enable Comments")
     quorum = IntegerField("Quorum")
-    status = StringField("Status")
+    status = SelectField(
+        "Status",
+        choices=[
+            ("Draft", "Draft"),
+            ("Stage 1", "Stage 1"),
+            ("Pending Stage 2", "Pending Stage 2"),
+            ("Stage 2", "Stage 2"),
+            ("Quorum not met", "Quorum not met"),
+            ("Completed", "Completed"),
+        ],
+    )
     chair_notes_md = TextAreaField(
         "Chair Notes",
         description="Private notes for meeting admins; not shown to members.",
@@ -90,6 +101,7 @@ class MeetingForm(FlaskForm):
     summary_md = TextAreaField(
         "Summary Paragraph",
         description="Shown on public motion pages as an overview of the meeting.",
+        render_kw={"data-markdown-editor": "1"},
     )
     notice_md = TextAreaField(
         "Meeting Notice",

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -143,5 +143,8 @@
   </div>
   {% endif %}
 </form>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/easymde.min.css') }}">
+<script src="{{ url_for('static', filename='js/easymde.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/markdown_editor.js') }}"></script>
 <script src="{{ url_for('static', filename='js/meeting_form.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add EasyMDE markdown editor to summary and results doc intro fields
- turn meeting status input into a dropdown
- load markdown editor assets on meeting form

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685eddc88448832ba606b83dd93912ad