### PR TITLE
Add amendment submission flow

### DIFF
--- a/app/meetings/routes.py
+++ b/app/meetings/routes.py
@@ -1786,7 +1786,7 @@ def preview_email(meeting_id: int, email_type: str):
             member=member,
             meeting=meeting,
             review_url=url_for('main.review_motions', token='preview', meeting_id=meeting.id, _external=True),
-            link=url_for('submissions.submit_motion', token='preview', meeting_id=meeting.id, _external=True),
+            link=url_for('submissions.submit_amendment_select', token='preview', meeting_id=meeting.id, _external=True),
             unsubscribe_url=unsubscribe,
             resubscribe_url=resubscribe,
             test_mode=True,

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -805,7 +805,7 @@ def send_review_invite(member: Member, meeting: Meeting, *, test_mode: bool = Fa
     )
     db.session.commit()
     review_url = url_for('main.review_motions', token=plain, meeting_id=meeting.id, _external=True)
-    link = url_for('submissions.submit_motion', token=plain, meeting_id=meeting.id, _external=True)
+    link = url_for('submissions.submit_amendment_select', token=plain, meeting_id=meeting.id, _external=True)
     unsubscribe = _unsubscribe_url(member)
     resubscribe = _resubscribe_url(member)
     msg = Message(

--- a/app/submissions/forms.py
+++ b/app/submissions/forms.py
@@ -37,6 +37,12 @@ class AmendmentSubmissionForm(FlaskForm):
     submit = SubmitField('Submit Amendment')
 
 
+class AmendmentSubmissionSelectForm(AmendmentSubmissionForm):
+    """Amendment form with motion selection."""
+
+    motion_id = SelectField('Motion', coerce=int, validators=[DataRequired()])
+
+
 class MotionSubmissionEditForm(FlaskForm):
     """Form for admins to edit a motion submission."""
 

--- a/app/templates/public_review.html
+++ b/app/templates/public_review.html
@@ -3,6 +3,16 @@
 {% block content %}
 {{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)), ('Review Motions', None)]) }}
 <h1 class="font-bold text-bp-blue mb-2">{{ meeting.title }} – Motions</h1>
+<p class="text-bp-grey-700 mb-4">Stage: {{ meeting.status or 'Draft' }} – Amendments {{ 'open' if amendments_open else 'closed' }}</p>
+{% set can_submit = token != 'preview' or (current_user.is_authenticated and current_user.has_permission('manage_meetings')) %}
+{% if can_submit %}
+<div class="mb-4 flex flex-wrap gap-2">
+  <a href="{{ url_for('submissions.submit_motion', token=token, meeting_id=meeting.id) }}" class="bp-btn-primary">Submit New Motion</a>
+  {% if amendments_open or (current_user.is_authenticated and current_user.has_permission('manage_meetings')) %}
+  <a href="{{ url_for('submissions.submit_amendment_select', token=token, meeting_id=meeting.id) }}" class="bp-btn-primary">Submit Amendment</a>
+  {% endif %}
+</div>
+{% endif %}
 {% for motion in motions %}
 <div class="bp-card bp-glow mb-4">
   <h2 class="font-semibold mb-2 flex items-center gap-2">
@@ -18,7 +28,7 @@
   </h2>
   <div class="prose">{{ motion.text_md|markdown_to_html|safe }}</div>
   {% if meeting.comments_enabled %}
-  <p class="mt-2"><a href="{{ url_for('comments.motion_comments', token=token, motion_id=motion.id) }}" class="bp-link">View Comments</a></p>
+  <p class="mt-2"><a href="{{ url_for('comments.motion_comments', token=token, motion_id=motion.id) }}" class="bp-btn-secondary inline-block">Add/View Comments ({{ motion_counts[motion.id] }})</a></p>
   {% endif %}
 </div>
 {% else %}

--- a/app/templates/submissions/amendment_form.html
+++ b/app/templates/submissions/amendment_form.html
@@ -1,7 +1,20 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
-{{ breadcrumbs([('Meetings', url_for('main.public_meetings')), (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)), (motion.title, url_for('meetings.view_motion', motion_id=motion.id)), ('Submit Amendment', None)]) }}
+{% if motion %}
+{{ breadcrumbs([
+  ('Meetings', url_for('main.public_meetings')),
+  (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)),
+  (motion.title, url_for('meetings.view_motion', motion_id=motion.id)),
+  ('Submit Amendment', None)
+]) }}
+{% else %}
+{{ breadcrumbs([
+  ('Meetings', url_for('main.public_meetings')),
+  (meeting.title, url_for('main.public_meeting_detail', meeting_id=meeting.id)),
+  ('Submit Amendment', None)
+]) }}
+{% endif %}
 {% if setting('site_logo') %}
 <img src="{{ url_for('static', filename=setting('site_logo')) }}" alt="{{ setting('site_title', 'VoteBuddy') }}" class="h-12 mx-auto mb-4">
 {% endif %}
@@ -9,6 +22,12 @@
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}
   {{ form_errors(form) }}
+  {% if form.motion_id is defined %}
+  <div>
+    {{ form.motion_id.label(class_='block font-semibold') }}
+    {{ form.motion_id(class_='border p-2 rounded w-full') }}
+  </div>
+  {% endif %}
   <div>
     {{ form.name.label(class_='block font-semibold') }}
     {{ form.name(class_='border p-2 rounded w-full') }}

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -290,7 +290,7 @@ def test_send_review_invite_links():
                 mock_send.assert_called_once()
                 sent = mock_send.call_args[0][0]
                 assert '/review/' in sent.body
-                assert '/submit/' in sent.body
+                assert '/amendment/new/' in sent.body
 
 def test_send_submission_invite_links():
     app = create_app()


### PR DESCRIPTION
## Summary
- create AmendmentSubmissionSelectForm for selecting a motion
- implement submit_amendment_select route
- update amendment form and review email links
- show amendment buttons and status on motions review page
- fix email service test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ee2bc36a0832bbd4212e5def8c921