### PR TITLE
Add meeting date auto-fill

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -134,9 +134,16 @@ def register_extensions(app):
         }
 
     @app.context_processor
-    def inject_notice_days():
+    def inject_timing_defaults():
+        """Expose timing-related config values to all templates."""
         return {
-            'notice_days': app.config.get('NOTICE_PERIOD_DAYS', 14)
+            'notice_days': app.config.get('NOTICE_PERIOD_DAYS', 14),
+            'stage1_days': app.config.get('STAGE1_LENGTH_DAYS', 7),
+            'stage2_days': app.config.get('STAGE2_LENGTH_DAYS', 5),
+            'stage_gap_days': app.config.get('STAGE_GAP_DAYS', 1),
+            'runoff_minutes': app.config.get('RUNOFF_EXTENSION_MINUTES', 2880),
+            'motion_window_days': app.config.get('MOTION_WINDOW_DAYS', 7),
+            'motion_deadline_gap_days': app.config.get('MOTION_DEADLINE_GAP_DAYS', 7),
         }
 
     @app.context_processor

--- a/app/static/js/meeting_form.js
+++ b/app/static/js/meeting_form.js
@@ -1,5 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const noticeDays = parseInt(document.body.dataset.noticeDays || '14', 10);
+  const cfg = document.body.dataset;
+  const noticeDays = parseInt(cfg.noticeDays || '14', 10);
+  const stage1Days = parseInt(cfg.stage1Days || '7', 10);
+  const stage2Days = parseInt(cfg.stage2Days || '5', 10);
+  const stageGapDays = parseInt(cfg.stageGapDays || '1', 10);
+  const runoffMinutes = parseInt(cfg.runoffMinutes || '2880', 10);
+  const motionWindowDays = parseInt(cfg.motionWindowDays || '7', 10);
+  const motionDeadlineGapDays = parseInt(cfg.motionDeadlineGapDays || '7', 10);
+
   const agmField = document.getElementById('closes_at_stage2');
   if (!agmField) return;
 
@@ -8,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return new Date(date.getTime() - tz).toISOString().slice(0, 16);
   };
 
-  agmField.addEventListener('change', () => {
+  function fillAll(force) {
     const base = new Date(agmField.value);
     if (isNaN(base)) return;
 
@@ -16,29 +24,51 @@ document.addEventListener('DOMContentLoaded', () => {
     const closes1 = document.getElementById('closes_at_stage1');
     const opens1 = document.getElementById('opens_at_stage1');
     const notice = document.getElementById('notice_date');
+    const motionsOpen = document.getElementById('motions_opens_at');
+    const motionsClose = document.getElementById('motions_closes_at');
+    const amendsOpen = document.getElementById('amendments_opens_at');
+    const amendsClose = document.getElementById('amendments_closes_at');
 
-    if (opens2 && !opens2.value) {
-      const d = new Date(base);
-      d.setDate(d.getDate() - 5);
-      opens2.value = toLocal(d);
-    }
+    const dStage2Open = new Date(base);
+    dStage2Open.setDate(dStage2Open.getDate() - stage2Days);
+    if (force || !opens2.value) opens2.value = toLocal(dStage2Open);
 
-    if (opens2 && closes1 && !closes1.value && opens2.value) {
-      const d = new Date(opens2.value);
-      d.setDate(d.getDate() - 1);
-      closes1.value = toLocal(d);
-    }
+    const dStage1Close = new Date(dStage2Open);
+    dStage1Close.setDate(dStage1Close.getDate() - stageGapDays - runoffMinutes / 1440);
+    if (force || !closes1.value) closes1.value = toLocal(dStage1Close);
 
-    if (closes1 && opens1 && !opens1.value && closes1.value) {
-      const d = new Date(closes1.value);
-      d.setDate(d.getDate() - 7);
-      opens1.value = toLocal(d);
-    }
+    const dStage1Open = new Date(dStage1Close);
+    dStage1Open.setDate(dStage1Open.getDate() - stage1Days);
+    if (force || !opens1.value) opens1.value = toLocal(dStage1Open);
 
-    if (opens1 && notice && !notice.value && opens1.value) {
-      const d = new Date(opens1.value);
-      d.setDate(d.getDate() - noticeDays);
-      notice.value = toLocal(d);
-    }
-  });
+    const dNotice = new Date(dStage1Open);
+    dNotice.setDate(dNotice.getDate() - noticeDays);
+    if (force || !notice.value) notice.value = toLocal(dNotice);
+
+    const dMotionsClose = new Date(dNotice);
+    dMotionsClose.setDate(dMotionsClose.getDate() - motionDeadlineGapDays);
+    if (force || !motionsClose.value) motionsClose.value = toLocal(dMotionsClose);
+
+    const dMotionsOpen = new Date(dMotionsClose);
+    dMotionsOpen.setDate(dMotionsOpen.getDate() - motionWindowDays);
+    if (force || !motionsOpen.value) motionsOpen.value = toLocal(dMotionsOpen);
+
+    if (force || !amendsOpen.value) amendsOpen.value = toLocal(dNotice);
+
+    const dAmendsClose = new Date(dStage1Open);
+    dAmendsClose.setDate(dAmendsClose.getDate() - 21);
+    if (force || !amendsClose.value) amendsClose.value = toLocal(dAmendsClose);
+  }
+
+  agmField.addEventListener('change', () => fillAll(false));
+
+  const btn = document.getElementById('auto-populate-btn');
+  if (btn) {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      if (confirm('Auto fill all dates? This will overwrite any existing values.')) {
+        fillAll(true);
+      }
+    });
+  }
 });

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -53,7 +53,14 @@
       }
     </style>
   </head>
