### PR TITLE
Add breadcrumb link to meeting dashboard

### DIFF
--- a/app/templates/meetings/meetings_form.html
+++ b/app/templates/meetings/meetings_form.html
@@ -1,7 +1,12 @@
 {% extends 'base.html' %}
 {% from '_macros.html' import breadcrumbs, form_errors %}
 {% block content %}
-{{ breadcrumbs([('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings')), ('Edit Meeting' if meeting else 'Create Meeting', None)]) }}
+{% set bc_items = [('Dashboard', url_for('admin.dashboard')), ('Meetings', url_for('meetings.list_meetings'))] %}
+{% if meeting %}
+  {% set bc_items = bc_items + [(meeting.title, url_for('meetings.meeting_overview', meeting_id=meeting.id))] %}
+{% endif %}
+{% set bc_items = bc_items + [('Edit Meeting' if meeting else 'Create Meeting', None)] %}
+{{ breadcrumbs(bc_items) }}
 <h1 class="font-bold text-bp-blue mb-4">{{ 'Edit' if meeting else 'Create' }} Meeting</h1>
 <form method="post" class="bp-form bp-card space-y-4" hx-boost="false">
   {{ form.hidden_tag() }}


### PR DESCRIPTION
## Summary
- link to meeting overview from edit meeting breadcrumb

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68601da278e8832bb5ddd9f709dfca52