### PR TITLE
Add amendment review invite email

### DIFF
--- a/app/meetings/forms.py
+++ b/app/meetings/forms.py
@@ -235,6 +235,7 @@ class ManualEmailForm(FlaskForm):
             ("stage2_invite", "Stage 2 Invite"),
             ("submission_invite", "Motion Submission Invite"),
             ("review_invite", "Motion Review Invite"),
+            ("amendment_review_invite", "Amendment Review Invite"),
         ],
         validators=[DataRequired()],
     )

--- a/app/templates/email/amendment_review_invite.html
+++ b/app/templates/email/amendment_review_invite.html
@@ -1,0 +1,53 @@
+<table width="600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #2d3748; margin: 0 auto; background-color: #f7fafc; border-radius:12px; overflow: hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.1);">
+  {% include 'email/_brand_header.html' %}
+  <tr>
+    <td style="padding: 0; background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);">
+      <div style="padding: 32px 32px 24px 32px;">
+        <h2 style="margin: 0 0 16px 0; font-size: 24px; font-weight: 600; color: #1a202c;">Hello {{ member.name }}! 💬</h2>
+        <p style="margin: 0 0 20px 0; font-size: 18px; color: #4a5568; line-height: 1.5;">Amendment submissions for <strong style="color: #2d3748;">{{ meeting.title }}</strong> have now closed. You can review them and leave comments before voting opens.</p>
+      </div>
+      <div style="padding: 0 32px 24px 32px;">
+        <div style="background: #f7fafc; padding: 20px; border-radius: 8px; border: 1px solid #e2e8f0;">
+          <p style="margin: 0 0 12px 0; color: #4a5568; line-height: 1.5;">
+            <strong style="color: #2d3748;">👀 Review Amendments</strong><br>
+            Visit the review page to read all submitted amendments and share your thoughts. For guidance, see our <a href="{{ url_for('help.show_help', _external=True) }}" style="color: #3182ce; text-decoration: none; font-weight: 500;">voting help page</a>.
+          </p>
+        </div>
+      </div>
+      <div style="padding: 32px; text-align: center;">
+        <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 2px; border-radius: 50px; display: inline-block; box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);">
+          <a href="{{ review_url }}" style="display: block; background: linear-gradient(135deg, #4299e1 0%, #3182ce 100%); color: #ffffff; padding: 16px 40px; text-decoration: none; border-radius: 48px; font-weight: 600; font-size: 18px; letter-spacing: 0.5px; transition: all 0.3s ease; text-shadow: 0 1px 2px rgba(0,0,0,0.2);">View Amendments</a>
+        </div>
+        <p style="margin: 20px 0 0 0; color: #718096; font-size: 14px;">Review • Comment</p>
+      </div>
+      <div style="padding: 0 32px 24px 32px;">
+        <div style="background: #edf2f7; padding: 20px; border-radius: 8px; text-align: center;">
+          <p style="margin: 0 0 12px 0; color: #4a5568; font-size: 14px; font-weight: 500;">Button not working? Copy this link:</p>
+          <div style="background: #ffffff; padding: 12px; border-radius: 6px; border: 1px solid #cbd5e0; word-break: break-all; font-family: 'Monaco', 'Menlo', monospace; font-size: 12px; color: #2d3748;">{{ review_url }}</div>
+        </div>
+      </div>
+    </td>
+  </tr>
+  {% include 'email/_why_text.html' %}
+  <tr>
+    <td style="background: linear-gradient(135deg, #2d3748 0%, #4a5568 100%); padding: 24px 32px; color: #e2e8f0;">
+      <div style="text-align: center; border-bottom: 1px solid rgba(226, 232, 240, 0.2); padding-bottom: 16px; margin-bottom: 16px;">
+        <h3 style="margin: 0 0 8px 0; font-size: 16px; font-weight: 600; color: #ffffff;">Need Help?</h3>
+      </div>
+      <div style="display: table; width: 100%; font-size: 14px;">
+        <div style="display: table-cell; width: 50%; text-align: center; padding: 0 8px;">
+          <strong style="color: #cbd5e0;">❓ Help Center</strong><br>
+          <a href="{{ url_for('help.show_help', _external=True) }}" style="color: #90cdf4; text-decoration: none;">Voting Guide</a>
+        </div>
+        <div style="display: table-cell; width: 50%; text-align: center; padding: 0 8px; border-left: 1px solid rgba(226, 232, 240, 0.2);">
+          <strong style="color: #cbd5e0;">⚖️ Company Info</strong><br>
+          <span style="color: #a0aec0;">No. 12345678</span>
+        </div>
+      </div>
+      <div style="text-align: center; margin-top: 16px; padding-top: 16px; border-top: 1px solid rgba(226, 232, 240, 0.2); font-size: 12px; color: #a0aec0;">
+        <a href="{{ unsubscribe_url }}" style="color: #90cdf4; text-decoration: none; margin: 0 8px;">Unsubscribe</a> •
+        <a href="{{ resubscribe_url }}" style="color: #90cdf4; text-decoration: none; margin: 0 8px;">Resubscribe</a>
+      </div>
+    </td>
+  </tr>
+</table>