-  <body hx-boost="true" class="flex flex-col min-h-screen font-sans" data-notice-days="{{ notice_days }}">
+  <body hx-boost="true" class="flex flex-col min-h-screen font-sans"
+    data-notice-days="{{ notice_days }}"
+    data-stage1-days="{{ stage1_days }}"
+    data-stage2-days="{{ stage2_days }}"
+    data-stage-gap-days="{{ stage_gap_days }}"
+    data-runoff-minutes="{{ runoff_minutes }}"
+    data-motion-window-days="{{ motion_window_days }}"
+    data-motion-deadline-gap-days="{{ motion_deadline_gap_days }}">
     <a href="#main" class="bp-skip-link sr-only focus:not-sr-only">Skip to main content</a>
     <header class="bp-header">
       <nav class="bp-header-nav bg-bp-blue text-white shadow-lg">

--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -23,10 +23,18 @@
     <p id="{{ form.type.id }}-error" class="bp-error-text">{{ form.type.errors[0] if form.type.errors else '' }}</p>
   </div>
   <div>
+    {{ form.ballot_mode.label(class_='block font-semibold') }}
+    {{ form.ballot_mode(class_='border p-3 rounded w-full', **{'aria-describedby': form.ballot_mode.id + '-error'}) }}
+    <p id="{{ form.ballot_mode.id }}-error" class="bp-error-text">{{ form.ballot_mode.errors[0] if form.ballot_mode.errors else '' }}</p>
+  </div>
+  <div>
     {{ form.closes_at_stage2.label(class_='block font-semibold') }}
     {{ form.closes_at_stage2(class_='border p-3 rounded w-full', **{'aria-describedby': form.closes_at_stage2.id + '-error'}) }}
     <p class="text-xs text-bp-grey-700 mt-1">{{ form.closes_at_stage2.description }}</p>
     <p id="{{ form.closes_at_stage2.id }}-error" class="bp-error-text">{{ form.closes_at_stage2.errors[0] if form.closes_at_stage2.errors else '' }}</p>
+  </div>
+  <div>
+    <button type="button" id="auto-populate-btn" class="bp-btn-secondary">Auto Populate</button>
   </div>
   <div>
     {{ form.notice_date.label(class_='block font-semibold') }}
@@ -75,11 +83,6 @@
     {{ form.opens_at_stage2(class_='border p-3 rounded w-full', **{'aria-describedby': form.opens_at_stage2.id + '-error'}) }}
     <p class="text-xs text-bp-grey-700 mt-1">{{ form.opens_at_stage2.description }}</p>
     <p id="{{ form.opens_at_stage2.id }}-error" class="bp-error-text">{{ form.opens_at_stage2.errors[0] if form.opens_at_stage2.errors else '' }}</p>
-  </div>
-  <div>
-    {{ form.ballot_mode.label(class_='block font-semibold') }}
-    {{ form.ballot_mode(class_='border p-3 rounded w-full', **{'aria-describedby': form.ballot_mode.id + '-error'}) }}
-    <p id="{{ form.ballot_mode.id }}-error" class="bp-error-text">{{ form.ballot_mode.errors[0] if form.ballot_mode.errors else '' }}</p>
   </div>
   <div class="flex items-center space-x-2">
     {{ form.revoting_allowed(**{'aria-describedby': form.revoting_allowed.id + '-error'}) }}

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -528,3 +528,4 @@ SES/SMTP  ─── Outbound mail
 
 
 * 2025-09-10 – Added amendment review invite email between motion review and Stage 1.
+* 2025-09-12 – Added Auto Populate button for meeting dates and moved Ballot Mode above AGM date.

--- a/docs/template-motion.md
+++ b/docs/template-motion.md
@@ -90,6 +90,7 @@ Electronic seconds must accompany the amendment submission; in-person seconds ma
 | Step | Who | Timing | Comment |
 |------|-----|--------|---------|
 | Declare ballot type & timetable | Chair | ≥ 14 days pre-vote | Include platform URL |
+| Auto-populate meeting timeline | Coordinator | After setting AGM date | Use VoteBuddy's button to generate default windows |
 | Motion submission window | Coordinator | Opens {{ motions_opens_at }} closes {{ motions_closes_at }} | Email invite sent automatically |
 | Amendment deadline | Secretary | –21 days | Max 3 per member |
 | Chair issues rulings | Chair | –7 days | Merge duplicates, set order |


### PR DESCRIPTION
## Summary
- expose timing defaults to templates
- add auto-populate button to meeting form and move ballot mode above AGM date
- support auto fill logic in JS using config
- document auto-populate tool in motion template
- note feature in PRD changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ef8e867b4832bba5ead00493e5eff