### PR TITLE
Fix PDF generation with matplotlib headless backend

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -229,6 +229,8 @@ def generate_results_pdf(meeting, stage1_results, stage2_results) -> bytes:
         PageBreak,
     )
     from reportlab.lib.units import inch
+    import matplotlib
+    matplotlib.use("Agg")
     from matplotlib import pyplot as plt
     from .voting.routes import compile_motion_text
     import io


### PR DESCRIPTION
## Summary
- avoid Tkinter backend in PDF charts by using `Agg`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ee893a8b0832bb24da66b0c2f5e53