--- a/app/templates/email/amendment_review_invite.txt
+++ b/app/templates/email/amendment_review_invite.txt
@@ -1,0 +1,14 @@
+Hello {{ member.name }}!
+
+Amendment submissions for {{ meeting.title }} have now closed.
+You can read the final amendments and leave comments before voting opens.
+
+👀 View amendments: {{ review_url }}
+
+❓ Need help with the process?
+Visit our help guide: {{ url_for('help.show_help', _external=True) }}
+
+{% include 'email/_why_text.txt' %}
+
+To stop these emails, visit: {{ unsubscribe_url }}
+To start them again later, visit: {{ resubscribe_url }}

--- a/app/templates/meetings/_member_rows.html
+++ b/app/templates/meetings/_member_rows.html
@@ -50,6 +50,11 @@
             <button type="submit" class="group flex items-center px-4 py-2 text-sm text-bp-grey-700 hover:bg-bp-grey-50 hover:text-bp-grey-900 transition-colors" role="menuitem">Resend Review Invite</button>
           </form>
           {% endif %}
+          {% if email_opts.amendment_review_invite %}
+          <form method="post" action="{{ url_for('meetings.send_member_email', meeting_id=meeting.id, member_id=m.id, kind='amendment_review_invite') }}" hx-boost="false">
+            <button type="submit" class="group flex items-center px-4 py-2 text-sm text-bp-grey-700 hover:bg-bp-grey-50 hover:text-bp-grey-900 transition-colors" role="menuitem">Resend Amendment Review Invite</button>
+          </form>
+          {% endif %}
           {% if email_opts.final_results %}
           <form method="post" action="{{ url_for('meetings.send_member_email', meeting_id=meeting.id, member_id=m.id, kind='final_results') }}" hx-boost="false">
             <button type="submit" class="group flex items-center px-4 py-2 text-sm text-bp-grey-700 hover:bg-bp-grey-50 hover:text-bp-grey-900 transition-colors" role="menuitem">Resend Final Results</button>

--- a/docs/original-british-powerlifting-voting-process-motion.md
+++ b/docs/original-british-powerlifting-voting-process-motion.md
@@ -68,6 +68,8 @@ Major funding bodies like Sport England look for organisations with clear, democ
 
 (f) An amendment may include multiple edits, provided they serve a single coherent purpose or effect a logically unified change to the motion. Amendments must not combine substantively unrelated or independent revisions. The Chair shall have discretion to determine whether an amendment exceeds this scope and may, where appropriate, require that compound amendments be separated, redrafted, or resubmitted individually for clarity and procedural fairness.
 
+(g) Once the amendment deadline passes, all qualifying amendments shall be published for member review and comment. No further amendments may be submitted during this period, which shall last no fewer than five clear days before Stage 1 opens.
+
 ---
 
 #### Article 109(a) – Stage 1: voting on amendments

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -527,3 +527,4 @@ SES/SMTP  ─── Outbound mail
 
 
 
+* 2025-09-10 – Added amendment review invite email between motion review and Stage 1.

--- a/docs/template-motion.md
+++ b/docs/template-motion.md
@@ -39,6 +39,7 @@ The procedure below introduces a clear amendment stage **before** the final vote
 (d)  Once published, a motion may only be withdrawn or substantively altered with Chair **and** board approval, provided the change is notified ≥ 7 days before Stage 1.  
 (e)  Members can trigger a “Point-of-Order” review of any rejected/merged amendment if either 25 Voting Members **or** 5 % of the membership endorse the objection within the timescale stated.  
 (f)  An amendment may bundle multiple edits if they serve one coherent purpose; the Chair may insist on splitting compound proposals for clarity.
+(g)  After the amendment deadline the Secretary publishes all qualifying amendments for review and comment. No further amendments may be lodged, but members may discuss and comment until Stage 1 opens (allow at least 5 clear days).
 
 ### Clause 3 — Stage 1: Voting on Amendments
 * Every qualifying amendment receives a separate yes/no vote; simple majority carries.  
@@ -92,6 +93,7 @@ Electronic seconds must accompany the amendment submission; in-person seconds ma
 | Motion submission window | Coordinator | Opens {{ motions_opens_at }} closes {{ motions_closes_at }} | Email invite sent automatically |
 | Amendment deadline | Secretary | –21 days | Max 3 per member |
 | Chair issues rulings | Chair | –7 days | Merge duplicates, set order |
+| Amendment review & comments | Secretary | Until Stage 1 opens | Members review final amendments |
 | Stage 1 voting window | Returning Officer | ≥ 7 days | Separate votes per amendment |
 | Run-off (if required) | Returning Officer | Buffer ≥ 2 days | Only between conflicting carried amendments |
 | Publish amended motion + Stage-1 results | Secretary | ≥ 24 h pre-Stage 2 | Clear audit trail |

--- a/tests/test_email_settings.py
+++ b/tests/test_email_settings.py
@@ -50,6 +50,7 @@ def test_email_schedule_two_stage_includes_stage2():
         assert set(schedule.keys()) == {
             'submission_invite',
             'review_invite',
+            'amendment_review_invite',
             'stage1_invite',
             'stage1_reminder',
             'stage2_invite',
@@ -73,6 +74,7 @@ def test_email_schedule_combined_excludes_stage2():
         assert set(schedule.keys()) == {
             'submission_invite',
             'review_invite',
+            'amendment_review_invite',
             'stage1_invite',
             'stage1_reminder',
         }


### PR DESCRIPTION
## Summary
- add amendment review invite email with token-based links
- expose new email option in forms and admin pages
- document amendment review period in motion template and original voting process
- update email scheduling and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ef13e4a24832b9dd61edde410f655