### PR TITLE
Fix effective chart display

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -289,14 +289,22 @@ def generate_results_pdf(meeting, stage1_results, stage2_results) -> bytes:
     def make_chart(title: str, counts: dict[str, int]):
         fig, axes = plt.subplots(1, 3, figsize=(6, 2))
         for label, ax in zip(["Count", "Share", "Effective"], axes):
-            values = [counts.get("for", 0), counts.get("against", 0), counts.get("abstain", 0)]
+            values = [
+                counts.get("for", 0),
+                counts.get("against", 0),
+                counts.get("abstain", 0),
+            ]
             labels = ["For", "Against", "Abstain"]
             colors_ = ["#00b894", "#d63031", "#fdcb6e"]
-            if label == "Share" or label == "Effective":
-                total = sum(values)
-                if label == "Effective":
-                    total -= values[2]
-                total = total or 1
+
+            if label == "Effective":
+                # exclude abstentions entirely from the chart
+                values = values[:2]
+                labels = labels[:2]
+                colors_ = colors_[:2]
+
+            if label in {"Share", "Effective"}:
+                total = sum(values) or 1
                 values = [v / total * 100 for v in values]
                 ax.set_ylim(0, 100)
             bars = ax.bar(

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -499,6 +499,7 @@ SES/SMTP  ─── Outbound mail
 * 2025-06-27 – Draft motions visible to coordinators on review preview with publish toggle.
 * 2025-09-03 – Motion submissions append selected handling preferences as a Markdown list.
 * 2025-09-06 – Clarified chart axis labels in final results PDF and reduced chart font sizes.
+* 2025-09-07 – Removed abstain bar from Effective % charts in final results PDF.
 * 2025-06-27 – Auto Email Summary section uses a three‑column grid on meeting overview.
 * 2025-06-27 – Public meeting page lists published motions and amendments in expandable accordions.
 * 2025-06-27 – Added 'Manage Permissions' link on Roles page and removed Permissions from the admin menu.


### PR DESCRIPTION
## Summary
- remove abstain bar from "Effective" percentage charts in results PDF
- document change in PRD changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ee7f49000832bbde9e20739064cf7