### PR TITLE
Add Manage Permissions link from Roles page

### DIFF
--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -3,6 +3,7 @@
 {% block content %}
 {{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Roles', url_for('admin.list_roles'))]) }}
 <h1 class="font-bold text-bp-blue mb-4">Roles</h1>
+<a href="{{ url_for('admin.list_permissions') }}" class="bp-btn-secondary mb-4 inline-block">Manage Permissions</a>
 <div class="bp-card">
 <table class="bp-table">
   <thead class="bg-bp-grey-50">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -124,10 +124,6 @@
                     <img src="{{ url_for('static', filename='icons/group_30dp_000000_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
                     Roles
                   </a>
-                  <a href="{{ url_for('admin.list_permissions') }}" class="bp-dropdown-item" role="menuitem">
-                    <img src="{{ url_for('static', filename='icons/key_30dp_000000_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
-                    Permissions
-                  </a>
                   {% endif %}
                   {% if current_user.has_permission('manage_users') %}
                   <a href="{{ url_for('admin.view_audit') }}" class="bp-dropdown-item" role="menuitem">
@@ -250,10 +246,6 @@
             <a href="{{ url_for('admin.list_roles') }}" class="bp-nav-link text-white">
               <img src="{{ url_for('static', filename='icons/group_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
               Roles
-            </a>
-            <a href="{{ url_for('admin.list_permissions') }}" class="bp-nav-link text-white">
-              <img src="{{ url_for('static', filename='icons/key_30dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg') }}" alt="" class="bp-icon mr-2 w-5 h-5">
-              Permissions
             </a>
             {% endif %}
             {% if current_user.has_permission('manage_meetings') %}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -501,6 +501,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-09-06 – Clarified chart axis labels in final results PDF and reduced chart font sizes.
 * 2025-06-27 – Auto Email Summary section uses a three‑column grid on meeting overview.
 * 2025-06-27 – Public meeting page lists published motions and amendments in expandable accordions.
+* 2025-06-27 – Added 'Manage Permissions' link on Roles page and removed Permissions from the admin menu.
 
 ---
 


### PR DESCRIPTION
## Summary
- show Manage Permissions button on roles list
- remove Permissions menu option from header
- document the change in PRD

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ee50f9dd4832b8e8c68f5a0488e63